### PR TITLE
feat: Enhance OTLP documentation and syslog level normalization

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,6 +43,7 @@
     "@logward-dev/sdk-node": "^0.1.0",
     "@logward/shared": "workspace:*",
     "@maxmind/geoip2-node": "^6.3.4",
+    "@opentelemetry/otlp-transformer": "^0.208.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.65.1",
     "dotenv": "^17.2.3",

--- a/packages/backend/src/modules/otlp/parser.ts
+++ b/packages/backend/src/modules/otlp/parser.ts
@@ -4,12 +4,22 @@
  * Parses OpenTelemetry Protocol messages in both JSON and Protobuf formats.
  *
  * JSON format: Standard JSON encoding of OTLP messages
- * Protobuf format: Binary protocol buffer encoding
+ * Protobuf format: Binary protocol buffer encoding using OpenTelemetry proto definitions
  *
  * @see https://opentelemetry.io/docs/specs/otlp/
  */
 
 import type { OtlpExportLogsRequest } from './transformer.js';
+import { createRequire } from 'module';
+
+// Import the generated protobuf definitions from @opentelemetry/otlp-transformer
+// The module exports a protobufjs Root object with all OpenTelemetry proto definitions
+const require = createRequire(import.meta.url);
+const $root = require('@opentelemetry/otlp-transformer/build/esm/generated/root.js');
+
+// Get the ExportLogsServiceRequest message type for decoding protobuf messages
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ExportLogsServiceRequest: any = $root.opentelemetry?.proto?.collector?.logs?.v1?.ExportLogsServiceRequest;
 
 // ============================================================================
 // JSON Parser
