### PR TITLE
v0.2.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,11 @@ PUBLIC_API_URL=http://localhost:8080
 # With token: 5000 requests/hour rate limit
 # Create token at: https://github.com/settings/tokens (no scopes needed for public repos)
 # GITHUB_TOKEN=ghp_your_github_personal_access_token_here
+
+# Docker Images (optional - specify custom images or versions)
+# By default, uses latest from Docker Hub
+# Available registries:
+#   - Docker Hub: logward/backend:latest, logward/frontend:latest
+#   - GHCR: ghcr.io/logward-dev/logward-backend:latest, ghcr.io/logward-dev/logward-frontend:latest
+# LOGWARD_BACKEND_IMAGE=logward/backend:0.2.3
+# LOGWARD_FRONTEND_IMAGE=logward/frontend:0.2.3

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,126 @@
+name: Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.2.3)'
+        required: true
+        type: string
+
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '10'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and Publish Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+
+      - name: Docker meta for backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            logward/backend
+            ghcr.io/${{ github.repository_owner }}/logward-backend
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Docker meta for frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            logward/frontend
+            ghcr.io/${{ github.repository_owner }}/logward-frontend
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PUBLIC_API_URL=http://localhost:8080
+
+      - name: Create release summary
+        run: |
+          echo "## 🐳 Docker Images Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Backend" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "docker pull logward/backend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ github.repository_owner }}/logward-backend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Frontend" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "docker pull logward/frontend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ github.repository_owner }}/logward-frontend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,9 +70,7 @@ services:
       - logward-network
 
   backend:
-    build:
-      context: ..
-      dockerfile: packages/backend/Dockerfile
+    image: ${LOGWARD_BACKEND_IMAGE:-logward/backend:latest}
     container_name: logward-backend
     ports:
       - "8080:8080"
@@ -103,9 +101,7 @@ services:
       - logward-network
 
   worker:
-    build:
-      context: ..
-      dockerfile: packages/backend/Dockerfile
+    image: ${LOGWARD_BACKEND_IMAGE:-logward/backend:latest}
     container_name: logward-worker
     command: ["worker"]
     healthcheck:
@@ -135,11 +131,7 @@ services:
       - logward-network
 
   frontend:
-    build:
-      context: ..
-      dockerfile: packages/frontend/Dockerfile
-      args:
-        PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080}
+    image: ${LOGWARD_FRONTEND_IMAGE:-logward/frontend:latest}
     container_name: logward-frontend
     ports:
       - "3000:3000"

--- a/packages/frontend/src/routes/docs/deployment/+page.svelte
+++ b/packages/frontend/src/routes/docs/deployment/+page.svelte
@@ -7,7 +7,7 @@
         CardHeader,
         CardTitle,
     } from "$lib/components/ui/card";
-    import { AlertCircle, CheckCircle2 } from "lucide-svelte";
+    import { AlertCircle, CheckCircle2, Package, Server } from "lucide-svelte";
 </script>
 
 <div class="docs-content">
@@ -15,119 +15,150 @@
 
     <h1 class="text-3xl font-bold mb-4">Deployment Guide</h1>
     <p class="text-lg text-muted-foreground mb-8">
-        Production deployment instructions for LogWard using Docker Compose.
+        Deploy LogWard on your infrastructure using pre-built Docker images or build from source.
     </p>
 
     <h2
-        id="automated-deployment"
+        id="pre-built-images"
         class="text-2xl font-semibold mb-4 scroll-mt-20 border-b border-border pb-2"
     >
-        Automated Deployment (Recommended)
+        Pre-built Images (Recommended)
     </h2>
 
     <div class="mb-12 space-y-6">
         <Card>
             <CardHeader>
                 <div class="flex items-start gap-3">
-                    <CheckCircle2 class="w-5 h-5 text-green-500 mt-0.5" />
+                    <Package class="w-5 h-5 text-primary mt-0.5" />
                     <div>
-                        <CardTitle class="text-base"
-                            >One-Click Installation</CardTitle
-                        >
+                        <CardTitle class="text-base">No Build Required</CardTitle>
                     </div>
                 </div>
             </CardHeader>
             <CardContent class="text-sm text-muted-foreground">
-                The automated installer handles everything for you - from
-                prerequisites checks to database migrations.
+                Use our official pre-built images from Docker Hub or GitHub Container Registry.
+                Just download the config, set your passwords, and run.
             </CardContent>
         </Card>
 
         <div>
-            <h3 class="text-lg font-semibold mb-3">Quick Start (5 Minutes)</h3>
+            <h3 class="text-lg font-semibold mb-3">Quick Start (2 Minutes)</h3>
             <CodeBlock
                 lang="bash"
