### PR TITLE
Add map_syslog_level.lua download command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Total control over your data. **No build required** - uses pre-built images from
     curl -O https://raw.githubusercontent.com/logtide-dev/logtide/main/docker/parsers.conf
     curl -O https://raw.githubusercontent.com/logtide-dev/logtide/main/docker/extract_container_id.lua
     curl -O https://raw.githubusercontent.com/logtide-dev/logtide/main/docker/wrap_logs.lua
+    curl -O https://raw.githubusercontent.com/logtide-dev/logtide/main/docker/map_syslog_level.lua
 
     # Set your LogTide API key in .env
     echo "FLUENT_BIT_API_KEY=your_api_key_here" >> .env


### PR DESCRIPTION
This PR fixes a missing URL and file in the README documentation :

Without this fluent-bit will not start correctly and no logs will be collected.