@@ -119,44 +129,239 @@ function normalizeLogRecords(lr: unknown): unknown[] {
 /**
  * Parse OTLP Protobuf request body.
  *
- * Note: Full protobuf support requires the OpenTelemetry proto definitions.
- * This implementation provides a basic parser using protobufjs.
- *
- * For production use, consider using @opentelemetry/otlp-transformer or
- * generating TypeScript bindings from the official proto files.
+ * Uses the OpenTelemetry proto definitions from @opentelemetry/otlp-transformer
+ * to properly decode binary protobuf messages.
  *
  * @param buffer - Raw protobuf buffer
  * @returns Parsed OTLP request
  * @throws Error if parsing fails
  */
 export async function parseOtlpProtobuf(buffer: Buffer): Promise<OtlpExportLogsRequest> {
-  // For now, we'll use a simplified approach
-  // Full protobuf support would require loading the proto definitions
-
+  // First, try to parse as JSON (some clients send JSON with protobuf content-type)
   try {
-    // Try to parse as JSON first (some clients send JSON with protobuf content-type)
     const jsonString = buffer.toString('utf-8');
     if (jsonString.startsWith('{') || jsonString.startsWith('[')) {
+      console.log('[OTLP] Protobuf content-type but JSON payload detected, parsing as JSON');
       return parseOtlpJson(jsonString);
     }
   } catch {
     // Not JSON, continue to protobuf parsing
   }
 
-  // For protobuf, we need the proto definitions
-  // This requires setting up protobufjs with the OpenTelemetry proto files
-  //
-  // Implementation options:
-  // 1. Use pre-compiled proto definitions (recommended)
-  // 2. Load proto files at runtime
-  // 3. Use @opentelemetry/otlp-proto-exporter-base
-  //
-  // For now, throw an error indicating protobuf support needs setup
+  // Verify ExportLogsServiceRequest is available
+  if (!ExportLogsServiceRequest) {
+    throw new Error(
+      'OTLP protobuf support not available. The OpenTelemetry proto definitions could not be loaded. ' +
+      'Please use application/json content-type.'
+    );
+  }
 
-  throw new Error(
-    'Protobuf parsing requires proto definitions. ' +
-    'Please use application/json content-type or configure protobuf support.'
-  );
+  // Decode the protobuf message using OpenTelemetry proto definitions
+  try {
+    const decoded = ExportLogsServiceRequest.decode(buffer);
+
+    // Convert to plain JavaScript object for processing
+    const message = ExportLogsServiceRequest.toObject(decoded, {
+      longs: String,  // Convert Long to string for JSON compatibility
+      bytes: String,  // Convert bytes to base64 string
+      defaults: false, // Don't include default values
+      arrays: true,   // Always return arrays even if empty
+      objects: true,  // Always return nested objects
+    });
+
+    console.log('[OTLP] Successfully decoded protobuf message with',
+      message.resourceLogs?.length || 0, 'resourceLogs');
+
+    // Normalize the decoded message to match our OtlpExportLogsRequest interface
+    return normalizeDecodedProtobuf(message);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[OTLP] Failed to decode protobuf:', errorMessage);
+    throw new Error(`Failed to decode OTLP protobuf: ${errorMessage}`);
+  }
+}
+
+/**
+ * Normalize decoded protobuf message to OtlpExportLogsRequest format.
+ * The protobuf decoder uses different field names than our interface.
+ */
+function normalizeDecodedProtobuf(message: Record<string, unknown>): OtlpExportLogsRequest {
+  const resourceLogs = message.resourceLogs as unknown[] | undefined;
+
+  if (!Array.isArray(resourceLogs)) {
+    return { resourceLogs: [] };
+  }
+
+  return {
+    resourceLogs: resourceLogs.map(normalizeResourceLogsFromProtobuf),
+  };
+}
+
+/**
+ * Normalize ResourceLogs from protobuf format.
+ */
+function normalizeResourceLogsFromProtobuf(rl: unknown): Record<string, unknown> {
+  if (!rl || typeof rl !== 'object') return {};
+
+  const data = rl as Record<string, unknown>;
+
+  return {
+    resource: data.resource,
+    scopeLogs: normalizeScopeLogsFromProtobuf(data.scopeLogs),
+    schemaUrl: data.schemaUrl,
+  };
+}
+
+/**
+ * Normalize ScopeLogs from protobuf format.
+ */
+function normalizeScopeLogsFromProtobuf(sl: unknown): unknown[] {
+  if (!Array.isArray(sl)) return [];
+
+  return sl.map((s) => {
+    if (!s || typeof s !== 'object') return {};
+    const data = s as Record<string, unknown>;
+
+    return {
+      scope: data.scope,
+      logRecords: normalizeLogRecordsFromProtobuf(data.logRecords),
+      schemaUrl: data.schemaUrl,
+    };
+  });
+}
+
+/**
+ * Normalize LogRecords from protobuf format.
+ * Handles the conversion of protobuf field types to our expected format.
+ */
+function normalizeLogRecordsFromProtobuf(lr: unknown): unknown[] {
+  if (!Array.isArray(lr)) return [];
+
+  return lr.map((l) => {
+    if (!l || typeof l !== 'object') return {};
+    const data = l as Record<string, unknown>;
+
+    // Debug log to see actual protobuf structure
+    if (process.env.OTLP_DEBUG === 'true') {
+      console.log('[OTLP Debug] Raw log record from protobuf:', JSON.stringify(data, null, 2));
+    }
+
+    // Normalize the body - protobuf decoder may use different structure
+    const normalizedBody = normalizeBodyFromProtobuf(data.body);
+
+    return {
+      timeUnixNano: data.timeUnixNano,
+      observedTimeUnixNano: data.observedTimeUnixNano,
+      severityNumber: data.severityNumber,
+      severityText: data.severityText,
+      body: normalizedBody,
+      attributes: normalizeAttributesFromProtobuf(data.attributes),
+      droppedAttributesCount: data.droppedAttributesCount,
+      flags: data.flags,
+      // Convert Uint8Array trace/span IDs to hex strings
+      traceId: normalizeTraceSpanId(data.traceId),
+      spanId: normalizeTraceSpanId(data.spanId),
+    };
+  });
+}
+
+/**
+ * Normalize body (AnyValue) from protobuf format.
+ * The protobuf decoder may encode values differently.
+ */
+function normalizeBodyFromProtobuf(body: unknown): Record<string, unknown> | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+
+  const data = body as Record<string, unknown>;
+
+  // If it already has our expected structure, return as-is
+  if (data.stringValue !== undefined ||
+      data.boolValue !== undefined ||
+      data.intValue !== undefined ||
+      data.doubleValue !== undefined ||
+      data.arrayValue !== undefined ||
+      data.kvlistValue !== undefined ||
+      data.bytesValue !== undefined) {
+    return data as Record<string, unknown>;
+  }
+
+  // Check for protobuf snake_case variants
+  if ((data as Record<string, unknown>).string_value !== undefined) {
+    return { stringValue: (data as Record<string, unknown>).string_value };
+  }
+  if ((data as Record<string, unknown>).bool_value !== undefined) {
+    return { boolValue: (data as Record<string, unknown>).bool_value };
+  }
+  if ((data as Record<string, unknown>).int_value !== undefined) {
+    return { intValue: (data as Record<string, unknown>).int_value };
+  }
+  if ((data as Record<string, unknown>).double_value !== undefined) {
+    return { doubleValue: (data as Record<string, unknown>).double_value };
+  }
+  if ((data as Record<string, unknown>).array_value !== undefined) {
+    return { arrayValue: (data as Record<string, unknown>).array_value };
+  }
+  if ((data as Record<string, unknown>).kvlist_value !== undefined) {
+    return { kvlistValue: (data as Record<string, unknown>).kvlist_value };
+  }
+  if ((data as Record<string, unknown>).bytes_value !== undefined) {
+    return { bytesValue: (data as Record<string, unknown>).bytes_value };
+  }
+
+  // If the body is something else, try to extract the value
+  // Some protobuf decoders might use 'value' as a wrapper
+  if ((data as Record<string, unknown>).value !== undefined) {
+    return normalizeBodyFromProtobuf((data as Record<string, unknown>).value);
+  }
+
+  // Return as-is and let the transformer handle it
+  return data as Record<string, unknown>;
+}
+
+/**
+ * Normalize attributes from protobuf format.
+ */
+function normalizeAttributesFromProtobuf(attrs: unknown): unknown[] | undefined {
+  if (!Array.isArray(attrs)) return undefined;
+
+  return attrs.map((attr) => {
+    if (!attr || typeof attr !== 'object') return attr;
+    const data = attr as Record<string, unknown>;
+
+    return {
+      key: data.key,
+      value: normalizeBodyFromProtobuf(data.value),
+    };
+  });
+}
+
+/**
+ * Convert trace/span ID from protobuf format (Uint8Array or base64 string) to hex string.
+ */
+function normalizeTraceSpanId(id: unknown): string | undefined {
+  if (!id) return undefined;
+
+  // If already a hex string, return as-is
+  if (typeof id === 'string') {
+    // Check if it's base64 encoded (from protobuf toObject with bytes: String)
+    if (id.length > 0 && !/^[0-9a-fA-F]+$/.test(id)) {
+      // It's base64, convert to hex
+      try {
+        const buffer = Buffer.from(id, 'base64');
+        return buffer.toString('hex');
+      } catch {
+        return id; // Return as-is if conversion fails
+      }
+    }
+    return id;
+  }
+
+  // If Uint8Array, convert to hex
+  if (id instanceof Uint8Array || Buffer.isBuffer(id)) {
+    return Buffer.from(id).toString('hex');
+  }
+
+  return undefined;
 }
 
 // ============================================================================