-                code={`# Clone the repository
-git clone https://github.com/logward-dev/logward.git
-cd logward
+                code={`# Create project directory
+mkdir logward && cd logward
 
-# Run the installer
-chmod +x install.sh
-./install.sh`}
+# Download docker-compose.yml
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/docker-compose.yml
+
+# Download environment template
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/.env.example
+mv .env.example .env
+
+# Edit .env with secure passwords
+nano .env
+
+# Start LogWard
+docker compose up -d`}
             />
+        </div>
 
-            <div class="mt-4 space-y-3">
-                <p class="text-sm text-muted-foreground">
-                    The installer will automatically:
-                </p>
-                <ul class="space-y-2 text-sm text-muted-foreground ml-4">
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span>Check Docker and Docker Compose installation</span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            >Verify required ports (5432, 6379, 8080, 3000)</span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            >Generate secure random passwords (32 characters)</span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            >Create <code>docker/.env</code> configuration file</span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span>Pull and build Docker images</span>
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            ><strong
-                                >Run database migrations automatically</strong
-                            ></span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            >Start all services (PostgreSQL, Redis, Backend,
-                            Worker, Frontend)</span
-                        >
-                    </li>
-                    <li class="flex items-start gap-2">
-                        <CheckCircle2
-                            class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
-                        />
-                        <span
-                            >Perform health checks and display access URLs</span
-                        >
-                    </li>
-                </ul>
+        <div>
+            <h3 class="text-lg font-semibold mb-3">Required Environment Variables</h3>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm border border-border rounded-lg">
+                    <thead class="bg-muted">
+                        <tr>
+                            <th class="text-left p-3 border-b border-border">Variable</th>
+                            <th class="text-left p-3 border-b border-border">Description</th>
+                            <th class="text-left p-3 border-b border-border">Example</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">DB_PASSWORD</td>
+                            <td class="p-3 border-b border-border">PostgreSQL password</td>
+                            <td class="p-3 border-b border-border font-mono text-xs">random_secure_password</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">REDIS_PASSWORD</td>
+                            <td class="p-3 border-b border-border">Redis password</td>
+                            <td class="p-3 border-b border-border font-mono text-xs">another_secure_password</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">API_KEY_SECRET</td>
+                            <td class="p-3 border-b border-border">Encryption key (32+ chars)</td>
+                            <td class="p-3 border-b border-border font-mono text-xs">your_32_character_secret_key_here</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs">PUBLIC_API_URL</td>
+                            <td class="p-3">Backend API URL</td>
+                            <td class="p-3 font-mono text-xs">http://localhost:8080</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
+
+        <div>
+            <h3 class="text-lg font-semibold mb-3">Available Docker Images</h3>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm border border-border rounded-lg">
+                    <thead class="bg-muted">
+                        <tr>
+                            <th class="text-left p-3 border-b border-border">Image</th>
+                            <th class="text-left p-3 border-b border-border">Registry</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">logward/backend</td>
+                            <td class="p-3 border-b border-border">
+                                <a href="https://hub.docker.com/r/logward/backend" class="text-primary hover:underline" target="_blank">Docker Hub</a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">logward/frontend</td>
+                            <td class="p-3 border-b border-border">
+                                <a href="https://hub.docker.com/r/logward/frontend" class="text-primary hover:underline" target="_blank">Docker Hub</a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">ghcr.io/logward-dev/logward-backend</td>
+                            <td class="p-3 border-b border-border">
+                                <a href="https://github.com/logward-dev/logward/pkgs/container/logward-backend" class="text-primary hover:underline" target="_blank">GitHub Container Registry</a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs">ghcr.io/logward-dev/logward-frontend</td>
+                            <td class="p-3">
+                                <a href="https://github.com/logward-dev/logward/pkgs/container/logward-frontend" class="text-primary hover:underline" target="_blank">GitHub Container Registry</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <Card class="border-yellow-500/30 bg-yellow-500/5">
+            <CardHeader>
+                <div class="flex items-start gap-3">
+                    <AlertCircle class="w-5 h-5 text-yellow-500 mt-0.5" />
+                    <div>
+                        <CardTitle class="text-base">Production Tip</CardTitle>
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent class="text-sm text-muted-foreground">
+                <p>Always pin to a specific version in production instead of using <code>latest</code>:</p>
+                <CodeBlock
+                    lang="bash"
+                    code={`# In your .env file
+LOGWARD_BACKEND_IMAGE=logward/backend:0.2.3
+LOGWARD_FRONTEND_IMAGE=logward/frontend:0.2.3`}
+                />
+            </CardContent>
+        </Card>
 
         <div class="bg-green-500/10 border border-green-500/20 rounded-lg p-4">
             <div class="flex items-start gap-3">
@@ -138,11 +169,11 @@ chmod +x install.sh
                     <p
                         class="font-semibold text-green-600 dark:text-green-400 mb-1"
                     >
