### PR TITLE
feat: add version update notifications to admin dashboard with configurable release channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Database migration `022_add_rate_of_change_alerts` (adds columns to `alert_rules` + `baseline_metadata` JSONB to `alert_history`)
   - 19 new tests (routes, baseline calculator, service dispatching, validation) — 105 total alert tests passing
 
+- **Version Update Notifications**: Admin dashboard banner that checks GitHub releases for new versions
+  - Backend endpoint `GET /api/v1/admin/version-check` proxies GitHub Releases API with 6-hour cache (via CacheManager)
+  - Compares current `package.json` version against latest stable and beta releases using semver
+  - Release channel setting (`stable` / `beta`) configurable from Admin Settings page, persisted as `updates.channel` in `system_settings`
+  - Blue "Update available" banner with version comparison and direct link to release, or green "Up to date" indicator
+  - Dynamic version in `/health` endpoint (replaced hardcoded string with `package.json` read)
+
 ### Fixed
 
 - **Log Context metadata expanding dialog infinitely**: Opening metadata in the Log Context dialog caused horizontal overflow, stretching the dialog indefinitely. Added `max-w-full` to `<pre>` blocks and `overflow-hidden` to log entry containers so metadata scrolls within its bounds

--- a/packages/backend/src/modules/admin/routes.ts
+++ b/packages/backend/src/modules/admin/routes.ts
@@ -629,6 +629,27 @@ export async function adminRoutes(fastify: FastifyInstance) {
         }
     );
 
+    // GET /api/v1/admin/version-check - Check for new releases on GitHub
+    fastify.get(
+        '/version-check',
+        {
+            config: {
+                rateLimit: rateLimitConfig,
+            },
+        },
+        async (_request, reply) => {
+            try {
+                const result = await adminService.checkVersion();
+                return reply.send(result);
+            } catch (error) {
+                console.error('Error checking version:', error);
+                return reply.status(500).send({
+                    error: 'Failed to check for updates',
+                });
+            }
+        }
+    );
+
     // Cache Management Routes
     // GET /api/v1/admin/cache/stats - Get cache statistics
     fastify.get(

--- a/packages/backend/src/modules/settings/service.ts
+++ b/packages/backend/src/modules/settings/service.ts
@@ -14,10 +14,14 @@ export const SETTING_KEYS = {
   AUTH_SIGNUP_ENABLED: 'auth.signup_enabled',
   AUTH_MODE: 'auth.mode',
   AUTH_DEFAULT_USER_ID: 'auth.default_user_id',
+  UPDATES_CHANNEL: 'updates.channel',
 } as const;
 
 // Type for auth mode
 export type AuthMode = 'standard' | 'none';
+
+// Type for update channel
+export type UpdateChannel = 'stable' | 'beta';
 
 // Interface for a setting record
 export interface SettingRecord {
@@ -33,6 +37,7 @@ export interface SystemSettings {
   'auth.signup_enabled': boolean;
   'auth.mode': AuthMode;
   'auth.default_user_id': string | null;
+  'updates.channel': UpdateChannel;
 }
 
 // Default values for settings
@@ -40,6 +45,7 @@ const DEFAULT_VALUES: SystemSettings = {
   'auth.signup_enabled': true,
   'auth.mode': 'standard',
   'auth.default_user_id': null,
+  'updates.channel': 'stable',
 };
 
 export class SettingsService {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -37,6 +37,12 @@ import { initializeInternalLogging, shutdownInternalLogging } from './utils/inte
 import websocketPlugin from './plugins/websocket.js';
 import websocketRoutes from './modules/query/websocket.js';
 import { enrichmentService } from './modules/siem/enrichment-service.js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __serverDirname = path.dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(path.resolve(__serverDirname, '../package.json'), 'utf-8'));
 
 const PORT = config.PORT;
 const HOST = config.HOST;
@@ -134,7 +140,7 @@ export async function build(opts = {}) {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),
-      version: '0.5.5',
+      version: packageJson.version,
     };
   });
 
@@ -211,8 +217,6 @@ async function start() {
 }
 
 // Start the server directly when this file is run