--- a/packages/backend/src/tests/modules/otlp/parser.test.ts
+++ b/packages/backend/src/tests/modules/otlp/parser.test.ts
@@ -276,13 +276,22 @@ describe('OTLP Parser', () => {
       expect(result.resourceLogs).toHaveLength(1);
     });
 
-    it('should throw error for actual protobuf data', async () => {
-      // Binary data that isn't JSON
+    it('should throw error for invalid protobuf data', async () => {
+      // Invalid binary data that cannot be parsed as valid protobuf
       const buffer = Buffer.from([0x0a, 0x0b, 0x0c, 0x0d]);
 
       await expect(parseOtlpProtobuf(buffer)).rejects.toThrow(
-        'Protobuf parsing requires proto definitions'
+        'Failed to decode OTLP protobuf'
       );
+    });
+
+    it('should parse valid empty protobuf message', async () => {
+      // An empty ExportLogsServiceRequest (just the message with no resourceLogs)
+      // In protobuf, an empty message is literally empty bytes
+      const buffer = Buffer.from([]);
+
+      const result = await parseOtlpProtobuf(buffer);
+      expect(result.resourceLogs).toEqual([]);
     });
 
     it('should handle array JSON format', async () => {

--- a/packages/frontend/src/routes/docs/syslog/+page.svelte
+++ b/packages/frontend/src/routes/docs/syslog/+page.svelte
@@ -295,7 +295,10 @@
         <div>
             <h3 class="text-lg font-semibold mb-3">map_syslog_level.lua</h3>
             <p class="text-sm text-muted-foreground mb-3">
-                Lua script to convert syslog severity (0-7) to LogWard log levels:
+                Lua script to convert syslog severity (0-7) to log levels.
+                <strong>Note:</strong> LogWard automatically normalizes syslog levels server-side,
+                so you can send levels like "notice", "emergency", "warning" etc. and they will be
+                mapped to LogWard's 5 levels (debug, info, warn, error, critical).
             </p>
             <CodeBlock
                 lang="lua"
@@ -303,6 +306,13 @@
 -- Syslog severity levels (from RFC 3164/5424):
 -- 0 = Emergency, 1 = Alert, 2 = Critical, 3 = Error
 -- 4 = Warning, 5 = Notice, 6 = Informational, 7 = Debug
+--
+-- LogWard automatically maps these to its 5 levels:
+-- emergency/alert/critical -> critical
+-- error -> error
+-- warning -> warn
+-- notice/info -> info
+-- debug -> debug
 
 function map_syslog_level(tag, timestamp, record)
     local pri = tonumber(record["pri"])
@@ -312,6 +322,7 @@ function map_syslog_level(tag, timestamp, record)
         local severity = pri % 8
 
         -- Map severity number to log level string
+        -- LogWard will normalize these to its 5 levels
         local level_map = {
             [0] = "emergency",
             [1] = "alert",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@maxmind/geoip2-node':
         specifier: ^6.3.4
         version: 6.3.4
+      '@opentelemetry/otlp-transformer':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -809,9 +812,53 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.38.0':
+    resolution: {integrity: sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==}
+    engines: {node: '>=14'}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -3563,8 +3610,55 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/semantic-conventions@1.38.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
This pull request introduces full support for OpenTelemetry OTLP log ingestion in both JSON and Protobuf formats, improves normalization of log levels (including syslog and case-insensitive values), and enhances documentation for endpoint usage. It also adds comprehensive tests for syslog level normalization and OTLP Protobuf parsing, and updates dependencies to include the OpenTelemetry transformer.

**OpenTelemetry OTLP Protobuf Support:**
- Added dependency on `@opentelemetry/otlp-transformer` and integrated its generated protobuf definitions for decoding OTLP Protobuf log messages in `parser.ts`. Now, binary Protobuf payloads are properly parsed, normalized, and mapped to the internal format, with robust error handling and support for both JSON and Protobuf payloads. [[1]](diffhunk://#diff-e095a6dd10bb40447d8290e79f70c15334e874e757e25a569b9d3449ed4fe27dR46) [[2]](diffhunk://#diff-8ed3721f0a3e6d978765013b636200453f177a044102bee9cb011e80bd5a916cL7-R22) [[3]](diffhunk://#diff-8ed3721f0a3e6d978765013b636200453f177a044102bee9cb011e80bd5a916cL122-R366)
- Streamlined content-type parsing for Protobuf in Fastify to support both Content-Length and chunked encoding, ensuring compatibility with all OpenTelemetry SDKs and collectors.

**Log Level Normalization Improvements:**
- Enhanced the normalization logic to map syslog levels and common string log levels (including case-insensitive values) to LogWard's standard levels. [[1]](diffhunk://#diff-4e78a3f86a3006ceae64098787dc99b3ef71be2f5bfd3f12c81403a30c2b4d8dL68-R70) [[2]](diffhunk://#diff-4e78a3f86a3006ceae64098787dc99b3ef71be2f5bfd3f12c81403a30c2b4d8dL78-R126)
- Added integration tests to verify correct mapping of syslog and case-insensitive log levels.

**Testing and Error Handling:**
- Improved OTLP Protobuf parser tests to cover empty messages, invalid protobuf data, and array JSON payloads, ensuring robust error reporting and correct parsing behavior.

**Documentation and Example Updates:**
- Updated frontend documentation to clarify support for both JSON and Protobuf OTLP log ingestion, provided full endpoint URLs for cloud and self-hosted deployments, and updated code examples to use the correct endpoints. [[1]](diffhunk://#diff-f6d5cdd56fece18d36fb207d2a4b1b4283f770c9d8482cd8fb960405fe1fcbe7R40-R48) [[2]](diffhunk://#diff-f6d5cdd56fece18d36fb207d2a4b1b4283f770c9d8482cd8fb960405fe1fcbe7R64-R87) [[3]](diffhunk://#diff-f6d5cdd56fece18d36fb207d2a4b1b4283f770c9d8482cd8fb960405fe1fcbe7R231-R234) [[4]](diffhunk://#diff-f6d5cdd56fece18d36fb207d2a4b1b4283f770c9d8482cd8fb960405fe1fcbe7R297-R300)

Refs: #60