### PR TITLE
Apply metadata filters on ClickHouse and Mongo engines

### DIFF
--- a/packages/reservoir/src/engines/clickhouse/query-translator-metadata.test.ts
+++ b/packages/reservoir/src/engines/clickhouse/query-translator-metadata.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { ClickHouseQueryTranslator } from './query-translator.js';
+import type { MetadataFilter } from '../../core/types.js';
+
+const translator = new ClickHouseQueryTranslator('logs');
+
+const baseParams = {
+  projectId: '00000000-0000-0000-0000-000000000001',
+  from: new Date('2026-01-01T00:00:00Z'),
+  to: new Date('2026-01-02T00:00:00Z'),
+};
+
+/** Build a fully-typed MetadataFilter with include_missing defaulting to false */
+function mf(o: Omit<MetadataFilter, 'include_missing'> & { include_missing?: boolean }): MetadataFilter {
+  return { include_missing: false, ...o } as MetadataFilter;
+}
+
+function paramsOf(r: { parameters: unknown[] }): Record<string, unknown> {
+  return r.parameters[0] as Record<string, unknown>;
+}
+
+describe('ClickHouseQueryTranslator metadata filters', () => {
+  it('no filters adds nothing', () => {
+    const r = translator.translateQuery(baseParams);
+    expect(r.query).not.toContain('JSONExtractString(metadata,');
+  });
+
+  it('equals emits JSONExtractString = predicate', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'equals', value: 'prod' })],
+    });
+    expect(r.query).toContain('JSONExtractString(metadata,');
+    expect(Object.values(paramsOf(r))).toContain('env');
+    expect(Object.values(paramsOf(r))).toContain('prod');
+  });
+
+  it('not_equals with include_missing=true allows missing key', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_equals', value: 'dev', include_missing: true })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain(' = 0');
+    expect(r.query).toContain('!=');
+  });
+
+  it('not_equals with include_missing=false requires key present', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_equals', value: 'dev', include_missing: false })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain(' = 1');
+    expect(r.query).toContain('!=');
+  });
+
+  it('in emits IN array', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'in', values: ['prod', 'staging'] })],
+    });
+    expect(r.query).toContain('IN ({');
+    expect(Object.values(paramsOf(r))).toContainEqual(['prod', 'staging']);
+  });
+
+  it('not_in with include_missing=true allows missing key', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_in', values: ['dev'], include_missing: true })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain('NOT IN');
+  });
+
+  it('not_in with include_missing=false requires key present', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_in', values: ['dev'], include_missing: false })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain(' = 1');
+    expect(r.query).toContain('NOT IN');
+  });
+
+  it('exists emits JSONHas = 1', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'exists' })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain(' = 1');
+    expect(Object.values(paramsOf(r))).toContain('env');
+  });
+
+  it('not_exists emits JSONHas = 0', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_exists' })],
+    });
+    expect(r.query).toContain('JSONHas(metadata,');
+    expect(r.query).toContain(' = 0');
+    expect(Object.values(paramsOf(r))).toContain('env');
+  });
+
+  it('contains emits case-insensitive position match', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'msg', op: 'contains', value: 'foo' })],
+    });
+    expect(r.query).toContain('positionCaseInsensitive(JSONExtractString(metadata,');
+    expect(Object.values(paramsOf(r))).toContain('foo');
+  });
+
+  it('combines multiple filters with AND', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [
+        mf({ key: 'env', op: 'equals', value: 'prod' }),
+        mf({ key: 'region', op: 'in', values: ['us', 'eu'] }),
+      ],
+    });
+    const values = Object.values(paramsOf(r));
+    expect(values).toContain('env');
+    expect(values).toContain('prod');
+    expect(values).toContain('region');
+    expect(values).toContainEqual(['us', 'eu']);
+  });
+
+  it('applies metadata filters in translateCount as well', () => {
+    const r = translator.translateCount({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'equals', value: 'prod' })],
+    });
+    expect(r.query).toContain('JSONExtractString(metadata,');
+    expect(Object.values(paramsOf(r))).toContain('env');
+  });
+});

--- a/packages/reservoir/src/engines/clickhouse/query-translator.ts
+++ b/packages/reservoir/src/engines/clickhouse/query-translator.ts
@@ -5,6 +5,7 @@ import type {
   CountParams,
   DeleteByTimeRangeParams,
   DistinctParams,
+  MetadataFilter,
   QueryParams,
   TopValuesParams,
 } from '../../core/types.js';
@@ -93,6 +94,10 @@ export class ClickHouseQueryTranslator extends QueryTranslator {
         conditions.push(`hasToken(lower(message), {p_search:String})`);
         queryParams.p_search = params.search.toLowerCase();
       }
