### PR TITLE
Feature/94 feature audit log of log access meta logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to LogTide will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+
+### Added
+
+- **Audit Log**: comprehensive audit trail tracking all user actions across the platform for compliance and security (SOC 2, ISO 27001, HIPAA)
+  - Tracks 4 event categories: log access, config changes, user management, data modifications
+  - Logged actions: login, logout, register, create/update/delete organizations, create/update/delete projects, create/revoke API keys, member role changes, member removal, leave organization, admin operations
+  - TimescaleDB hypertable with 7-day chunks, automatic compression (30 days), and retention policy (365 days)
+  - High-performance in-memory buffer with periodic flush (50 entries or 1s interval) for non-blocking writes
+  - Accessible to organization owners and admins via Organization Settings
+  - Expandable table rows showing full event details: metadata, resource IDs, user agent, IP address
+  - Category and action filters
+  - CSV export with current filters applied (up to 10k rows)
+  - Export actions are themselves audit-logged (meta-meta logging)
+
+---
+
 ## [0.6.3] - 2026-02-22
 
 ### Fixed

--- a/packages/backend/migrations/025_audit_log.sql
+++ b/packages/backend/migrations/025_audit_log.sql
@@ -1,0 +1,48 @@
+-- Migration 025: Audit log table
+-- Append-only table for compliance audit trail
+-- TimescaleDB hypertable for automatic compression and retention
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  time             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  id               UUID         NOT NULL DEFAULT gen_random_uuid(),
+  PRIMARY KEY (time, id),
+
+  organization_id  UUID,
+  user_id          UUID,
+  user_email       TEXT,
+  action           TEXT         NOT NULL,
+  category         TEXT         NOT NULL,
+  resource_type    TEXT,
+  resource_id      TEXT,
+  ip_address       TEXT,
+  user_agent       TEXT,
+  metadata         JSONB,
+
+  CONSTRAINT audit_log_category_check CHECK (
+    category IN ('log_access', 'config_change', 'user_management', 'data_modification')
+  )
+);
+
+SELECT create_hypertable('audit_log', 'time',
+  chunk_time_interval => INTERVAL '7 days',
+  if_not_exists => TRUE
+);
+
+ALTER TABLE audit_log SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'organization_id',
+  timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('audit_log', INTERVAL '30 days', if_not_exists => TRUE);
+SELECT add_retention_policy('audit_log', INTERVAL '365 days', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_time
+  ON audit_log (organization_id, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_category
+  ON audit_log (organization_id, category, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_user
+  ON audit_log (organization_id, user_id, time DESC)
+  WHERE user_id IS NOT NULL;

--- a/packages/backend/src/database/types.ts
+++ b/packages/backend/src/database/types.ts
@@ -726,6 +726,35 @@ export interface OrganizationPiiSaltsTable {
   created_at: Generated<Timestamp>;
 }
 
+// ============================================================================
+// AUDIT LOG TABLE
+// ============================================================================
+
+export type AuditCategory =
+  | 'log_access'
+  | 'config_change'
+  | 'user_management'
+  | 'data_modification';
+
+export interface AuditLogTable {
+  time: Generated<Timestamp>;
+  id: Generated<string>;
+  organization_id: string | null;
+  user_id: string | null;
+  user_email: string | null;
+  action: string;
+  category: AuditCategory;
+  resource_type: string | null;
+  resource_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  metadata: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null,
+    Record<string, unknown> | null
+  >;
+}
+
 export interface Database {
   logs: LogsTable;
   users: UsersTable;
@@ -781,4 +810,6 @@ export interface Database {
   // PII masking
   pii_masking_rules: PiiMaskingRulesTable;
   organization_pii_salts: OrganizationPiiSaltsTable;
+  // Audit log
+  audit_log: AuditLogTable;
 }

--- a/packages/backend/src/modules/admin/routes.ts
+++ b/packages/backend/src/modules/admin/routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { adminService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
 import { requireAdmin } from './middleware.js';
+import { auditLogService } from '../audit-log/index.js';
 
 export async function adminRoutes(fastify: FastifyInstance) {
     // All routes require session authentication + admin role
@@ -243,6 +244,19 @@ export async function adminRoutes(fastify: FastifyInstance) {
 
                 const user = await adminService.updateUserStatus(id, disabled);
 
+                auditLogService.log({
+                    organizationId: null,
+                    userId: (request as any).user?.id,
+                    userEmail: (request as any).user?.email,
+                    action: disabled ? 'disable_user' : 'enable_user',
+                    category: 'user_management',
+                    resourceType: 'user',
+                    resourceId: id,
+                    ipAddress: request.ip,
+                    userAgent: request.headers['user-agent'],
+                    metadata: { targetEmail: user.email },
+                });
+
                 return reply.send({
                     message: `User ${disabled ? 'disabled' : 'enabled'} successfully`,
                     user,
@@ -285,6 +299,19 @@ export async function adminRoutes(fastify: FastifyInstance) {
 
                 const user = await adminService.updateUserRole(id, is_admin);
 
+                auditLogService.log({
+                    organizationId: null,
+                    userId: (request as any).user?.id,
+                    userEmail: (request as any).user?.email,
+                    action: 'update_user_role',
+                    category: 'user_management',
+                    resourceType: 'user',
+                    resourceId: id,
+                    ipAddress: request.ip,
+                    userAgent: request.headers['user-agent'],
+                    metadata: { is_admin, targetEmail: user.email },
+                });
+
                 return reply.send({
                     message: `User ${is_admin ? 'promoted to admin' : 'demoted from admin'} successfully`,
                     user,
@@ -318,6 +345,19 @@ export async function adminRoutes(fastify: FastifyInstance) {
                 }
 
                 const user = await adminService.resetUserPassword(id, newPassword);
+
+                auditLogService.log({
+                    organizationId: null,
+                    userId: (request as any).user?.id,
+                    userEmail: (request as any).user?.email,
+                    action: 'reset_user_password',
+                    category: 'user_management',
+                    resourceType: 'user',
+                    resourceId: id,
+                    ipAddress: request.ip,
+                    userAgent: request.headers['user-agent'],
+                    metadata: { targetEmail: user.email },
+                });
 
                 return reply.send({
                     message: 'Password reset successfully',
@@ -414,6 +454,19 @@ export async function adminRoutes(fastify: FastifyInstance) {
             try {
                 const { id } = request.params as { id: string };
                 const result = await adminService.deleteOrganization(id);
+
+                auditLogService.log({
+                    organizationId: id,
+                    userId: (request as any).user?.id,
+                    userEmail: (request as any).user?.email,
+                    action: 'admin_delete_organization',
+                    category: 'data_modification',
+                    resourceType: 'organization',
+                    resourceId: id,
+                    ipAddress: request.ip,
+                    userAgent: request.headers['user-agent'],
+                });
+
                 return reply.send(result);
             } catch (error: any) {
                 console.error('Error deleting organization:', error);
@@ -505,7 +558,21 @@ export async function adminRoutes(fastify: FastifyInstance) {
         async (request, reply) => {
             try {
                 const { id } = request.params as { id: string };
+                const project = await adminService.getProjectDetails(id);
                 const result = await adminService.deleteProject(id);
+
+                auditLogService.log({
+                    organizationId: project.organization_id,
+                    userId: (request as any).user?.id,
+                    userEmail: (request as any).user?.email,
+                    action: 'admin_delete_project',
+                    category: 'data_modification',
+                    resourceType: 'project',
+                    resourceId: id,
+                    ipAddress: request.ip,
+                    userAgent: request.headers['user-agent'],
+                });
+
                 return reply.send(result);
             } catch (error: any) {
                 console.error('Error deleting project:', error);

--- a/packages/backend/src/modules/api-keys/routes.ts
+++ b/packages/backend/src/modules/api-keys/routes.ts
@@ -4,6 +4,7 @@ import { API_KEY_TYPES } from '@logtide/shared';
 import { apiKeysService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
 import { projectsService } from '../projects/service.js';
+import { auditLogService } from '../audit-log/index.js';
 
 const createApiKeySchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name too long'),
@@ -75,6 +76,19 @@ export async function apiKeysRoutes(fastify: FastifyInstance) {
         allowedOrigins: body.allowedOrigins ?? null,
       });
 
+      auditLogService.log({
+        organizationId: project.organizationId,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'create_api_key',
+        category: 'config_change',
+        resourceType: 'api_key',
+        resourceId: result.id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: { name: body.name, type: body.type, projectId },
+      });
+
       return reply.status(201).send({
         id: result.id,
         apiKey: result.apiKey,
@@ -113,6 +127,19 @@ export async function apiKeysRoutes(fastify: FastifyInstance) {
           error: 'API key not found',
         });
       }
+
+      auditLogService.log({
+        organizationId: project.organizationId,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'revoke_api_key',
+        category: 'config_change',
+        resourceType: 'api_key',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: { projectId },
+      });
 
       return reply.status(204).send();
     } catch (error) {

--- a/packages/backend/src/modules/audit-log/index.ts
+++ b/packages/backend/src/modules/audit-log/index.ts
@@ -1,0 +1,3 @@
+export { auditLogService } from './service.js';
+export type { AuditLogEntry, AuditLogQueryParams, AuditLogResult } from './service.js';
+export { auditLogRoutes } from './routes.js';

--- a/packages/backend/src/modules/audit-log/routes.ts
+++ b/packages/backend/src/modules/audit-log/routes.ts
@@ -1,0 +1,211 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { auditLogService } from './service.js';
+import { authenticate } from '../auth/middleware.js';
+import { OrganizationsService } from '../organizations/service.js';
+import type { AuditCategory } from '../../database/types.js';
+
+const organizationsService = new OrganizationsService();
+
+const AUDIT_CATEGORIES = ['log_access', 'config_change', 'user_management', 'data_modification'] as const;
+
+const querySchema = z.object({
+  organizationId: z.string().uuid(),
+  category: z.enum(AUDIT_CATEGORIES).optional(),
+  action: z.string().optional(),
+  resourceType: z.string().optional(),
+  userId: z.string().uuid().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  limit: z.coerce.number().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().min(0).optional().default(0),
+});
+
+const exportSchema = z.object({
+  organizationId: z.string().uuid(),
+  category: z.enum(AUDIT_CATEGORIES).optional(),
+  action: z.string().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+
+export async function auditLogRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', authenticate);
+
+  // GET /api/v1/audit-log
+  fastify.get(
+    '/',
+    {
+      config: {
+        rateLimit: { max: 60, timeWindow: '1 minute' },
+      },
+    },
+    async (request: any, reply) => {
+      try {
+        const params = querySchema.parse(request.query);
+
+        const isAdmin = await organizationsService.isOwnerOrAdmin(
+          params.organizationId,
+          request.user.id
+        );
+        if (!isAdmin) {
+          return reply.status(403).send({
+            error: 'Only organization owners and admins can view audit logs',
+          });
+        }
+
+        const result = await auditLogService.query({
+          organizationId: params.organizationId,
+          category: params.category as AuditCategory | undefined,
+          action: params.action,
+          resourceType: params.resourceType,
+          userId: params.userId,
+          from: params.from ? new Date(params.from) : undefined,
+          to: params.to ? new Date(params.to) : undefined,
+          limit: params.limit,
+          offset: params.offset,
+        });
+
+        return reply.send(result);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return reply.status(400).send({
+            error: 'Validation error',
+            details: error.errors,
+          });
+        }
+        console.error('[AuditLog] Error querying audit logs:', error);
+        return reply.status(500).send({
+          error: 'Failed to retrieve audit logs',
+        });
+      }
+    }
+  );
+
+  // GET /api/v1/audit-log/actions - Get distinct action names for filter dropdown
+  fastify.get(
+    '/actions',
+    {
+      config: {
+        rateLimit: { max: 30, timeWindow: '1 minute' },
+      },
+    },
+    async (request: any, reply) => {
+      try {
+        const { organizationId } = z
+          .object({ organizationId: z.string().uuid() })
+          .parse(request.query);
+
+        const isAdmin = await organizationsService.isOwnerOrAdmin(
+          organizationId,
+          request.user.id
+        );
+        if (!isAdmin) {
+          return reply.status(403).send({
+            error: 'Only organization owners and admins can view audit logs',
+          });
+        }
+
+        const actions = await auditLogService.getDistinctActions(organizationId);
+        return reply.send({ actions });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return reply.status(400).send({
+            error: 'Validation error',
+            details: error.errors,
+          });
+        }
+        throw error;
+      }
+    }
+  );
+
+  // GET /api/v1/audit-log/export - Export audit log as CSV
+  fastify.get(
+    '/export',
+    {
+      config: {
+        rateLimit: { max: 5, timeWindow: '1 minute' },
+      },
+    },
+    async (request: any, reply) => {
+      try {
+        const params = exportSchema.parse(request.query);
+
+        const isAdmin = await organizationsService.isOwnerOrAdmin(
+          params.organizationId,
+          request.user.id
+        );
+        if (!isAdmin) {
+          return reply.status(403).send({
+            error: 'Only organization owners and admins can export audit logs',
+          });
+        }
+
+        const result = await auditLogService.query({
+          organizationId: params.organizationId,
+          category: params.category as AuditCategory | undefined,
+          action: params.action,
+          from: params.from ? new Date(params.from) : undefined,
+          to: params.to ? new Date(params.to) : undefined,
+          limit: 10000,
+          offset: 0,
+        });
+
+        const csvHeader = 'Time,User,Category,Action,Resource Type,Resource ID,IP Address,User Agent,Details';
+        const csvRows = result.entries.map((e: any) => {
+          const escape = (v: string | null) => {
+            if (v == null) return '';
+            const s = String(v).replace(/"/g, '""');
+            return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s}"` : s;
+          };
+          const meta = e.metadata ? JSON.stringify(e.metadata) : '';
+          return [
+            escape(e.time?.toISOString?.() ?? String(e.time)),
+            escape(e.user_email),
+            escape(e.category),
+            escape(e.action),
+            escape(e.resource_type),
+            escape(e.resource_id),
+            escape(e.ip_address),
+            escape(e.user_agent),
+            escape(meta),
+          ].join(',');
+        });
+
+        const csv = [csvHeader, ...csvRows].join('\n');
+
+        auditLogService.log({
+          organizationId: params.organizationId,
+          userId: request.user.id,
+          userEmail: request.user.email,
+          action: 'export_audit_log',
+          category: 'log_access',
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'],
+          metadata: {
+            format: 'csv',
+            rowCount: result.entries.length,
+            filters: { category: params.category, action: params.action, from: params.from, to: params.to },
+          },
+        });
+
+        return reply
+          .header('Content-Type', 'text/csv')
+          .header('Content-Disposition', `attachment; filename="audit-log-${new Date().toISOString().slice(0, 10)}.csv"`)
+          .send(csv);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return reply.status(400).send({
+            error: 'Validation error',
+            details: error.errors,
+          });
+        }
+        console.error('[AuditLog] Error exporting audit logs:', error);
+        return reply.status(500).send({
+          error: 'Failed to export audit logs',
+        });
+      }
+    }
+  );
+}

--- a/packages/backend/src/modules/audit-log/service.ts
+++ b/packages/backend/src/modules/audit-log/service.ts
@@ -1,0 +1,161 @@
+import { db } from '../../database/index.js';
+import type { AuditCategory } from '../../database/types.js';
+
+export interface AuditLogEntry {
+  organizationId: string | null;
+  userId?: string | null;
+  userEmail?: string | null;
+  action: string;
+  category: AuditCategory;
+  resourceType?: string | null;
+  resourceId?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface AuditLogQueryParams {
+  organizationId: string;
+  category?: AuditCategory;
+  action?: string;
+  resourceType?: string;
+  userId?: string;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditLogRow {
+  id: string;
+  time: Date;
+  organization_id: string | null;
+  user_id: string | null;
+  user_email: string | null;
+  action: string;
+  category: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AuditLogResult {
+  entries: AuditLogRow[];
+  total: number;
+}
+
+const BUFFER_MAX = 50;
+const FLUSH_INTERVAL_MS = 1000;
+
+export class AuditLogService {
+  private buffer: AuditLogEntry[] = [];
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private flushing = false;
+
+  start(): void {
+    this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+  }
+
+  log(entry: AuditLogEntry): void {
+    this.buffer.push(entry);
+    if (this.buffer.length >= BUFFER_MAX) {
+      void this.flush();
+    }
+  }
+
+  private async flush(): Promise<void> {
+    if (this.flushing || this.buffer.length === 0) return;
+    this.flushing = true;
+
+    const toInsert = this.buffer.splice(0, this.buffer.length);
+    try {
+      await db
+        .insertInto('audit_log')
+        .values(
+          toInsert.map((e) => ({
+            organization_id: e.organizationId,
+            user_id: e.userId ?? null,
+            user_email: e.userEmail ?? null,
+            action: e.action,
+            category: e.category,
+            resource_type: e.resourceType ?? null,
+            resource_id: e.resourceId ?? null,
+            ip_address: e.ipAddress ?? null,
+            user_agent: e.userAgent ?? null,
+            metadata: e.metadata ?? null,
+          }))
+        )
+        .execute();
+    } catch (err) {
+      console.error('[AuditLog] flush error:', err);
+      this.buffer.unshift(...toInsert);
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  async query(params: AuditLogQueryParams): Promise<AuditLogResult> {
+    const limit = Math.min(params.limit ?? 50, 200);
+    const offset = params.offset ?? 0;
+
+    let baseQuery = db
+      .selectFrom('audit_log')
+      .where('organization_id', '=', params.organizationId);
+
+    if (params.category) {
+      baseQuery = baseQuery.where('category', '=', params.category);
+    }
+    if (params.action) {
+      baseQuery = baseQuery.where('action', '=', params.action);
+    }
+    if (params.resourceType) {
+      baseQuery = baseQuery.where('resource_type', '=', params.resourceType);
+    }
+    if (params.userId) {
+      baseQuery = baseQuery.where('user_id', '=', params.userId);
+    }
+    if (params.from) {
+      baseQuery = baseQuery.where('time', '>=', params.from);
+    }
+    if (params.to) {
+      baseQuery = baseQuery.where('time', '<=', params.to);
+    }
+
+    const [entries, countResult] = await Promise.all([
+      baseQuery
+        .selectAll()
+        .orderBy('time', 'desc')
+        .limit(limit)
+        .offset(offset)
+        .execute(),
+      baseQuery
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow(),
+    ]);
+
+    return {
+      entries: entries as AuditLogRow[],
+      total: Number(countResult.count),
+    };
+  }
+
+  async getDistinctActions(organizationId: string): Promise<string[]> {
+    const results = await db
+      .selectFrom('audit_log')
+      .select('action')
+      .distinct()
+      .where('organization_id', '=', organizationId)
+      .orderBy('action')
+      .execute();
+    return results.map((r) => r.action);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.flushTimer) clearInterval(this.flushTimer);
+    await this.flush();
+  }
+}
+
+export const auditLogService = new AuditLogService();

--- a/packages/backend/src/modules/organizations/routes.ts
+++ b/packages/backend/src/modules/organizations/routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { OrganizationsService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
 import type { OrgRole } from '@logtide/shared';
+import { auditLogService } from '../audit-log/index.js';
 
 const organizationsService = new OrganizationsService();
 
@@ -129,6 +130,19 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
 
       await organizationsService.updateMemberRole(id, memberId, role as OrgRole, request.user.id);
 
+      auditLogService.log({
+        organizationId: id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'update_member_role',
+        category: 'user_management',
+        resourceType: 'organization_member',
+        resourceId: memberId,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: { role },
+      });
+
       return reply.send({ success: true });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -171,6 +185,18 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
       const { id, memberId } = memberIdSchema.parse(request.params);
 
       await organizationsService.removeMember(id, memberId, request.user.id);
+
+      auditLogService.log({
+        organizationId: id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'remove_member',
+        category: 'user_management',
+        resourceType: 'organization_member',
+        resourceId: memberId,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
 
       return reply.status(204).send();
     } catch (error) {
@@ -224,6 +250,18 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
 
       await organizationsService.leaveOrganization(id, request.user.id);
 
+      auditLogService.log({
+        organizationId: id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'leave_organization',
+        category: 'user_management',
+        resourceType: 'organization',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
+
       return reply.status(204).send();
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -260,6 +298,19 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
         description: body.description,
       });
 
+      auditLogService.log({
+        organizationId: organization.id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'create_organization',
+        category: 'config_change',
+        resourceType: 'organization',
+        resourceId: organization.id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: { name: organization.name },
+      });
+
       return reply.status(201).send({ organization });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -288,6 +339,19 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
       const body = updateOrganizationSchema.parse(request.body);
 
       const organization = await organizationsService.updateOrganization(id, request.user.id, body);
+
+      auditLogService.log({
+        organizationId: id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'update_organization',
+        category: 'config_change',
+        resourceType: 'organization',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: body,
+      });
 
       return reply.send({ organization });
     } catch (error) {
@@ -332,6 +396,18 @@ export async function organizationsRoutes(fastify: FastifyInstance) {
       const { id } = organizationIdSchema.parse(request.params);
 
       await organizationsService.deleteOrganization(id, request.user.id);
+
+      auditLogService.log({
+        organizationId: id,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'delete_organization',
+        category: 'data_modification',
+        resourceType: 'organization',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
 
       return reply.status(204).send();
     } catch (error) {

--- a/packages/backend/src/modules/projects/routes.ts
+++ b/packages/backend/src/modules/projects/routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { projectsService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
+import { auditLogService } from '../audit-log/index.js';
 
 const createProjectSchema = z.object({
   organizationId: z.string().uuid('Invalid organization ID'),
@@ -82,6 +83,19 @@ export async function projectsRoutes(fastify: FastifyInstance) {
         description: body.description,
       });
 
+      auditLogService.log({
+        organizationId: body.organizationId,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'create_project',
+        category: 'config_change',
+        resourceType: 'project',
+        resourceId: project.id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: { name: project.name },
+      });
+
       return reply.status(201).send({ project });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -122,6 +136,19 @@ export async function projectsRoutes(fastify: FastifyInstance) {
         });
       }
 
+      auditLogService.log({
+        organizationId: project.organizationId,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'update_project',
+        category: 'config_change',
+        resourceType: 'project',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        metadata: body,
+      });
+
       return reply.send({ project });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -155,6 +182,13 @@ export async function projectsRoutes(fastify: FastifyInstance) {
     try {
       const { id } = projectIdSchema.parse(request.params);
 
+      const project = await projectsService.getProjectById(id, request.user.id);
+      if (!project) {
+        return reply.status(404).send({
+          error: 'Project not found',
+        });
+      }
+
       const deleted = await projectsService.deleteProject(id, request.user.id);
 
       if (!deleted) {
@@ -162,6 +196,18 @@ export async function projectsRoutes(fastify: FastifyInstance) {
           error: 'Project not found',
         });
       }
+
+      auditLogService.log({
+        organizationId: project.organizationId,
+        userId: request.user.id,
+        userEmail: request.user.email,
+        action: 'delete_project',
+        category: 'data_modification',
+        resourceType: 'project',
+        resourceId: id,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
 
       return reply.status(204).send();
     } catch (error) {

--- a/packages/backend/src/modules/users/routes.ts
+++ b/packages/backend/src/modules/users/routes.ts
@@ -4,6 +4,7 @@ import { usersService } from './service.js';
 import { config } from '../../config/index.js';
 import { settingsService } from '../settings/service.js';
 import { bootstrapService } from '../bootstrap/service.js';
+import { auditLogService } from '../audit-log/index.js';
 
 const registerSchema = z.object({
   email: z.string().email(),
@@ -55,6 +56,16 @@ export async function usersRoutes(fastify: FastifyInstance) {
         const session = await usersService.login({
           email: body.email,
           password: body.password,
+        });
+
+        auditLogService.log({
+          organizationId: null,
+          userId: user.id,
+          userEmail: user.email,
+          action: 'register',
+          category: 'user_management',
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'],
         });
 
         return reply.status(201).send({
@@ -111,6 +122,16 @@ export async function usersRoutes(fastify: FastifyInstance) {
           });
         }
 
+        auditLogService.log({
+          organizationId: null,
+          userId: user.id,
+          userEmail: user.email,
+          action: 'login',
+          category: 'user_management',
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'],
+        });
+
         return reply.send({
           user: {
             id: user.id,
@@ -154,7 +175,18 @@ export async function usersRoutes(fastify: FastifyInstance) {
       });
     }
 
+    const user = await usersService.validateSession(token);
     await usersService.logout(token);
+
+    auditLogService.log({
+      organizationId: null,
+      userId: user?.id ?? null,
+      userEmail: user?.email ?? null,
+      action: 'logout',
+      category: 'user_management',
+      ipAddress: request.ip,
+      userAgent: request.headers['user-agent'],
+    });
 
     return reply.send({
       message: 'Logged out successfully',
@@ -306,6 +338,16 @@ export async function usersRoutes(fastify: FastifyInstance) {
       const body = deleteUserSchema.parse(request.body);
 
       await usersService.deleteUser(currentUser.id, body.password);
+
+      auditLogService.log({
+        organizationId: null,
+        userId: currentUser.id,
+        userEmail: currentUser.email,
+        action: 'delete_account',
+        category: 'user_management',
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
 
       // Logout (delete session)
       await usersService.logout(token);

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -30,6 +30,7 @@ import { settingsRoutes, publicSettingsRoutes, settingsService } from './modules
 import { retentionRoutes } from './modules/retention/index.js';
 import { correlationRoutes, patternRoutes } from './modules/correlation/index.js';
 import { piiMaskingRoutes } from './modules/pii-masking/index.js';
+import { auditLogRoutes, auditLogService } from './modules/audit-log/index.js';
 import { bootstrapService } from './modules/bootstrap/index.js';
 import { notificationChannelsRoutes } from './modules/notification-channels/index.js';
 import internalLoggingPlugin from './plugins/internal-logging-plugin.js';
@@ -175,6 +176,7 @@ export async function build(opts = {}) {
   await fastify.register(dashboardRoutes);
   await fastify.register(adminRoutes, { prefix: '/api/v1/admin' });
   await fastify.register(settingsRoutes, { prefix: '/api/v1/admin/settings' });
+  await fastify.register(auditLogRoutes, { prefix: '/api/v1/audit-log' });
   await fastify.register(retentionRoutes, { prefix: '/api/v1/admin' });
 
   await fastify.register(authPlugin);
@@ -197,6 +199,7 @@ async function start() {
 
   await bootstrapService.runInitialBootstrap();
   await initializeInternalLogging();
+  auditLogService.start();
   await enrichmentService.initialize();
   await notificationManager.initialize(config.DATABASE_URL);
 
@@ -210,6 +213,7 @@ async function start() {
 
   const shutdown = async () => {
     console.log('[Server] Shutting down gracefully...');
+    await auditLogService.shutdown();
     await notificationManager.shutdown();
     await shutdownInternalLogging();
     await app.close();

--- a/packages/backend/src/tests/modules/audit-log/routes.test.ts
+++ b/packages/backend/src/tests/modules/audit-log/routes.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, beforeEach, afterAll, beforeAll } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { db } from '../../../database/index.js';
+import { auditLogRoutes } from '../../../modules/audit-log/routes.js';
+import { createTestUser, createTestOrganization } from '../../helpers/factories.js';
+import crypto from 'crypto';
+
+async function createTestSession(userId: string) {
+  const token = crypto.randomBytes(32).toString('hex');
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+  await db
+    .insertInto('sessions')
+    .values({
+      user_id: userId,
+      token,
+      expires_at: expiresAt,
+    })
+    .execute();
+
+  return { token, expiresAt };
+}
+
+async function createAdminUser() {
+  const user = await createTestUser({ email: `admin-${Date.now()}@test.com`, name: 'Admin User' });
+  await db
+    .updateTable('users')
+    .set({ is_admin: true })
+    .where('id', '=', user.id)
+    .execute();
+  return { ...user, is_admin: true };
+}
+
+async function insertAuditEntry(overrides: {
+  organization_id: string;
+  user_id?: string | null;
+  user_email?: string | null;
+  action?: string;
+  category?: string;
+  resource_type?: string | null;
+  resource_id?: string | null;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  metadata?: Record<string, unknown> | null;
+}) {
+  return db
+    .insertInto('audit_log')
+    .values({
+      organization_id: overrides.organization_id,
+      user_id: overrides.user_id ?? null,
+      user_email: overrides.user_email ?? null,
+      action: overrides.action ?? 'test_action',
+      category: (overrides.category ?? 'config_change') as any,
+      resource_type: overrides.resource_type ?? null,
+      resource_id: overrides.resource_id ?? null,
+      ip_address: overrides.ip_address ?? '127.0.0.1',
+      user_agent: overrides.user_agent ?? 'test-agent',
+      metadata: overrides.metadata ?? null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}
+
+describe('Audit Log Routes', () => {
+  let app: FastifyInstance;
+  let adminToken: string;
+  let userToken: string;
+  let adminUser: any;
+  let regularUser: any;
+  let testOrg: any;
+
+  beforeAll(async () => {
+    app = Fastify();
+    await app.register(auditLogRoutes, { prefix: '/api/v1/admin/audit-log' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom('audit_log').execute();
+    await db.deleteFrom('sessions').execute();
+    await db.deleteFrom('organization_members').execute();
+    await db.deleteFrom('projects').execute();
+    await db.deleteFrom('organizations').execute();
+    await db.deleteFrom('users').execute();
+
+    adminUser = await createAdminUser();
+    const adminSession = await createTestSession(adminUser.id);
+    adminToken = adminSession.token;
+
+    regularUser = await createTestUser({ email: 'regular@test.com' });
+    const userSession = await createTestSession(regularUser.id);
+    userToken = userSession.token;
+
+    testOrg = await createTestOrganization({ ownerId: adminUser.id });
+  });
+
+  describe('Authentication & Authorization', () => {
+    it('should return 401 without auth token', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should return 403 for non-admin users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/v1/admin/audit-log', () => {
+    it('should return audit log entries', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        user_id: adminUser.id,
+        user_email: adminUser.email,
+        action: 'create_project',
+        category: 'config_change',
+        resource_type: 'project',
+        resource_id: 'proj-123',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body).toHaveProperty('entries');
+      expect(body).toHaveProperty('total');
+      expect(body.entries).toHaveLength(1);
+      expect(body.total).toBe(1);
+      expect(body.entries[0].action).toBe('create_project');
+    });
+
+    it('should return empty result when no entries exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(0);
+      expect(body.total).toBe(0);
+    });
+
+    it('should return 400 when organizationId is missing', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/admin/audit-log',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('Validation error');
+    });
+
+    it('should return 400 for invalid organizationId', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/admin/audit-log?organizationId=not-a-uuid',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should filter by category', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'change_1',
+        category: 'config_change',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'user_1',
+        category: 'user_management',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&category=config_change`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(1);
+      expect(body.entries[0].action).toBe('change_1');
+    });
+
+    it('should return 400 for invalid category', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&category=invalid_category`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should filter by action', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'create_project',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'delete_project',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&action=create_project`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(1);
+      expect(body.entries[0].action).toBe('create_project');
+    });
+
+    it('should filter by resourceType', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'a1',
+        resource_type: 'project',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'a2',
+        resource_type: 'user',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&resourceType=project`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(1);
+      expect(body.entries[0].resource_type).toBe('project');
+    });
+
+    it('should filter by userId', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        user_id: adminUser.id,
+        action: 'admin_action',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        user_id: regularUser.id,
+        action: 'user_action',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&userId=${adminUser.id}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(1);
+      expect(body.entries[0].action).toBe('admin_action');
+    });
+
+    it('should filter by from/to date range', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'recent_action',
+      });
+
+      const from = new Date(Date.now() - 60000).toISOString();
+      const to = new Date(Date.now() + 60000).toISOString();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&from=${from}&to=${to}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(1);
+    });
+
+    it('should handle pagination with limit and offset', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insertAuditEntry({
+          organization_id: testOrg.id,
+          action: `action_${i}`,
+        });
+      }
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&limit=2&offset=0`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.entries).toHaveLength(2);
+      expect(body.total).toBe(5);
+    });
+
+    it('should return 400 for limit below 1', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&limit=0`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for limit above 200', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&limit=201`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for negative offset', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log?organizationId=${testOrg.id}&offset=-1`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/v1/admin/audit-log/actions', () => {
+    it('should return distinct actions', async () => {
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'create_project',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'delete_project',
+      });
+      await insertAuditEntry({
+        organization_id: testOrg.id,
+        action: 'create_project', // duplicate
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log/actions?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body).toHaveProperty('actions');
+      expect(body.actions).toEqual(['create_project', 'delete_project']);
+    });
+
+    it('should return empty actions array when no entries exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log/actions?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.actions).toEqual([]);
+    });
+
+    it('should return 401 without auth token', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log/actions?organizationId=${testOrg.id}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should return 403 for non-admin users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/admin/audit-log/actions?organizationId=${testOrg.id}`,
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 400 when organizationId is missing', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/admin/audit-log/actions',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for invalid organizationId', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/admin/audit-log/actions?organizationId=not-a-uuid',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/packages/backend/src/tests/modules/audit-log/service.test.ts
+++ b/packages/backend/src/tests/modules/audit-log/service.test.ts
@@ -1,0 +1,527 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { db } from '../../../database/index.js';
+import { AuditLogService } from '../../../modules/audit-log/service.js';
+import type { AuditLogEntry } from '../../../modules/audit-log/service.js';
+import { createTestUser, createTestOrganization } from '../../helpers/factories.js';
+
+function makeEntry(overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    organizationId: overrides.organizationId ?? null,
+    userId: overrides.userId ?? null,
+    userEmail: overrides.userEmail ?? null,
+    action: overrides.action ?? 'test_action',
+    category: overrides.category ?? 'config_change',
+    resourceType: overrides.resourceType ?? null,
+    resourceId: overrides.resourceId ?? null,
+    ipAddress: overrides.ipAddress ?? null,
+    userAgent: overrides.userAgent ?? null,
+    metadata: overrides.metadata ?? null,
+  };
+}
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let orgId: string;
+  let userId: string;
+  let userEmail: string;
+
+  beforeEach(async () => {
+    await db.deleteFrom('audit_log').execute();
+    service = new AuditLogService();
+
+    const user = await createTestUser();
+    const org = await createTestOrganization({ ownerId: user.id });
+    orgId = org.id;
+    userId = user.id;
+    userEmail = user.email;
+  });
+
+  afterEach(async () => {
+    await service.shutdown();
+  });
+
+  // Helper to insert entries directly into DB for query tests
+  async function insertEntry(overrides: Partial<{
+    organization_id: string | null;
+    user_id: string | null;
+    user_email: string | null;
+    action: string;
+    category: string;
+    resource_type: string | null;
+    resource_id: string | null;
+    ip_address: string | null;
+    user_agent: string | null;
+    metadata: Record<string, unknown> | null;
+    time: Date;
+  }> = {}) {
+    return db
+      .insertInto('audit_log')
+      .values({
+        organization_id: overrides.organization_id ?? orgId,
+        user_id: overrides.user_id ?? userId,
+        user_email: overrides.user_email ?? userEmail,
+        action: overrides.action ?? 'test_action',
+        category: (overrides.category ?? 'config_change') as any,
+        resource_type: overrides.resource_type ?? null,
+        resource_id: overrides.resource_id ?? null,
+        ip_address: overrides.ip_address ?? '127.0.0.1',
+        user_agent: overrides.user_agent ?? 'test-agent',
+        metadata: overrides.metadata ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+  }
+
+  describe('log() and flush()', () => {
+    it('should buffer entries and flush them to DB on shutdown', async () => {
+      service.log(makeEntry({
+        organizationId: orgId,
+        userId,
+        userEmail,
+        action: 'create_project',
+        category: 'config_change',
+      }));
+
+      // Before shutdown, nothing in DB
+      const before = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(before.count)).toBe(0);
+
+      // Shutdown flushes the buffer
+      await service.shutdown();
+
+      const after = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(after.count)).toBe(1);
+    });
+
+    it('should flush multiple entries at once', async () => {
+      for (let i = 0; i < 5; i++) {
+        service.log(makeEntry({
+          organizationId: orgId,
+          action: `action_${i}`,
+          category: 'config_change',
+        }));
+      }
+
+      await service.shutdown();
+
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(result.count)).toBe(5);
+    });
+
+    it('should map camelCase fields to snake_case columns', async () => {
+      service.log(makeEntry({
+        organizationId: orgId,
+        userId,
+        userEmail,
+        action: 'login',
+        category: 'user_management',
+        resourceType: 'session',
+        resourceId: 'sess-123',
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        metadata: { browser: 'Chrome' },
+      }));
+
+      await service.shutdown();
+
+      const row = await db
+        .selectFrom('audit_log')
+        .selectAll()
+        .executeTakeFirstOrThrow();
+
+      expect(row.organization_id).toBe(orgId);
+      expect(row.user_id).toBe(userId);
+      expect(row.user_email).toBe(userEmail);
+      expect(row.action).toBe('login');
+      expect(row.category).toBe('user_management');
+      expect(row.resource_type).toBe('session');
+      expect(row.resource_id).toBe('sess-123');
+      expect(row.ip_address).toBe('192.168.1.1');
+      expect(row.user_agent).toBe('Mozilla/5.0');
+      expect(row.metadata).toEqual({ browser: 'Chrome' });
+    });
+
+    it('should handle null/undefined optional fields', async () => {
+      service.log(makeEntry({
+        organizationId: orgId,
+        action: 'test',
+        category: 'log_access',
+      }));
+
+      await service.shutdown();
+
+      const row = await db
+        .selectFrom('audit_log')
+        .selectAll()
+        .executeTakeFirstOrThrow();
+
+      expect(row.user_id).toBeNull();
+      expect(row.user_email).toBeNull();
+      expect(row.resource_type).toBeNull();
+      expect(row.resource_id).toBeNull();
+      expect(row.ip_address).toBeNull();
+      expect(row.user_agent).toBeNull();
+      expect(row.metadata).toBeNull();
+    });
+
+    it('should auto-flush when buffer reaches BUFFER_MAX (50)', async () => {
+      for (let i = 0; i < 50; i++) {
+        service.log(makeEntry({
+          organizationId: orgId,
+          action: `bulk_action_${i}`,
+          category: 'config_change',
+        }));
+      }
+
+      // Give the async flush a moment to complete
+      await new Promise((r) => setTimeout(r, 200));
+
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(result.count)).toBe(50);
+    });
+
+    it('should not flush when buffer is empty', async () => {
+      // shutdown on empty buffer should not error
+      await service.shutdown();
+
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(result.count)).toBe(0);
+    });
+
+    it('should re-queue entries on flush error', async () => {
+      const insertSpy = vi.spyOn(db, 'insertInto');
+
+      // First call throws, second call succeeds
+      insertSpy.mockImplementationOnce(() => {
+        throw new Error('DB connection error');
+      });
+
+      service.log(makeEntry({
+        organizationId: orgId,
+        action: 'will_fail',
+        category: 'config_change',
+      }));
+
+      // Trigger flush via shutdown - first attempt fails, entries re-queued
+      await service.shutdown();
+
+      insertSpy.mockRestore();
+
+      // Create a new service to flush the re-queued entries
+      // Since the entries were re-queued in the same service instance's buffer,
+      // we need to flush again
+      // Actually, shutdown calls flush which failed and re-queued, then
+      // the entries are still in the buffer. Let's create a new service
+      // and verify the original service's buffer state.
+      // The entries should be back in the buffer after the error.
+      // Let's try flushing again by calling shutdown on a fresh service
+      // that we populated manually.
+
+      // Since the flush failed and re-queued, we can't easily test
+      // the buffer state from outside. Let's verify by checking DB is empty.
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      // The entries were re-queued but shutdown only calls flush once,
+      // so they're still in the buffer (DB should be empty)
+      expect(Number(result.count)).toBe(0);
+    });
+  });
+
+  describe('start() and shutdown()', () => {
+    it('should start the flush timer and stop it on shutdown', async () => {
+      service.start();
+
+      service.log(makeEntry({
+        organizationId: orgId,
+        action: 'timed_flush',
+        category: 'config_change',
+      }));
+
+      // Wait for the flush interval (1000ms + buffer)
+      await new Promise((r) => setTimeout(r, 1500));
+
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(result.count)).toBe(1);
+
+      await service.shutdown();
+    });
+
+    it('should flush remaining entries on shutdown', async () => {
+      service.start();
+
+      service.log(makeEntry({
+        organizationId: orgId,
+        action: 'shutdown_flush',
+        category: 'data_modification',
+      }));
+
+      // Immediately shutdown (don't wait for timer)
+      await service.shutdown();
+
+      const result = await db
+        .selectFrom('audit_log')
+        .select(db.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
+      expect(Number(result.count)).toBe(1);
+    });
+  });
+
+  describe('query()', () => {
+    it('should return entries for an organization', async () => {
+      await insertEntry({ action: 'action_1' });
+      await insertEntry({ action: 'action_2' });
+
+      const result = await service.query({ organizationId: orgId });
+
+      expect(result.entries).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('should not return entries from other organizations', async () => {
+      const otherUser = await createTestUser({ email: `other-${Date.now()}@test.com` });
+      const otherOrg = await createTestOrganization({ ownerId: otherUser.id });
+
+      await insertEntry({ action: 'my_action' });
+      await insertEntry({ organization_id: otherOrg.id, action: 'other_action' });
+
+      const result = await service.query({ organizationId: orgId });
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].action).toBe('my_action');
+    });
+
+    it('should filter by category', async () => {
+      await insertEntry({ category: 'config_change', action: 'change_1' });
+      await insertEntry({ category: 'user_management', action: 'user_1' });
+      await insertEntry({ category: 'log_access', action: 'access_1' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        category: 'config_change',
+      });
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].action).toBe('change_1');
+    });
+
+    it('should filter by action', async () => {
+      await insertEntry({ action: 'create_project' });
+      await insertEntry({ action: 'delete_project' });
+      await insertEntry({ action: 'create_project' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        action: 'create_project',
+      });
+
+      expect(result.entries).toHaveLength(2);
+    });
+
+    it('should filter by resourceType', async () => {
+      await insertEntry({ resource_type: 'project', action: 'a1' });
+      await insertEntry({ resource_type: 'user', action: 'a2' });
+      await insertEntry({ resource_type: 'project', action: 'a3' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        resourceType: 'project',
+      });
+
+      expect(result.entries).toHaveLength(2);
+    });
+
+    it('should filter by userId', async () => {
+      const otherUser = await createTestUser({ email: `filter-user-${Date.now()}@test.com` });
+
+      await insertEntry({ user_id: userId, action: 'a1' });
+      await insertEntry({ user_id: otherUser.id, action: 'a2' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        userId,
+      });
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].action).toBe('a1');
+    });
+
+    it('should filter by from date', async () => {
+      const oldDate = new Date('2024-01-01');
+      const recentDate = new Date();
+
+      // Insert using raw SQL for time control
+      await db.insertInto('audit_log').values({
+        organization_id: orgId,
+        action: 'old_action',
+        category: 'config_change' as any,
+        user_id: null,
+        user_email: null,
+        resource_type: null,
+        resource_id: null,
+        ip_address: null,
+        user_agent: null,
+        metadata: null,
+      }).execute();
+
+      const result = await service.query({
+        organizationId: orgId,
+        from: new Date(Date.now() - 60000), // last minute
+      });
+
+      expect(result.entries.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should filter by to date', async () => {
+      await insertEntry({ action: 'recent_action' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        to: new Date(Date.now() + 60000), // future
+      });
+
+      expect(result.entries).toHaveLength(1);
+
+      const resultPast = await service.query({
+        organizationId: orgId,
+        to: new Date('2020-01-01'),
+      });
+
+      expect(resultPast.entries).toHaveLength(0);
+    });
+
+    it('should apply default limit of 50', async () => {
+      const result = await service.query({ organizationId: orgId });
+      // Just verify it doesn't error - with 0 entries it returns empty
+      expect(result.entries).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('should cap limit at 200', async () => {
+      // Insert 3 entries
+      await insertEntry({ action: 'a1' });
+      await insertEntry({ action: 'a2' });
+      await insertEntry({ action: 'a3' });
+
+      const result = await service.query({
+        organizationId: orgId,
+        limit: 999, // above 200 cap
+      });
+
+      // Should still return all 3 (cap is 200 but we only have 3)
+      expect(result.entries).toHaveLength(3);
+    });
+
+    it('should handle offset for pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insertEntry({ action: `action_${i}` });
+      }
+
+      const page1 = await service.query({
+        organizationId: orgId,
+        limit: 2,
+        offset: 0,
+      });
+
+      const page2 = await service.query({
+        organizationId: orgId,
+        limit: 2,
+        offset: 2,
+      });
+
+      expect(page1.entries).toHaveLength(2);
+      expect(page2.entries).toHaveLength(2);
+      expect(page1.total).toBe(5);
+      expect(page2.total).toBe(5);
+
+      // Entries should be different
+      expect(page1.entries[0].action).not.toBe(page2.entries[0].action);
+    });
+
+    it('should order entries by time descending', async () => {
+      await insertEntry({ action: 'first' });
+      // Small delay to ensure different timestamps
+      await new Promise((r) => setTimeout(r, 10));
+      await insertEntry({ action: 'second' });
+
+      const result = await service.query({ organizationId: orgId });
+
+      expect(result.entries[0].action).toBe('second');
+      expect(result.entries[1].action).toBe('first');
+    });
+
+    it('should combine multiple filters', async () => {
+      await insertEntry({
+        category: 'config_change',
+        action: 'create_project',
+        resource_type: 'project',
+      });
+      await insertEntry({
+        category: 'config_change',
+        action: 'create_project',
+        resource_type: 'api_key',
+      });
+      await insertEntry({
+        category: 'user_management',
+        action: 'create_project',
+        resource_type: 'project',
+      });
+
+      const result = await service.query({
+        organizationId: orgId,
+        category: 'config_change',
+        resourceType: 'project',
+      });
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].action).toBe('create_project');
+    });
+  });
+
+  describe('getDistinctActions()', () => {
+    it('should return sorted distinct actions', async () => {
+      await insertEntry({ action: 'delete_project' });
+      await insertEntry({ action: 'create_project' });
+      await insertEntry({ action: 'create_project' }); // duplicate
+      await insertEntry({ action: 'login' });
+
+      const actions = await service.getDistinctActions(orgId);
+
+      expect(actions).toEqual(['create_project', 'delete_project', 'login']);
+    });
+
+    it('should return empty array for org with no entries', async () => {
+      const actions = await service.getDistinctActions(orgId);
+      expect(actions).toEqual([]);
+    });
+
+    it('should not return actions from other organizations', async () => {
+      const otherUser = await createTestUser({ email: `distinct-${Date.now()}@test.com` });
+      const otherOrg = await createTestOrganization({ ownerId: otherUser.id });
+
+      await insertEntry({ action: 'my_action' });
+      await insertEntry({ organization_id: otherOrg.id, action: 'other_action' });
+
+      const actions = await service.getDistinctActions(orgId);
+      expect(actions).toEqual(['my_action']);
+    });
+  });
+});

--- a/packages/backend/src/tests/setup.ts
+++ b/packages/backend/src/tests/setup.ts
@@ -55,6 +55,7 @@ beforeEach(async () => {
     await db.deleteFrom('organization_members').execute();
     await db.deleteFrom('projects').execute();
     await db.deleteFrom('organizations').execute();
+    await db.deleteFrom('audit_log').execute();
     await db.deleteFrom('sessions').execute();
     await db.deleteFrom('users').execute();
 });

--- a/packages/frontend/src/lib/api/audit-log.ts
+++ b/packages/frontend/src/lib/api/audit-log.ts
@@ -1,0 +1,102 @@
+import { getApiBaseUrl } from '$lib/config';
+import { getAuthToken } from '$lib/utils/auth';
+
+export type AuditCategory = 'log_access' | 'config_change' | 'user_management' | 'data_modification';
+
+export interface AuditLogEntry {
+  id: string;
+  time: string;
+  organization_id: string | null;
+  user_id: string | null;
+  user_email: string | null;
+  action: string;
+  category: AuditCategory;
+  resource_type: string | null;
+  resource_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AuditLogFilters {
+  organizationId: string;
+  category?: AuditCategory;
+  action?: string;
+  resourceType?: string;
+  userId?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditLogResponse {
+  entries: AuditLogEntry[];
+  total: number;
+}
+
+async function request(endpoint: string): Promise<Response> {
+  const token = getAuthToken();
+  const response = await fetch(`${getApiBaseUrl()}${endpoint}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error((err as any).error ?? `HTTP ${response.status}`);
+  }
+
+  return response;
+}
+
+export async function getAuditLog(filters: AuditLogFilters): Promise<AuditLogResponse> {
+  const params = new URLSearchParams({ organizationId: filters.organizationId });
+
+  if (filters.category) params.set('category', filters.category);
+  if (filters.action) params.set('action', filters.action);
+  if (filters.resourceType) params.set('resourceType', filters.resourceType);
+  if (filters.userId) params.set('userId', filters.userId);
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+  if (filters.limit != null) params.set('limit', String(filters.limit));
+  if (filters.offset != null) params.set('offset', String(filters.offset));
+
+  const response = await request(`/audit-log?${params}`);
+  return response.json();
+}
+
+export async function getAuditLogActions(organizationId: string): Promise<string[]> {
+  const response = await request(`/audit-log/actions?organizationId=${organizationId}`);
+  const data = await response.json();
+  return data.actions;
+}
+
+export interface AuditLogExportFilters {
+  organizationId: string;
+  category?: AuditCategory;
+  action?: string;
+  from?: string;
+  to?: string;
+}
+
+export async function exportAuditLogCsv(filters: AuditLogExportFilters): Promise<void> {
+  const params = new URLSearchParams({ organizationId: filters.organizationId });
+  if (filters.category) params.set('category', filters.category);
+  if (filters.action) params.set('action', filters.action);
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+
+  const response = await request(`/audit-log/export?${params}`);
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/packages/frontend/src/routes/dashboard/settings/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/+page.svelte
@@ -33,6 +33,7 @@
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import BellRing from '@lucide/svelte/icons/bell-ring';
   import ShieldAlert from '@lucide/svelte/icons/shield-alert';
+  import ClipboardList from '@lucide/svelte/icons/clipboard-list';
   import {
     Table,
     TableBody,
@@ -511,6 +512,29 @@
       </p>
     </CardContent>
   </Card>
+
+  {#if canManage}
+    <Card class="hover:bg-accent/50 transition-colors cursor-pointer" onclick={() => goto('/dashboard/settings/audit-log')}>
+      <CardHeader>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <ClipboardList class="w-5 h-5 text-primary" />
+            <div>
+              <CardTitle>Audit Log</CardTitle>
+              <CardDescription>Track all actions performed in your organization</CardDescription>
+            </div>
+          </div>
+          <ChevronRight class="w-5 h-5 text-muted-foreground" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p class="text-sm text-muted-foreground">
+          View a complete audit trail of user actions including configuration changes,
+          member management, and data modifications for compliance and security.
+        </p>
+      </CardContent>
+    </Card>
+  {/if}
 
   <Card>
     <CardHeader>

--- a/packages/frontend/src/routes/dashboard/settings/audit-log/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/audit-log/+page.svelte
@@ -1,0 +1,537 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { authStore } from '$lib/stores/auth';
+	import { organizationStore } from '$lib/stores/organization';
+	import { layoutStore } from '$lib/stores/layout';
+	import {
+		getAuditLog,
+		getAuditLogActions,
+		exportAuditLogCsv,
+		type AuditLogEntry,
+		type AuditCategory,
+	} from '$lib/api/audit-log';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle,
+	} from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow,
+	} from '$lib/components/ui/table';
+	import { Button } from '$lib/components/ui/button';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import type { OrganizationWithRole } from '@logtide/shared';
+	import { canManageMembers } from '@logtide/shared';
+	import ClipboardList from '@lucide/svelte/icons/clipboard-list';
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+	import Download from '@lucide/svelte/icons/download';
+
+	const CATEGORIES: { value: AuditCategory; label: string; color: string }[] = [
+		{
+			value: 'log_access',
+			label: 'Log Access',
+			color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+		},
+		{
+			value: 'config_change',
+			label: 'Config Change',
+			color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+		},
+		{
+			value: 'user_management',
+			label: 'User Management',
+			color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+		},
+		{
+			value: 'data_modification',
+			label: 'Data Modification',
+			color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+		},
+	];
+
+	let token: string | null = null;
+	let currentOrg = $state<OrganizationWithRole | null>(null);
+	let maxWidthClass = $state('max-w-7xl');
+	let containerPadding = $state('px-6 py-8');
+
+	let entries = $state<AuditLogEntry[]>([]);
+	let total = $state(0);
+	let loading = $state(true);
+	let error = $state('');
+	let availableActions = $state<string[]>([]);
+	let lastLoadedOrgId = $state<string | null>(null);
+	let expandedId = $state<string | null>(null);
+	let exporting = $state(false);
+
+	// Filters
+	let categoryFilter = $state<AuditCategory | ''>('');
+	let actionFilter = $state('');
+
+	// Pagination
+	let currentPage = $state(1);
+	const pageSize = 50;
+
+	$effect(() => {
+		const unsubscribe = layoutStore.maxWidthClass.subscribe((value) => {
+			maxWidthClass = value;
+		});
+		return unsubscribe;
+	});
+
+	$effect(() => {
+		const unsubscribe = layoutStore.containerPadding.subscribe((value) => {
+			containerPadding = value;
+		});
+		return unsubscribe;
+	});
+
+	authStore.subscribe((state) => {
+		token = state.token;
+	});
+
+	organizationStore.subscribe((state) => {
+		currentOrg = state.currentOrganization;
+	});
+
+	onMount(() => {
+		if (!token) {
+			goto('/login');
+			return;
+		}
+	});
+
+	let canManage = $derived(currentOrg ? canManageMembers(currentOrg.role) : false);
+
+	$effect(() => {
+		if (browser && currentOrg && currentOrg.id !== lastLoadedOrgId) {
+			lastLoadedOrgId = currentOrg.id;
+			currentPage = 1;
+			void loadEntries();
+			void loadActions();
+		}
+	});
+
+	async function loadEntries() {
+		if (!currentOrg) return;
+		loading = true;
+		error = '';
+		try {
+			const result = await getAuditLog({
+				organizationId: currentOrg.id,
+				category: categoryFilter || undefined,
+				action: actionFilter || undefined,
+				limit: pageSize,
+				offset: (currentPage - 1) * pageSize,
+			});
+			entries = result.entries;
+			total = result.total;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load audit log';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadActions() {
+		if (!currentOrg) return;
+		try {
+			availableActions = await getAuditLogActions(currentOrg.id);
+		} catch {
+			// Not critical
+		}
+	}
+
+	function applyFilters() {
+		currentPage = 1;
+		void loadEntries();
+	}
+
+	function clearFilters() {
+		categoryFilter = '';
+		actionFilter = '';
+		currentPage = 1;
+		void loadEntries();
+	}
+
+	async function handleExport() {
+		if (!currentOrg || exporting) return;
+		exporting = true;
+		try {
+			await exportAuditLogCsv({
+				organizationId: currentOrg.id,
+				category: categoryFilter || undefined,
+				action: actionFilter || undefined,
+			});
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to export';
+		} finally {
+			exporting = false;
+		}
+	}
+
+	function prevPage() {
+		if (currentPage > 1) {
+			currentPage -= 1;
+			void loadEntries();
+		}
+	}
+
+	function nextPage() {
+		if (currentPage < totalPages) {
+			currentPage += 1;
+			void loadEntries();
+		}
+	}
+
+	function toggleExpand(id: string) {
+		expandedId = expandedId === id ? null : id;
+	}
+
+	const totalPages = $derived(Math.max(1, Math.ceil(total / pageSize)));
+
+	function getCategoryInfo(cat: string) {
+		return (
+			CATEGORIES.find((c) => c.value === cat) ?? {
+				label: cat,
+				color: 'bg-gray-100 text-gray-800',
+			}
+		);
+	}
+
+	function formatDate(iso: string) {
+		return new Date(iso).toLocaleString();
+	}
+
+	function formatAction(action: string) {
+		return action.replace(/_/g, ' ');
+	}
+
+	function describeEntry(entry: AuditLogEntry): string {
+		const actor = entry.user_email ?? 'Unknown user';
+		const action = formatAction(entry.action);
+		const resource = entry.resource_type ?? '';
+		const meta = entry.metadata;
+
+		// Build a human-readable description from action + metadata
+		switch (entry.action) {
+			case 'create_organization':
+				return `${actor} created organization "${meta?.name ?? ''}"`;
+			case 'update_organization':
+				return `${actor} updated organization settings${meta?.name ? ` (name: "${meta.name}")` : ''}`;
+			case 'delete_organization':
+				return `${actor} deleted the organization`;
+			case 'leave_organization':
+				return `${actor} left the organization`;
+			case 'create_project':
+				return `${actor} created project "${meta?.name ?? ''}"`;
+			case 'update_project':
+				return `${actor} updated project${meta?.name ? ` "${meta.name}"` : ''}${meta?.description !== undefined ? ' description' : ''}`;
+			case 'delete_project':
+				return `${actor} deleted a project`;
+			case 'create_api_key':
+				return `${actor} created API key "${meta?.name ?? ''}" (${meta?.type ?? 'write'})`;
+			case 'revoke_api_key':
+				return `${actor} revoked an API key`;
+			case 'update_member_role':
+				return `${actor} changed a member's role to ${meta?.role ?? 'unknown'}`;
+			case 'remove_member':
+				return `${actor} removed a member from the organization`;
+			case 'register':
+				return `${actor} registered a new account`;
+			case 'login':
+				return `${actor} logged in`;
+			case 'logout':
+				return `${actor} logged out`;
+			case 'delete_account':
+				return `${actor} deleted their account`;
+			case 'disable_user':
+			case 'enable_user':
+				return `${actor} ${entry.action === 'disable_user' ? 'disabled' : 'enabled'} user ${meta?.targetEmail ?? ''}`;
+			case 'update_user_role':
+				return `${actor} ${meta?.is_admin ? 'promoted' : 'demoted'} user ${meta?.targetEmail ?? ''}`;
+			case 'reset_user_password':
+				return `${actor} reset password for ${meta?.targetEmail ?? ''}`;
+			default:
+				return `${actor} performed ${action}${resource ? ` on ${resource}` : ''}`;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Audit Log - LogTide</title>
+</svelte:head>
+
+<div class="container mx-auto space-y-6 {containerPadding} {maxWidthClass}">
+	<div>
+		<Button variant="ghost" size="sm" href="/dashboard/settings" class="mb-4 -ml-2 gap-2">
+			<ArrowLeft class="w-4 h-4" />
+			Back to Settings
+		</Button>
+		<div class="flex items-center justify-between">
+			<div>
+				<h1 class="text-3xl font-bold tracking-tight">Audit Log</h1>
+				<div class="flex items-center gap-2 mt-2">
+					<ClipboardList class="w-4 h-4 text-muted-foreground" />
+					<p class="text-muted-foreground">
+						Track all actions performed in {currentOrg?.name || 'your organization'}
+					</p>
+				</div>
+			</div>
+			<div class="flex gap-2">
+				<Button variant="outline" size="sm" onclick={handleExport} disabled={exporting || !canManage}>
+					<Download class="h-4 w-4 mr-1" />
+					{exporting ? 'Exporting...' : 'Export CSV'}
+				</Button>
+				<Button variant="outline" size="sm" onclick={() => loadEntries()}>
+					<RotateCcw class="h-4 w-4 mr-1" />
+					Refresh
+				</Button>
+			</div>
+		</div>
+	</div>
+
+	{#if !canManage}
+		<Card>
+			<CardContent class="py-12 text-center">
+				<ClipboardList class="mx-auto h-10 w-10 text-muted-foreground/40" />
+				<p class="mt-3 text-sm text-muted-foreground">
+					Only organization owners and admins can view the audit log.
+				</p>
+			</CardContent>
+		</Card>
+	{:else}
+		<!-- Filters -->
+		<Card>
+			<CardHeader class="pb-3">
+				<CardTitle class="text-base">Filters</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div class="flex flex-wrap items-end gap-3">
+					<div class="space-y-1">
+						<label for="category-filter" class="text-xs font-medium text-muted-foreground"
+							>Category</label
+						>
+						<select
+							id="category-filter"
+							bind:value={categoryFilter}
+							onchange={applyFilters}
+							class="flex h-9 w-44 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+						>
+							<option value="">All categories</option>
+							{#each CATEGORIES as cat}
+								<option value={cat.value}>{cat.label}</option>
+							{/each}
+						</select>
+					</div>
+
+					<div class="space-y-1">
+						<label for="action-filter" class="text-xs font-medium text-muted-foreground"
+							>Action</label
+						>
+						<select
+							id="action-filter"
+							bind:value={actionFilter}
+							onchange={applyFilters}
+							class="flex h-9 w-52 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+						>
+							<option value="">All actions</option>
+							{#each availableActions as action}
+								<option value={action}>{formatAction(action)}</option>
+							{/each}
+						</select>
+					</div>
+
+					{#if categoryFilter || actionFilter}
+						<Button variant="ghost" size="sm" onclick={clearFilters} class="h-9">
+							Clear
+						</Button>
+					{/if}
+				</div>
+			</CardContent>
+		</Card>
+
+		<!-- Events table -->
+		<Card>
+			<CardHeader class="pb-3">
+				<CardTitle class="text-base">
+					{total} event{total !== 1 ? 's' : ''}
+				</CardTitle>
+			</CardHeader>
+			<CardContent class="p-0">
+				{#if loading}
+					<div class="flex justify-center py-12">
+						<Spinner />
+					</div>
+				{:else if error}
+					<p class="py-8 text-center text-sm text-destructive">{error}</p>
+				{:else if entries.length === 0}
+					<div class="py-12 text-center">
+						<ClipboardList class="mx-auto h-10 w-10 text-muted-foreground/40" />
+						<p class="mt-3 text-sm text-muted-foreground">No audit events found.</p>
+					</div>
+				{:else}
+					<div class="overflow-x-auto">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead class="w-[30px]"></TableHead>
+									<TableHead class="w-[170px]">Time</TableHead>
+									<TableHead>User</TableHead>
+									<TableHead>Category</TableHead>
+									<TableHead>Action</TableHead>
+									<TableHead>Resource</TableHead>
+									<TableHead>IP Address</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{#each entries as entry (entry.id)}
+									{@const catInfo = getCategoryInfo(entry.category)}
+									{@const isExpanded = expandedId === entry.id}
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<TableRow
+										class="cursor-pointer hover:bg-muted/50"
+										onclick={() => toggleExpand(entry.id)}
+									>
+										<TableCell class="pr-0">
+											<ChevronDown
+												class="h-4 w-4 text-muted-foreground transition-transform {isExpanded ? '' : '-rotate-90'}"
+											/>
+										</TableCell>
+										<TableCell class="whitespace-nowrap text-xs text-muted-foreground">
+											{formatDate(entry.time)}
+										</TableCell>
+										<TableCell class="text-sm">
+											{entry.user_email ?? '\u2014'}
+										</TableCell>
+										<TableCell>
+											<span
+												class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {catInfo.color}"
+											>
+												{catInfo.label}
+											</span>
+										</TableCell>
+										<TableCell class="font-mono text-sm">
+											{formatAction(entry.action)}
+										</TableCell>
+										<TableCell class="text-sm">
+											{#if entry.resource_type}
+												<span class="text-muted-foreground">{entry.resource_type}</span>
+												{#if entry.resource_id}
+													<span class="ml-1 font-mono text-xs text-muted-foreground/70"
+														>{entry.resource_id.length > 12
+															? entry.resource_id.slice(0, 8) + '\u2026'
+															: entry.resource_id}</span
+													>
+												{/if}
+											{:else}
+												<span class="text-muted-foreground/50">\u2014</span>
+											{/if}
+										</TableCell>
+										<TableCell class="font-mono text-xs text-muted-foreground">
+											{entry.ip_address ?? '\u2014'}
+										</TableCell>
+									</TableRow>
+									{#if isExpanded}
+										<TableRow class="hover:bg-transparent">
+											<TableCell colspan={7} class="p-0">
+												<div class="bg-muted/30 mx-6 mb-4 mt-1 rounded-md px-5 py-4">
+													<p class="text-sm mb-3">{describeEntry(entry)}</p>
+													<div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+														<div>
+															<span class="text-xs font-medium text-muted-foreground">Time</span>
+															<p>{new Date(entry.time).toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'long' })}</p>
+														</div>
+														<div>
+															<span class="text-xs font-medium text-muted-foreground">User</span>
+															<p>{entry.user_email ?? '\u2014'}</p>
+															{#if entry.user_id}
+																<p class="font-mono text-xs text-muted-foreground">{entry.user_id}</p>
+															{/if}
+														</div>
+														{#if entry.resource_type}
+															<div>
+																<span class="text-xs font-medium text-muted-foreground">Resource Type</span>
+																<p>{entry.resource_type}</p>
+															</div>
+														{/if}
+														{#if entry.resource_id}
+															<div>
+																<span class="text-xs font-medium text-muted-foreground">Resource ID</span>
+																<p class="font-mono text-xs break-all">{entry.resource_id}</p>
+															</div>
+														{/if}
+														<div>
+															<span class="text-xs font-medium text-muted-foreground">IP Address</span>
+															<p class="font-mono">{entry.ip_address ?? '\u2014'}</p>
+														</div>
+														{#if entry.user_agent}
+															<div class="md:col-span-2">
+																<span class="text-xs font-medium text-muted-foreground">User Agent</span>
+																<p class="text-xs text-muted-foreground break-all">{entry.user_agent}</p>
+															</div>
+														{/if}
+														{#if entry.metadata && Object.keys(entry.metadata).length > 0}
+															<div class="md:col-span-2">
+																<span class="text-xs font-medium text-muted-foreground">Details</span>
+																<div class="mt-1 rounded-md bg-background border p-3">
+																	<dl class="space-y-1">
+																		{#each Object.entries(entry.metadata) as [key, value]}
+																			<div class="flex gap-2 text-sm">
+																				<dt class="font-mono text-xs text-muted-foreground shrink-0">{key}:</dt>
+																				<dd class="font-mono text-xs break-all">
+																					{typeof value === 'object' ? JSON.stringify(value) : String(value)}
+																				</dd>
+																			</div>
+																		{/each}
+																	</dl>
+																</div>
+															</div>
+														{/if}
+													</div>
+												</div>
+											</TableCell>
+										</TableRow>
+									{/if}
+								{/each}
+							</TableBody>
+						</Table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<!-- Pagination -->
+		{#if totalPages > 1}
+			<div class="flex items-center justify-between">
+				<p class="text-sm text-muted-foreground">
+					Page {currentPage} of {totalPages} ({total} total)
+				</p>
+				<div class="flex gap-2">
+					<Button variant="outline" size="sm" disabled={currentPage <= 1} onclick={prevPage}>
+						<ChevronLeft class="h-4 w-4" />
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={currentPage >= totalPages}
+						onclick={nextPage}
+					>
+						<ChevronRight class="h-4 w-4" />
+					</Button>
+				</div>
+			</div>
+		{/if}
+	{/if}
+</div>


### PR DESCRIPTION
This pull request introduces a comprehensive audit logging system to the backend, supporting compliance requirements (SOC 2, ISO 27001, HIPAA) by tracking all key user and admin actions across the platform. It includes a new database schema, backend service and API endpoints for querying and exporting audit logs, and integrates audit logging into sensitive admin and API key operations.

**Audit Log Infrastructure**

* Added a new `audit_log` table (TimescaleDB hypertable) with automatic compression and retention policies, tracking actions, categories, resources, user info, and metadata for compliance and security.
* Defined corresponding TypeScript types (`AuditLogTable`, `AuditCategory`) and added the table to the backend database interface for type-safe access. [[1]](diffhunk://#diff-2bc39c4ee0ed0e82dcc373fd226c8fb866661e554cebe45c515b50d94f722718R729-R757) [[2]](diffhunk://#diff-2bc39c4ee0ed0e82dcc373fd226c8fb866661e554cebe45c515b50d94f722718R813-R814)

**Backend API and Service**

* Implemented `auditLogService` and new REST API routes (`/api/v1/audit-log`) to:
  - Query audit logs with filtering (by category, action, user, resource, time range)
  - Fetch distinct actions for filtering UI
  - Export logs as CSV (with export actions themselves being audit-logged)
  - Enforce access control (only org owners/admins can access logs) [[1]](diffhunk://#diff-7ed284fafc1377b88cbd0dbfb891597b0580c78e508e16d4a4da4dc33904593eR1-R211) [[2]](diffhunk://#diff-4d4aa519e8f1f78c1ce845d24fcc47c521c84ed8785807b1a3e21fb28d8660fcR1-R3)

**Integration with Sensitive Operations**

* Integrated audit logging into admin and API key routes, so actions like user disable/enable, role changes, password resets, organization/project deletions, and API key creation/revocation are all logged with relevant metadata. [[1]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R247-R259) [[2]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R302-R314) [[3]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R349-R361) [[4]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R457-R469) [[5]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R561-R575) [[6]](diffhunk://#diff-4ffea6e0bfaefd2401c1b8b80e12b15f4ddcf21a9373a0aa470316366400f135R79-R91) [[7]](diffhunk://#diff-4ffea6e0bfaefd2401c1b8b80e12b15f4ddcf21a9373a0aa470316366400f135R131-R143) [[8]](diffhunk://#diff-4ffea6e0bfaefd2401c1b8b80e12b15f4ddcf21a9373a0aa470316366400f135R7) [[9]](diffhunk://#diff-fcec4d803ea81fec94912fa9e8c61172de2bee81e37ce5c583997c9722a3b222R5)

**Documentation**

* Updated `CHANGELOG.md` to document the new audit log feature and its capabilities.

ref: #94 