-                        Installation Complete
+                        Ready to Go
                     </p>
                     <p class="text-sm text-muted-foreground">
-                        Access LogWard at <code>http://localhost:3000</code> or
-                        <code>http://your-server-ip:3000</code>
+                        Access LogWard at <code>http://localhost:3000</code> -
+                        database migrations run automatically on first start.
                     </p>
                 </div>
             </div>
@@ -150,34 +181,30 @@ chmod +x install.sh
     </div>
 
     <h2
-        id="manual-deployment"
+        id="build-from-source"
         class="text-2xl font-semibold mb-4 scroll-mt-20 border-b border-border pb-2"
     >
-        Manual Deployment (Alternative)
+        Build from Source (Alternative)
     </h2>
 
     <div class="mb-12 space-y-6">
         <Card>
             <CardHeader>
                 <div class="flex items-start gap-3">
-                    <AlertCircle class="w-5 h-5 text-yellow-500 mt-0.5" />
+                    <Server class="w-5 h-5 text-muted-foreground mt-0.5" />
                     <div>
-                        <CardTitle class="text-base"
-                            >Before You Deploy</CardTitle
-                        >
+                        <CardTitle class="text-base">For Contributors & Custom Builds</CardTitle>
                     </div>
                 </div>
             </CardHeader>
             <CardContent class="text-sm text-muted-foreground">
-                Make sure you have Docker and Docker Compose installed on your
-                server.
+                Build Docker images locally from source code. Useful for development
+                or when you need custom modifications.
             </CardContent>
         </Card>
 
         <div>
-            <h3 class="text-lg font-semibold mb-3">
-                Step 1: Clone and Configure
-            </h3>
+            <h3 class="text-lg font-semibold mb-3">Clone and Build</h3>
             <CodeBlock
                 lang="bash"
                 code={`# Clone the repository
@@ -188,56 +215,11 @@ cd logward/docker
 cp ../.env.example .env
 
 # Edit .env with your configuration
-nano .env`}
+nano .env
+
+# Build and start all services
+docker compose up -d --build`}
             />
-        </div>
-
-        <div>
-            <h3 class="text-lg font-semibold mb-3">
-                Step 2: Start All Services
-            </h3>
-            <CodeBlock
-                lang="bash"
-                code={`# Build and start all services
-docker compose up -d --build
-
-# Check service health
-docker compose ps
-
-# View logs
-docker compose logs -f backend`}
-            />
-
-            <Card class="mt-4">
-                <CardHeader>
-                    <div class="flex items-start gap-3">
-                        <CheckCircle2 class="w-5 h-5 text-primary mt-0.5" />
-                        <div>
-                            <CardTitle class="text-base"
-                                >Automatic Migrations</CardTitle
-                            >
-                            <p class="text-sm text-muted-foreground mt-2">
-                                Database migrations run automatically when the
-                                backend container starts. No manual commands
-                                needed!
-                            </p>
-                        </div>
-                    </div>
-                </CardHeader>
-                <CardContent class="text-sm text-muted-foreground">
-                    <p>The entrypoint script will:</p>
-                    <ul class="list-disc list-inside mt-2 space-y-1 ml-2">
-                        <li>Wait for PostgreSQL to be ready</li>
-                        <li>Run pending migrations automatically</li>
-                        <li>Start the application</li>
-                    </ul>
-                    <p class="mt-3">
-                        View migration logs: <code class="text-xs"
-                            >docker compose logs backend | grep migration</code
-                        >
-                    </p>
-                </CardContent>
-            </Card>
         </div>
 
         <div class="bg-green-500/10 border border-green-500/20 rounded-lg p-4">
@@ -252,13 +234,13 @@ docker compose logs -f backend`}
                         Services Running
                     </p>
                     <p class="text-sm text-muted-foreground">
-                        Access LogWard at <code>http://your-server-ip:3000</code
-                        >
+                        Access LogWard at <code>http://your-server-ip:3000</code>
                     </p>
                 </div>
             </div>
         </div>
     </div>
+
 
     <h2
         id="monitoring"
@@ -297,8 +279,8 @@ docker compose logs --tail=100 -f backend
 docker compose down
 
 # Update to latest version
-git pull origin main
-docker compose up -d --build`}
+docker compose pull
+docker compose up -d`}
             />
         </div>
 

--- a/packages/frontend/src/routes/docs/getting-started/+page.svelte
+++ b/packages/frontend/src/routes/docs/getting-started/+page.svelte
@@ -158,22 +158,30 @@
                 </li>
             </ul>
             <p class="text-sm text-muted-foreground mt-3 ml-6">
-                That's it! No Node.js, no build tools, no database setup.
+                That's it! No Node.js, no build tools, no database setup. Uses pre-built images from Docker Hub.
             </p>
         </div>
 
         <div>