+    }
+
+    if (params.metadataFilters && params.metadataFilters.length > 0) {
+      this.pushMetadataFilters(conditions, queryParams, params.metadataFilters);
     }
 
     if (params.cursor) {
@@ -212,6 +217,10 @@ export class ClickHouseQueryTranslator extends QueryTranslator {
         conditions.push(`hasToken(lower(message), {p_search:String})`);
         queryParams.p_search = params.search.toLowerCase();
       }
+    }
+
+    if (params.metadataFilters && params.metadataFilters.length > 0) {
+      this.pushMetadataFilters(conditions, queryParams, params.metadataFilters);
     }
 
     const prewhereClause = prewhere.length > 0 ? ` PREWHERE ${prewhere.join(' AND ')}` : '';
@@ -374,6 +383,69 @@ export class ClickHouseQueryTranslator extends QueryTranslator {
     const where = ` WHERE ${conditions.join(' AND ')}`;
     const query = `ALTER TABLE ${this.tableName} DELETE${where}`;
     return { query, parameters: [queryParams] };
+  }
+
+  /**
+   * Translate metadata filters into ClickHouse predicates over the JSON `metadata` column.
+   * JSONExtractString returns '' for missing keys, so JSONHas is used to distinguish
+   * "key absent" from "key present but empty" when include_missing matters.
+   */
+  private pushMetadataFilters(
+    conditions: string[],
+    queryParams: Record<string, unknown>,
+    filters: MetadataFilter[],
+  ): void {
+    filters.forEach((f, i) => {
+      const keyParam = `p_mfk${i}`;
+      const valParam = `p_mfv${i}`;
+      queryParams[keyParam] = f.key;
+      const extract = `JSONExtractString(metadata, {${keyParam}:String})`;
+      const has = `JSONHas(metadata, {${keyParam}:String})`;
+
+      switch (f.op) {
+        case 'equals': {
+          conditions.push(`${extract} = {${valParam}:String}`);
+          queryParams[valParam] = f.value;
+          break;
+        }
+        case 'not_equals': {
+          queryParams[valParam] = f.value;
+          if (f.include_missing) {
+            conditions.push(`(${has} = 0 OR ${extract} != {${valParam}:String})`);
+          } else {
+            conditions.push(`(${has} = 1 AND ${extract} != {${valParam}:String})`);
+          }
+          break;
+        }
+        case 'in': {
+          conditions.push(`${extract} IN ({${valParam}:Array(String)})`);
+          queryParams[valParam] = f.values;
+          break;
+        }
+        case 'not_in': {
+          queryParams[valParam] = f.values;
+          if (f.include_missing) {
+            conditions.push(`(${has} = 0 OR ${extract} NOT IN ({${valParam}:Array(String)}))`);
+          } else {
+            conditions.push(`(${has} = 1 AND ${extract} NOT IN ({${valParam}:Array(String)}))`);
+          }
+          break;
+        }
+        case 'exists': {
+          conditions.push(`${has} = 1`);
+          break;
+        }
+        case 'not_exists': {
+          conditions.push(`${has} = 0`);
+          break;
+        }
+        case 'contains': {
+          conditions.push(`positionCaseInsensitive(${extract}, {${valParam}:String}) > 0`);
+          queryParams[valParam] = f.value ?? '';
+          break;
+        }
+      }
+    });
   }
 
   private pushClickHouseFilter(

--- a/packages/reservoir/src/engines/mongodb/query-translator-metadata.test.ts
+++ b/packages/reservoir/src/engines/mongodb/query-translator-metadata.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { MongoDBQueryTranslator } from './query-translator.js';
+import type { MetadataFilter } from '../../core/types.js';
+
+const translator = new MongoDBQueryTranslator();
+
+const baseParams = {
+  projectId: '00000000-0000-0000-0000-000000000001',
+  from: new Date('2026-01-01T00:00:00Z'),
+  to: new Date('2026-01-02T00:00:00Z'),
+};
+
+/** Build a fully-typed MetadataFilter with include_missing defaulting to false */
+function mf(o: Omit<MetadataFilter, 'include_missing'> & { include_missing?: boolean }): MetadataFilter {
+  return { include_missing: false, ...o } as MetadataFilter;
+}
+
+/** Collect the metadata.* clauses produced by the translator. */
+function metaClauses(r: { query: Record<string, unknown> }): Record<string, unknown>[] {
+  const and = (r.query.$and as Record<string, unknown>[] | undefined) ?? [];
+  return and.filter((c) => Object.keys(c).some((k) => k.startsWith('metadata.')));
+}
+
+describe('MongoDBQueryTranslator metadata filters', () => {
+  it('no filters adds no $and metadata clauses', () => {
+    const r = translator.translateQuery(baseParams);
+    expect(metaClauses(r as never)).toHaveLength(0);
+  });
+
+  it('equals emits exact match', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'equals', value: 'prod' })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': 'prod' });
+  });
+
+  it('not_equals with include_missing=true uses bare $ne (matches missing)', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_equals', value: 'dev', include_missing: true })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $ne: 'dev' } });
+  });
+
+  it('not_equals with include_missing=false requires key present', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_equals', value: 'dev', include_missing: false })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $exists: true, $ne: 'dev' } });
+  });
+
+  it('in emits $in', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'in', values: ['prod', 'staging'] })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $in: ['prod', 'staging'] } });
+  });
+
+  it('not_in with include_missing=true uses bare $nin (matches missing)', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_in', values: ['dev'], include_missing: true })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $nin: ['dev'] } });
+  });
+
+  it('not_in with include_missing=false requires key present', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_in', values: ['dev'], include_missing: false })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $exists: true, $nin: ['dev'] } });
+  });
+
+  it('exists emits $exists true', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'exists' })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $exists: true } });
+  });
+
+  it('not_exists emits $exists false', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'not_exists' })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': { $exists: false } });
+  });
+
+  it('contains emits case-insensitive $regex with escaped value', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'msg', op: 'contains', value: 'a.b' })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({
+      'metadata.msg': { $regex: 'a\\.b', $options: 'i' },
+    });
+  });
+
+  it('combines multiple filters as separate $and clauses', () => {
+    const r = translator.translateQuery({
+      ...baseParams,
+      metadataFilters: [
+        mf({ key: 'env', op: 'equals', value: 'prod' }),
+        mf({ key: 'region', op: 'in', values: ['us', 'eu'] }),
+      ],
+    });
+    const clauses = metaClauses(r as never);
+    expect(clauses).toContainEqual({ 'metadata.env': 'prod' });
+    expect(clauses).toContainEqual({ 'metadata.region': { $in: ['us', 'eu'] } });
+  });
+
+  it('applies metadata filters in translateCount as well', () => {
+    const r = translator.translateCount({
+      ...baseParams,
+      metadataFilters: [mf({ key: 'env', op: 'equals', value: 'prod' })],
+    });
+    expect(metaClauses(r as never)).toContainEqual({ 'metadata.env': 'prod' });
+  });
+});

