### PR TITLE
Enhance OIDC callback handling and update tests

### DIFF
--- a/packages/backend/src/modules/auth/authentication-service.ts
+++ b/packages/backend/src/modules/auth/authentication-service.ts
@@ -130,13 +130,14 @@ export class AuthenticationService {
    *
    * @param code - Authorization code
    * @param state - State parameter for CSRF validation
+   * @param callbackQuery - Full callback query parameters from provider redirect
    * @returns User profile and session
    */
   async handleOidcCallback(
     code: string,
-    state: string
+    state: string,
+    callbackQuery?: Record<string, string | string[] | undefined>
   ): Promise<AuthenticateResult> {
-    // Look up state from cache first, then database
     let stateData = await CacheManager.get<OidcStateData>(`oidc:state:${state}`);
 
     if (!stateData) {
@@ -186,12 +187,20 @@ export class AuthenticationService {
     }
 
     // Handle callback with provider (including PKCE data)
+    const fullCallbackQuery = {
+      ...callbackQuery,
+      // Ensure required parameters are always present for compatibility.
+      code,
+      state,
+    };
+
     const result = await provider.handleCallback(
       {
         code,
         state,
         codeVerifier: stateData.codeVerifier,
         redirectUri: stateData.redirectUri,
+        callbackQuery: fullCallbackQuery,
       },
       stateData.nonce
     );

--- a/packages/backend/src/modules/auth/external-routes.ts
+++ b/packages/backend/src/modules/auth/external-routes.ts
@@ -119,7 +119,13 @@ export async function publicAuthRoutes(fastify: FastifyInstance) {
   // OIDC: Handle callback
   fastify.get<{
     Params: { slug: string };
-    Querystring: { code?: string; state?: string; error?: string; error_description?: string };
+    Querystring: {
+      code?: string;
+      state?: string;
+      error?: string;
+      error_description?: string;
+      [key: string]: string | string[] | undefined;
+    };
   }>('/providers/:slug/callback', async (request, reply) => {
     // Frontend URL for redirects (defaults to localhost:3000 in development)
     const frontendUrl = config.FRONTEND_URL || (config.NODE_ENV === 'production' ? '' : 'http://localhost:3000');
@@ -138,7 +144,7 @@ export async function publicAuthRoutes(fastify: FastifyInstance) {
         return reply.redirect(`${frontendUrl}/login?error=Invalid%20callback%20parameters`);
       }
 
-      const result = await authenticationService.handleOidcCallback(code, state);
+      const result = await authenticationService.handleOidcCallback(code, state, request.query);
 
       auditLogService.log({
         organizationId: null,

--- a/packages/backend/src/modules/auth/providers/oidc-provider.ts
+++ b/packages/backend/src/modules/auth/providers/oidc-provider.ts
@@ -145,10 +145,24 @@ export class OidcProvider implements AuthProvider {
       const config = await this.discoverIssuer();
       const oidcConfig = this.getOidcConfig();
 
-      // Build the callback URL with the authorization code
+      // Build callback URL from the original redirect URI and provider response params.
       const callbackUrl = new URL(data.redirectUri);
-      callbackUrl.searchParams.set('code', data.code);
-      callbackUrl.searchParams.set('state', data.state);
+      const callbackQuery = data.callbackQuery ?? { code: data.code, state: data.state };
+
+      for (const [key, value] of Object.entries(callbackQuery)) {
+        if (value === undefined) {
+          continue;
+        }
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            callbackUrl.searchParams.append(key, String(item));
+          }
+          continue;
+        }
+
+        callbackUrl.searchParams.set(key, String(value));
+      }
 
       // Exchange code for tokens with PKCE code_verifier
       const tokens = await oidc.authorizationCodeGrant(config, callbackUrl, {

--- a/packages/backend/src/modules/auth/providers/types.ts
+++ b/packages/backend/src/modules/auth/providers/types.ts
@@ -112,6 +112,7 @@ export interface OidcCallbackData {
   state: string;
   codeVerifier: string; // PKCE code verifier from stored state
   redirectUri: string; // Original redirect URI for token exchange
+  callbackQuery?: Record<string, string | string[] | undefined>; // Full callback query params from provider
 }
 
 /**

--- a/packages/backend/src/tests/modules/auth/authentication-service.test.ts
+++ b/packages/backend/src/tests/modules/auth/authentication-service.test.ts
@@ -379,6 +379,74 @@ describe('AuthenticationService', () => {
 
             getProviderByIdSpy.mockRestore();
         });
+
+        it('should forward full callback query to provider callback handler', async () => {
+            const providerId = crypto.randomUUID();
+
+            await db.insertInto('auth_providers').values({
+                id: providerId,
+                type: 'oidc',
+                name: 'OIDC Query Provider',
+                slug: 'oidc-query-provider',
+                enabled: true,
+                config: {},
+            }).execute();
+
+            await db.insertInto('oidc_states').values({
+                state: 'query-state',
+                nonce: 'query-nonce',
+                provider_id: providerId,
+                redirect_uri: 'http://localhost/callback',
+                code_verifier: 'query-verifier',
+            }).execute();
+
+            const handleCallback = vi.fn().mockResolvedValue({
+                success: false,
+                error: 'Forced callback failure for forwarding test',
+            });
+
+            const mockProvider = {
+                config: {
+                    id: providerId,
+                    type: 'oidc',
+                    name: 'OIDC Query Provider',
+                    slug: 'oidc-query-provider',
+                    enabled: true,
+                    config: {},
+                },
+                handleCallback,
+            };
+
+            const getProviderByIdSpy = vi.spyOn(providerRegistryModule.providerRegistry, 'getProviderById')
+                .mockResolvedValue(mockProvider as any);
+
+            await expect(
+                authService.handleOidcCallback('code123', 'query-state', {
+                    code: 'code123',
+                    state: 'query-state',
+                    iss: 'https://auth.mdarhri.eu',
+                    scope: 'openid email profile',
+                })
+            ).rejects.toThrow('Forced callback failure for forwarding test');
+
+            expect(handleCallback).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    code: 'code123',
+                    state: 'query-state',
+                    codeVerifier: 'query-verifier',
+                    redirectUri: 'http://localhost/callback',
+                    callbackQuery: expect.objectContaining({
+                        code: 'code123',
+                        state: 'query-state',
+                        iss: 'https://auth.mdarhri.eu',
+                        scope: 'openid email profile',
+                    }),
+                }),
+                'query-nonce'
+            );
+
+            getProviderByIdSpy.mockRestore();
+        });
     });
 
     describe('getUserIdentities', () => {

--- a/packages/backend/src/tests/modules/auth/authentication-service.test.ts
+++ b/packages/backend/src/tests/modules/auth/authentication-service.test.ts
@@ -424,7 +424,7 @@ describe('AuthenticationService', () => {
                 authService.handleOidcCallback('code123', 'query-state', {
                     code: 'code123',
                     state: 'query-state',
-                    iss: 'https://auth.mdarhri.eu',
+                    iss: 'https://auth.example.eu',
                     scope: 'openid email profile',
                 })
             ).rejects.toThrow('Forced callback failure for forwarding test');
@@ -438,7 +438,7 @@ describe('AuthenticationService', () => {
                     callbackQuery: expect.objectContaining({
                         code: 'code123',
                         state: 'query-state',
-                        iss: 'https://auth.mdarhri.eu',
+                        iss: 'https://auth.example.eu',
                         scope: 'openid email profile',
                     }),
                 }),

--- a/packages/backend/src/tests/modules/auth/external-routes.test.ts
+++ b/packages/backend/src/tests/modules/auth/external-routes.test.ts
@@ -202,12 +202,22 @@ describe('External Auth Routes', () => {
 
                 const response = await app.inject({
                     method: 'GET',
-                    url: '/api/v1/auth/providers/google/callback?code=auth-code&state=state-123',
+                    url: '/api/v1/auth/providers/google/callback?code=auth-code&state=state-123&iss=https%3A%2F%2Fauth.example.com&scope=openid+email+profile',
                 });
 
                 expect(response.statusCode).toBe(302);
                 expect(response.headers.location).toContain('token=session-token-123');
                 expect(response.headers.location).toContain('new_user=false');
+                expect(handleCallbackSpy).toHaveBeenCalledWith(
+                    'auth-code',
+                    'state-123',
+                    expect.objectContaining({
+                        code: 'auth-code',
+                        state: 'state-123',
+                        iss: 'https://auth.example.com',
+                        scope: 'openid email profile',
+                    })
+                );
 
                 handleCallbackSpy.mockRestore();
             });

--- a/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
+++ b/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
@@ -240,7 +240,7 @@ describe('OidcProvider', () => {
                     callbackQuery: {
                         code: 'auth-code',
                         state: 'test-state',
-                        iss: 'https://auth.mdarhri.eu',
+                        iss: 'https://auth.example.eu',
                         scope: 'openid email profile',
                     },
                 },
@@ -252,7 +252,7 @@ describe('OidcProvider', () => {
 
             expect(callbackUrl.searchParams.get('code')).toBe('auth-code');
             expect(callbackUrl.searchParams.get('state')).toBe('test-state');
-            expect(callbackUrl.searchParams.get('iss')).toBe('https://auth.mdarhri.eu');
+            expect(callbackUrl.searchParams.get('iss')).toBe('https://auth.example.eu');
             expect(callbackUrl.searchParams.get('scope')).toBe('openid email profile');
         });
 

--- a/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
+++ b/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
@@ -230,6 +230,32 @@ describe('OidcProvider', () => {
             expect(result.name).toBe('Test User');
         });
 
+        it('should preserve full callback query params for authorizationCodeGrant', async () => {
+            await oidcProvider.handleCallback(
+                {
+                    code: 'auth-code',
+                    state: 'test-state',
+                    redirectUri: 'http://localhost/callback',
+                    codeVerifier: 'test-code-verifier',
+                    callbackQuery: {
+                        code: 'auth-code',
+                        state: 'test-state',
+                        iss: 'https://auth.mdarhri.eu',
+                        scope: 'openid email profile',
+                    },
+                },
+                'expected-nonce'
+            );
+
+            expect(mocks.mockAuthorizationCodeGrant).toHaveBeenCalledTimes(1);
+            const callbackUrl = mocks.mockAuthorizationCodeGrant.mock.calls[0][1] as URL;
+
+            expect(callbackUrl.searchParams.get('code')).toBe('auth-code');
+            expect(callbackUrl.searchParams.get('state')).toBe('test-state');
+            expect(callbackUrl.searchParams.get('iss')).toBe('https://auth.mdarhri.eu');
+            expect(callbackUrl.searchParams.get('scope')).toBe('openid email profile');
+        });
+
         it('should return error when claims are not available', async () => {
             mocks.mockAuthorizationCodeGrant.mockResolvedValueOnce({
                 claims: vi.fn().mockReturnValue(null),


### PR DESCRIPTION

PR to resolve  #232


OIDC login with Authelia fails during the callback step.

The callback request received by LogTide contains the iss parameter, but LogTide still fails with:

response parameter "iss" (issuer) missing

From the logs, Authelia redirects back correctly with:

iss=https%3A%2F%2Fauth.example.eu

However, LogTide appears to drop this parameter internally before passing the callback URL to openid-client / authorizationCodeGrant().