-            <h3 class="text-lg font-semibold mb-3">Installation</h3>
+            <h3 class="text-lg font-semibold mb-3">Installation (2 minutes)</h3>
             <CodeBlock
                 lang="bash"
-                code={`# 1. Clone repository
-git clone https://github.com/logward-dev/logward.git
-cd logward
+                code={`# 1. Create project directory
+mkdir logward && cd logward
 
-# 2. Start LogWard with Docker
+# 2. Download configuration files
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/docker-compose.yml
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/.env.example
+mv .env.example .env
+
+# 3. Configure secure passwords (IMPORTANT!)
+nano .env
+# Change: DB_PASSWORD, REDIS_PASSWORD, API_KEY_SECRET
+
+# 4. Start LogWard
 docker compose up -d
 
-# 3. Access the dashboard
+# 5. Access the dashboard
 # Open http://localhost:3000 in your browser`}
             />
         </div>
@@ -190,7 +198,7 @@ docker compose up -d
                         <CheckCircle2
                             class="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
                         />
-                        <span>Pulls all Docker images</span>
+                        <span>Pulls pre-built images from Docker Hub</span>
                     </li>
                     <li class="flex items-start gap-2">
                         <CheckCircle2
@@ -227,25 +235,55 @@ docker compose up -d
         </Card>
 
         <div>
-            <h3 class="text-lg font-semibold mb-3">Configuration (Optional)</h3>
+            <h3 class="text-lg font-semibold mb-3">Required Configuration</h3>
             <p class="text-muted-foreground mb-3">
-                Customize your deployment by editing the <code
-                    >.env.example</code
-                > file before starting:
+                Edit your <code>.env</code> file and set secure values for these variables:
             </p>
-            <CodeBlock
-                lang="bash"
-                code={`# Copy example configuration
-cp .env.example .env
-
-# Edit .env with your settings (domain, email, etc.)
-nano .env
-
-# Restart to apply changes
-docker compose down
-docker compose up -d`}
-            />
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm border border-border rounded-lg">
+                    <thead class="bg-muted">
+                        <tr>
+                            <th class="text-left p-3 border-b border-border">Variable</th>
+                            <th class="text-left p-3 border-b border-border">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">DB_PASSWORD</td>
+                            <td class="p-3 border-b border-border">PostgreSQL database password</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">REDIS_PASSWORD</td>
+                            <td class="p-3 border-b border-border">Redis password</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 border-b border-border font-mono text-xs">API_KEY_SECRET</td>
+                            <td class="p-3 border-b border-border">Encryption key (32+ characters)</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs">PUBLIC_API_URL</td>
+                            <td class="p-3">Backend URL (default: http://localhost:8080)</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
+
+        <Card class="border-primary/30 bg-primary/5">
+            <CardHeader>
+                <CardTitle class="text-base">Docker Images</CardTitle>
+            </CardHeader>
+            <CardContent class="text-sm text-muted-foreground">
+                <p class="mb-2">Pre-built images are available from:</p>
+                <ul class="space-y-1 ml-4">
+                    <li><strong>Docker Hub:</strong> <code>logward/backend</code>, <code>logward/frontend</code></li>
+                    <li><strong>GitHub:</strong> <code>ghcr.io/logward-dev/logward-backend</code></li>
+                </ul>
+                <p class="mt-3 text-xs">
+                    Pin versions in production: <code>LOGWARD_BACKEND_IMAGE=logward/backend:0.2.3</code>
+                </p>
+            </CardContent>
+        </Card>
     </div>
 
     <h2


### PR DESCRIPTION
This pull request introduces official Docker images for both the backend and frontend, updates documentation and configuration to use these pre-built images, and adds automation for publishing images to Docker Hub and GitHub Container Registry. The changes make self-hosted deployment much simpler and faster, requiring no manual build steps.

**Docker Image Support and Automation:**

- Added a GitHub Actions workflow (`.github/workflows/publish-images.yml`) to automate building and publishing backend and frontend Docker images to Docker Hub and GitHub Container Registry on every tagged release.
- Updated `docker/docker-compose.yml` to use the official published images for backend, worker, and frontend services by default, with support for overriding image tags via environment variables. [[1]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L73-R73) [[2]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L106-R104) [[3]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L138-R134)
- Added example Docker image configuration options to `.env.example` for easy customization of image versions or registries.

**Documentation Updates:**

- Updated the self-hosting instructions in `README.md` and the frontend documentation page to use pre-built Docker images, providing ready-to-use `docker-compose.yml` and `.env` examples, and emphasizing that no build step is required. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R159) [[2]](diffhunk://#diff-cd3d82dc1f0121595d65f0c67586d1d376c94ce523b8b77a56017b354ae919f4L189-R272)
- Added a Docker Hub badge to the `README.md` to highlight the availability of official images.

Closes: #30 