-import { fileURLToPath } from 'url';
-
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   start();
 }

--- a/packages/frontend/src/lib/api/admin.ts
+++ b/packages/frontend/src/lib/api/admin.ts
@@ -331,6 +331,25 @@ export interface SlowQueriesStats {
     pgStatStatementsAvailable: boolean;
 }
 
+// Version Check
+export interface ReleaseInfo {
+    version: string;
+    tag: string;
+    name: string;
+    publishedAt: string;
+    url: string;
+    prerelease: boolean;
+}
+
+export interface VersionCheckResult {
+    currentVersion: string;
+    channel: 'stable' | 'beta';
+    latestStable: ReleaseInfo | null;
+    latestBeta: ReleaseInfo | null;
+    updateAvailable: boolean;
+    checkedAt: string;
+}
+
 // System Settings Interfaces
 export interface SystemSetting {
     key: string;
@@ -427,6 +446,10 @@ class AdminAPI {
 
     async getSlowQueries(): Promise<SlowQueriesStats> {
         return this.fetch<SlowQueriesStats>('/stats/slow-queries');
+    }
+
+    async getVersionCheck(): Promise<VersionCheckResult> {
+        return this.fetch<VersionCheckResult>('/version-check');
     }
 
     // User Management

--- a/packages/frontend/src/routes/dashboard/admin/settings/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/admin/settings/+page.svelte
@@ -24,6 +24,7 @@
         Info,
         User,
         Search,
+        ArrowUpCircle,
     } from "lucide-svelte";
     import { browser } from "$app/environment";
     import { untrack } from "svelte";
@@ -43,6 +44,9 @@
     // Search settings state
     let searchDefaultMode = $state<"fulltext" | "substring">("fulltext");
     let searchSubstringIndexed = $state(true);
+
+    // Updates settings state
+    let updatesChannel = $state<"stable" | "beta">("stable");
 
     // Users list for auth-free mode selector
     let usersList = $state<UserBasic[]>([]);
@@ -97,6 +101,8 @@
             // Search settings
             searchDefaultMode = (settings["search.default_mode"] as "fulltext" | "substring") ?? "fulltext";
             searchSubstringIndexed = (settings["search.substring_indexed"] as boolean) ?? true;
+            // Updates settings
+            updatesChannel = (settings["updates.channel"] as "stable" | "beta") ?? "stable";
             // Only show active admin users for default user selection
             usersList = usersResponse.users.filter(u => !u.disabled && u.is_admin);
         } catch (e: any) {
@@ -118,6 +124,7 @@
                 "auth.default_user_id": defaultUserId,
                 "search.default_mode": searchDefaultMode,
                 "search.substring_indexed": searchSubstringIndexed,
+                "updates.channel": updatesChannel,
             });
             success = "Settings saved successfully";
             setTimeout(() => {
@@ -438,6 +445,52 @@
                             <p class="text-sm text-blue-600 dark:text-blue-400">
                                 <strong>Full-text:</strong> Word-based search with stemming (e.g., "fail" finds "failed", "failing").<br/>
                                 <strong>Substring:</strong> Finds text anywhere in the message (e.g., "bluez" finds "spa.bluez5.native").
+                            </p>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <!-- Update Channel Settings -->
+                <Card class="md:col-span-2">
+                    <CardHeader>
+                        <CardTitle class="flex items-center gap-2">
+                            <ArrowUpCircle class="h-5 w-5" />
+                            Update Notifications
+                        </CardTitle>
+                        <CardDescription>
+                            Choose which release channel to track for update notifications
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent class="space-y-4">
+                        <div class="grid gap-4 md:grid-cols-2">
+                            <div class="space-y-2">
+                                <Label>Release Channel</Label>
+                                <Select.Root
+                                    type="single"
+                                    value={updatesChannel}
+                                    onValueChange={(v) => {
+                                        if (v && (v === 'stable' || v === 'beta')) {
+                                            updatesChannel = v;
+                                        }
+                                    }}
+                                >
+                                    <Select.Trigger class="w-full">
+                                        {updatesChannel === "stable" ? "Stable" : "Beta (Pre-releases)"}
+                                    </Select.Trigger>
+                                    <Select.Content>
+                                        <Select.Item value="stable">Stable</Select.Item>
+                                        <Select.Item value="beta">Beta (Pre-releases)</Select.Item>
+                                    </Select.Content>
+                                </Select.Root>
+                                <p class="text-xs text-muted-foreground">
+                                    Controls which releases trigger "update available" notifications
+                                </p>
+                            </div>
+                        </div>
+                        <div class="bg-blue-500/10 border border-blue-500/20 rounded-md p-3">
+                            <p class="text-sm text-blue-600 dark:text-blue-400">
+                                <strong>Stable:</strong> Only notify for production-ready releases.<br/>
+                                <strong>Beta:</strong> Also notify for pre-release versions (may contain experimental features).
                             </p>
                         </div>
                     </CardContent>


### PR DESCRIPTION
This pull request introduces a new version update notification system for administrators, enhancing visibility into available updates and streamlining the upgrade process. It adds backend logic to check GitHub releases, exposes a new API endpoint, updates the frontend to display a notification banner in the admin dashboard, and makes the release channel configurable. Additionally, the backend `/health` endpoint now reports the actual package version dynamically.

**Version Update Notification System:**

* Added backend logic in `AdminService` to check for new releases on GitHub, compare versions using semver, and cache results for 6 hours. The check supports both stable and beta release channels, configurable via admin settings. [[1]](diffhunk://#diff-9c450af919e282e160c250bfca13b58dee1de030bb4feef92df32cc123b228e7R1614-R1729) [[2]](diffhunk://#diff-9c450af919e282e160c250bfca13b58dee1de030bb4feef92df32cc123b228e7R1873-R1900) [[3]](diffhunk://#diff-dc1e26475165ff1108298b6a8adeb6465e1b062678b8ddc1cbf70a334db685f8R17-R25) [[4]](diffhunk://#diff-dc1e26475165ff1108298b6a8adeb6465e1b062678b8ddc1cbf70a334db685f8R40-R48)
* Introduced new API endpoint `GET /api/v1/admin/version-check` to expose version check results to the frontend, with error handling and rate limiting.
* Updated frontend admin dashboard (`+page.svelte`) to fetch version check results and display a banner to admins: a blue "Update available" banner with version info and release link when an update exists, or a green "Up to date" indicator otherwise. (Fbc698f2L331R331, [[1]](diffhunk://#diff-111007d13da59ef79729694318cb610d20c57cf7cb387a2cb10fe20d2ee9ca36R451-R454) [[2]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR58) [[3]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dL98-R103) [[4]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR113) [[5]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR124) [[6]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR227-R294) [[7]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR38-R40) [[8]](diffhunk://#diff-885ffd2981b3552852e884b84df310b0eede500895d0caba00e78de455a7e37dR21)
* Added `updates.channel` setting to system settings, defaulting to `stable`, and made it editable from the admin settings page. [[1]](diffhunk://#diff-dc1e26475165ff1108298b6a8adeb6465e1b062678b8ddc1cbf70a334db685f8R17-R25) [[2]](diffhunk://#diff-dc1e26475165ff1108298b6a8adeb6465e1b062678b8ddc1cbf70a334db685f8R40-R48) [[3]](diffhunk://#diff-b0a51f6e1eac7d2f2877f12daaf3f2c6ed3741f2223af0adc6de7fad309a67e7R48-R50)

**Backend Improvements:**

* `/health` endpoint now reports the actual version from `package.json` instead of a hardcoded string, ensuring version accuracy. [[1]](diffhunk://#diff-4566d5c70de41c83e4eb7a94d183376a4f4c74b3f32e819599ea61abe5e54d26R40-R45) [[2]](diffhunk://#diff-4566d5c70de41c83e4eb7a94d183376a4f4c74b3f32e819599ea61abe5e54d26L137-R143) [[3]](diffhunk://#diff-4566d5c70de41c83e4eb7a94d183376a4f4c74b3f32e819599ea61abe5e54d26L214-L215)

**Documentation:**

* Updated `CHANGELOG.md` to document the new version update notification feature and related changes.