### PR TITLE
harden oidc callback param handling

### DIFF
--- a/packages/backend/src/modules/auth/providers/oidc-provider.ts
+++ b/packages/backend/src/modules/auth/providers/oidc-provider.ts
@@ -146,22 +146,20 @@ export class OidcProvider implements AuthProvider {
       const oidcConfig = this.getOidcConfig();
 
       // Build callback URL from the original redirect URI and provider response params.
+      // OIDC authorization response params are single-valued (RFC 6749 / RFC 9207),
+      // so collapse any duplicated query params to a single value instead of appending
+      // duplicates onto the URL handed to the token exchange.
       const callbackUrl = new URL(data.redirectUri);
       const callbackQuery = data.callbackQuery ?? { code: data.code, state: data.state };
 
       for (const [key, value] of Object.entries(callbackQuery)) {
-        if (value === undefined) {
+        const single = Array.isArray(value) ? value[0] : value;
+
+        if (single === undefined) {
           continue;
         }
 
-        if (Array.isArray(value)) {
-          for (const item of value) {
-            callbackUrl.searchParams.append(key, String(item));
-          }
-          continue;
-        }
-
-        callbackUrl.searchParams.set(key, String(value));
+        callbackUrl.searchParams.set(key, String(single));
       }
 
       // Exchange code for tokens with PKCE code_verifier

--- a/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
+++ b/packages/backend/src/tests/modules/auth/oidc-provider.test.ts
@@ -256,6 +256,31 @@ describe('OidcProvider', () => {
             expect(callbackUrl.searchParams.get('scope')).toBe('openid email profile');
         });
 
+        it('should collapse duplicated callback query params to a single value', async () => {
+            await oidcProvider.handleCallback(
+                {
+                    code: 'auth-code',
+                    state: 'test-state',
+                    redirectUri: 'http://localhost/callback',
+                    codeVerifier: 'test-code-verifier',
+                    callbackQuery: {
+                        code: 'auth-code',
+                        state: 'test-state',
+                        iss: ['https://auth.example.eu', 'https://evil.example.com'],
+                        error: undefined,
+                    },
+                },
+                'expected-nonce'
+            );
+
+            const callbackUrl = mocks.mockAuthorizationCodeGrant.mock.calls[0][1] as URL;
+
+            // Only the first value is kept, no duplicate iss reaches the token exchange.
+            expect(callbackUrl.searchParams.getAll('iss')).toEqual(['https://auth.example.eu']);
+            // Undefined params are skipped entirely.
+            expect(callbackUrl.searchParams.has('error')).toBe(false);
+        });
+
         it('should return error when claims are not available', async () => {
             mocks.mockAuthorizationCodeGrant.mockResolvedValueOnce({
                 claims: vi.fn().mockReturnValue(null),


### PR DESCRIPTION
Follow-up cleanup after #233.

### What
- Collapse duplicated/array-valued callback query params to a single value using `.set()` instead of `.append()`. OIDC authorization response params are single-valued (RFC 6749 / RFC 9207), so this avoids forwarding duplicate `iss`/params onto the URL passed to the token exchange.
- Add a test covering the array branch and the undefined-param branch, which closes the patch-coverage gap that failed codecov on #233.

### Verification
- oidc-provider: 26/26 pass
- authentication-service + external-routes: 65/65 pass
- `tsc --noEmit`: clean