--- a/packages/reservoir/src/engines/mongodb/query-translator.ts
+++ b/packages/reservoir/src/engines/mongodb/query-translator.ts
@@ -5,6 +5,7 @@ import type {
   CountParams,
   DeleteByTimeRangeParams,
   DistinctParams,
+  MetadataFilter,
   QueryParams,
   TopValuesParams,
 } from '../../core/types.js';
@@ -176,7 +177,44 @@ export class MongoDBQueryTranslator extends QueryTranslator {
       }
     }
 
+    if ('metadataFilters' in params && params.metadataFilters && params.metadataFilters.length > 0) {
+      const clauses = this.buildMetadataClauses(params.metadataFilters);
+      if (clauses.length > 0) {
+        // Use $and so multiple filters on the same metadata key don't overwrite each other.
+        filter.$and = clauses;
+      }
+    }
+
     return filter;
+  }
+
+  /**
+   * Translate metadata filters into MongoDB clauses over the `metadata` subdocument.
+   * Each filter becomes its own clause keyed on `metadata.<key>` so that repeated keys
+   * are AND'd rather than overwritten.
+   */
+  private buildMetadataClauses(filters: MetadataFilter[]): Record<string, unknown>[] {
+    return filters.map((f) => {
+      const field = `metadata.${f.key}`;
+      switch (f.op) {
+        case 'equals':
+          return { [field]: f.value };
+        case 'not_equals':
+          // Bare $ne already matches missing fields; require $exists when missing must be excluded.
+          return { [field]: f.include_missing ? { $ne: f.value } : { $exists: true, $ne: f.value } };
+        case 'in':
+          return { [field]: { $in: f.values } };
+        case 'not_in':
+          // Bare $nin already matches missing fields; require $exists when missing must be excluded.
+          return { [field]: f.include_missing ? { $nin: f.values } : { $exists: true, $nin: f.values } };
+        case 'exists':
+          return { [field]: { $exists: true } };
+        case 'not_exists':
+          return { [field]: { $exists: false } };
+        case 'contains':
+          return { [field]: { $regex: escapeRegex(f.value ?? ''), $options: 'i' } };
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
apply metadata filters on clickhouse and mongo engines were silently ignored on both, only timescale handled them (#224)