### PR TITLE
feat: Enhance Docker Compose setup with logging profile and Fluent Bit configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Total control over your data. **No build required** - uses pre-built images from
 
 > **Note:** Database migrations run automatically on first start.
 
+5.  **(Optional) Enable Docker log collection with Fluent Bit**
+    ```bash
+    # Download Fluent Bit configuration files
+    curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/fluent-bit.conf
+    curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/parsers.conf
+    curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/extract_container_id.lua
+    curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/wrap_logs.lua
+
+    # Set your LogWard API key in .env
+    echo "FLUENT_BIT_API_KEY=your_api_key_here" >> .env
+
+    # Start with logging profile
+    docker compose --profile logging up -d
+    ```
+
 **Docker Images:** [Docker Hub](https://hub.docker.com/r/logward/backend) | [GitHub Container Registry](https://github.com/logward-dev/logward/pkgs/container/logward-backend)
 
 > **Production:** Pin versions with `LOGWARD_BACKEND_IMAGE=logward/backend:0.3.0` in your `.env` file.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,6 @@
-version: '3.8'
+# LogWard Docker Compose Configuration
+# Basic usage: docker compose up -d
+# With Docker log collection: docker compose --profile logging up -d
 
 services:
   postgres:
@@ -153,6 +155,8 @@ services:
   fluent-bit:
     image: fluent/fluent-bit:latest
     container_name: logward-fluent-bit
+    profiles:
+      - logging
     volumes:
       - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ./parsers.conf:/fluent-bit/etc/parsers.conf:ro

--- a/packages/frontend/src/routes/docs/deployment/+page.svelte
+++ b/packages/frontend/src/routes/docs/deployment/+page.svelte
@@ -97,6 +97,30 @@ docker compose up -d`}
         </div>
 
         <div>
+            <h3 class="text-lg font-semibold mb-3">(Optional) Docker Log Collection with Fluent Bit</h3>
+            <p class="text-sm text-muted-foreground mb-3">
+                To automatically collect logs from all Docker containers using Fluent Bit:
+            </p>
+            <CodeBlock
+                lang="bash"
+                code={`# Download Fluent Bit configuration files
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/fluent-bit.conf
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/parsers.conf
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/extract_container_id.lua
+curl -O https://raw.githubusercontent.com/logward-dev/logward/main/docker/wrap_logs.lua
+
+# Add your LogWard API key to .env
+echo "FLUENT_BIT_API_KEY=your_api_key_here" >> .env
+
+# Start with logging profile enabled
+docker compose --profile logging up -d`}
+            />
+            <p class="text-sm text-muted-foreground mt-3">
+                This profile is optional. Without it, LogWard runs without the Fluent Bit container.
+            </p>
+        </div>
+
+        <div>
             <h3 class="text-lg font-semibold mb-3">Available Docker Images</h3>
             <div class="overflow-x-auto">
                 <table class="w-full text-sm border border-border rounded-lg">


### PR DESCRIPTION
This pull request adds optional support for Docker log collection using Fluent Bit, making it easier for users to collect and forward container logs. The changes update documentation and configuration files to guide users through enabling this feature and to ensure the Fluent Bit service is only started when explicitly requested.

**Documentation updates:**

* Added instructions in `README.md` for enabling Docker log collection with Fluent Bit, including steps to download configuration files, set the API key, and start the service with the logging profile.
* Updated the deployment documentation in `+page.svelte` to include a new section with step-by-step guidance for setting up Fluent Bit for log collection, emphasizing that this is optional.

**Configuration changes:**

* Updated `docker-compose.yml` to document the new logging profile and clarify usage instructions.
* Modified the Fluent Bit service definition in `docker-compose.yml` to add it to the `logging` profile, ensuring it only runs when the logging profile is enabled.

refs: #47 