### PR TITLE
resource usage metering (#212)

### DIFF
--- a/packages/backend/migrations/045_metering_events.sql
+++ b/packages/backend/migrations/045_metering_events.sql
@@ -1,0 +1,21 @@
+-- Resource usage metering events (#212)
+-- Control-plane hypertable. One row per recorder flush entry (per ingestion batch, etc.).
+-- Low volume relative to logs: aggregation is done at query time (no continuous aggregates).
+
+CREATE TABLE IF NOT EXISTS metering_events (
+  time            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  organization_id UUID NOT NULL,
+  project_id      UUID,
+  type            TEXT NOT NULL,
+  quantity        DOUBLE PRECISION NOT NULL,
+  metadata        JSONB
+);
+
+-- TimescaleDB hypertable on time (create_hypertable is transaction-safe, unlike continuous aggregates).
+SELECT create_hypertable('metering_events', 'time', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_metering_org_type_time
+  ON metering_events (organization_id, type, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_metering_org_project_time
+  ON metering_events (organization_id, project_id, time DESC);

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -61,6 +61,11 @@ const configSchema = z.object({
   CACHE_ENABLED: z.string().default('true').transform((val) => val === 'true'),
   CACHE_TTL: z.string().default('60').transform(Number), // Default TTL in seconds
 
+  // Metering / resource usage tracking (#212)
+  METERING_ENABLED: z.string().default('true').transform((val) => val === 'true'),
+  METERING_FLUSH_INTERVAL_MS: z.string().default('5000').transform(Number),
+  METERING_FLUSH_MAX_BUFFER: z.string().default('500').transform(Number),
+
   // Outbound SSRF guard. By default, HTTP/TCP monitors and webhook delivery
   // reject loopback/private/link-local/reserved targets. Self-hosted
   // deployments that legitimately monitor internal services can opt in.

--- a/packages/backend/src/database/types.ts
+++ b/packages/backend/src/database/types.ts
@@ -64,6 +64,19 @@ export interface LogsTable {
   created_at: Generated<Timestamp>;
 }
 
+export interface MeteringEventsTable {
+  time: Generated<Timestamp>;
+  organization_id: string;
+  project_id: string | null;
+  type: string;
+  quantity: number;
+  metadata: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null,
+    Record<string, unknown> | null
+  >;
+}
+
 export interface UsersTable {
   id: Generated<string>;
   email: string;
@@ -1129,4 +1142,6 @@ export interface Database {
   // Digest email reports
   digest_configs: DigestConfigsTable;
   digest_recipients: DigestRecipientsTable;
+  // Resource usage metering (#212)
+  metering_events: MeteringEventsTable;
 }

--- a/packages/backend/src/modules/ingestion/service.ts
+++ b/packages/backend/src/modules/ingestion/service.ts
@@ -10,6 +10,7 @@ import { correlationService, type IdentifierMatch } from '../correlation/service
 import { piiMaskingService } from '../pii-masking/service.js';
 import { projectsService } from '../projects/service.js';
 import { extractHostname } from './routes.js';
+import { recordLogIngestion } from '../metering/index.js';
 
 /**
  * Remove null characters (\u0000) that PostgreSQL doesn't support in text fields.
@@ -156,6 +157,16 @@ export class IngestionService {
     notificationPublisher.publishLogIngestion(projectId, logIds).catch((err) => {
       console.error('[Ingestion] Failed to publish notification:', err);
     });
+
+    // Record resource usage (#212). Fire-and-forget, never blocks ingestion.
+    if (organizationId) {
+      recordLogIngestion({
+        logs,
+        eventCount: insertedLogs.length,
+        organizationId,
+        projectId,
+      });
+    }
 
     return insertedLogs.length;
   }

--- a/packages/backend/src/modules/metering/breakdown.ts
+++ b/packages/backend/src/modules/metering/breakdown.ts
@@ -1,0 +1,129 @@
+import { sql } from 'kysely';
+import { db } from '../../database/index.js';
+import { reservoir } from '../../database/reservoir.js';
+
+export interface ProjectUsage {
+  projectId: string;
+  projectName: string;
+  events: number;
+  bytes: number;
+}
+
+export interface ValueCount {
+  value: string;
+  count: number;
+}
+
+export interface TypeUsage {
+  type: string;
+  quantity: number;
+}
+
+export interface UsageBreakdown {
+  /** Volume per metering signal type (logs.ingested.events/bytes, and later spans/metrics). */
+  byType: TypeUsage[];
+  /** Per-project consumption (from metering), with the project name resolved. */
+  byProject: ProjectUsage[];
+  /** Which services produced the ingested logs (from the reservoir, engine-agnostic). */
+  byService: ValueCount[];
+  /** Level distribution of the ingested logs. */
+  byLevel: ValueCount[];
+}
+
+export interface UsageBreakdownParams {
+  organizationId: string;
+  from: Date;
+  to: Date;
+  /** Cap on the number of services returned (levels are always returned in full). */
+  limit?: number;
+}
+
+/**
+ * Org-scoped "what is being ingested" breakdown for the Usage view.
+ * - byProject: events/bytes per project from metering_events, joined to project names.
+ * - byService / byLevel: composition of the ingested logs, aggregated across the org's
+ *   projects via the reservoir abstraction (so it works on any storage engine).
+ */
+export async function getUsageBreakdown(params: UsageBreakdownParams): Promise<UsageBreakdown> {
+  const { organizationId, from, to } = params;
+  const limit = params.limit ?? 20;
+
+  const projects = await db
+    .selectFrom('projects')
+    .select(['id', 'name'])
+    .where('organization_id', '=', organizationId)
+    .execute();
+  const nameById = new Map(projects.map((p) => [p.id, p.name]));
+
+  // Per-project events/bytes from metering_events.
+  const meter = await sql<{ project_id: string | null; type: string; quantity: number | string }>`
+    SELECT project_id, type, SUM(quantity)::float8 AS quantity
+    FROM metering_events
+    WHERE organization_id = ${organizationId}
+      AND time >= ${from} AND time < ${to}
+      AND type IN ('logs.ingested.events', 'logs.ingested.bytes')
+    GROUP BY project_id, type`.execute(db);
+
+  const perProject = new Map<string, { events: number; bytes: number }>();
+  for (const r of meter.rows) {
+    if (!r.project_id) continue;
+    const q = typeof r.quantity === 'number' ? r.quantity : parseFloat(r.quantity);
+    const acc = perProject.get(r.project_id) ?? { events: 0, bytes: 0 };
+    if (r.type === 'logs.ingested.events') acc.events += q;
+    else acc.bytes += q;
+    perProject.set(r.project_id, acc);
+  }
+
+  const byProject: ProjectUsage[] = Array.from(perProject.entries())
+    .map(([projectId, v]) => ({
+      projectId,
+      projectName: nameById.get(projectId) ?? 'unknown',
+      events: v.events,
+      bytes: v.bytes,
+    }))
+    .sort((a, b) => b.events - a.events);
+
+  // Volume per metering signal type (all types, so future spans/metrics surface too).
+  const typeRows = await sql<{ type: string; quantity: number | string }>`
+    SELECT type, SUM(quantity)::float8 AS quantity
+    FROM metering_events
+    WHERE organization_id = ${organizationId}
+      AND time >= ${from} AND time < ${to}
+    GROUP BY type
+    ORDER BY type`.execute(db);
+  const byType: TypeUsage[] = typeRows.rows.map((r) => ({
+    type: r.type,
+    quantity: typeof r.quantity === 'number' ? r.quantity : parseFloat(r.quantity),
+  }));
+
+  // Service + level composition from the ingested logs, merged across the org's projects.
+  const serviceCounts = new Map<string, number>();
+  const levelCounts = new Map<string, number>();
+  for (const p of projects) {
+    const [svc, lvl] = await Promise.all([
+      reservoir.topValues({ field: 'service', projectId: p.id, from, to, limit: 50 }),
+      reservoir.topValues({ field: 'level', projectId: p.id, from, to, limit: 20 }),
+    ]);
+    for (const v of svc.values) {
+      const key = String(v.value);
+      serviceCounts.set(key, (serviceCounts.get(key) ?? 0) + v.count);
+    }
+    for (const v of lvl.values) {
+      const key = String(v.value);
+      levelCounts.set(key, (levelCounts.get(key) ?? 0) + v.count);
+    }
+  }
+
+  const toSorted = (m: Map<string, number>, lim: number): ValueCount[] =>
+    Array.from(m.entries())
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, lim);
+
+  return {
+    byType,
+    byProject,
+    byService: toSorted(serviceCounts, limit),
+    byLevel: toSorted(levelCounts, 20),
+  };
+}

--- a/packages/backend/src/modules/metering/index.ts
+++ b/packages/backend/src/modules/metering/index.ts
@@ -40,3 +40,4 @@ export { MeteringRecorder } from './recorder.js';
 export { meteringService, MeteringService } from './service.js';
 export type { MeteringEvent, MeteringEventType } from './types.js';
 export type { UsageAggregateParams, UsageGroupBy, UsageRow } from './service.js';
+export { usageRoutes } from './routes.js';

--- a/packages/backend/src/modules/metering/index.ts
+++ b/packages/backend/src/modules/metering/index.ts
@@ -38,6 +38,8 @@ export function recordLogIngestion(params: {
 
 export { MeteringRecorder } from './recorder.js';
 export { meteringService, MeteringService } from './service.js';
+export { getUsageBreakdown } from './breakdown.js';
+export type { UsageBreakdown, UsageBreakdownParams, ProjectUsage, TypeUsage, ValueCount } from './breakdown.js';
 export type { MeteringEvent, MeteringEventType } from './types.js';
 export type { UsageAggregateParams, UsageGroupBy, UsageRow } from './service.js';
 export { usageRoutes } from './routes.js';

--- a/packages/backend/src/modules/metering/index.ts
+++ b/packages/backend/src/modules/metering/index.ts
@@ -1,0 +1,42 @@
+import { MeteringRecorder } from './recorder.js';
+import type { MeteringEvent } from './types.js';
+
+/** Process-wide singleton recorder. Started in server.ts, stopped on shutdown. */
+export const meteringRecorder = new MeteringRecorder();
+
+/** Thin facade so callsites depend on `metering.record(...)`, not the recorder class. */
+export const metering = {
+  record(event: MeteringEvent): void {
+    meteringRecorder.record(event);
+  },
+};
+
+/**
+ * Recording site helper for log ingestion. Fire-and-forget.
+ * `logs` is the raw input batch; bytes are measured from its JSON serialization.
+ */
+export function recordLogIngestion(params: {
+  logs: unknown[];
+  eventCount: number;
+  organizationId: string;
+  projectId: string;
+}): void {
+  const bytes = Buffer.byteLength(JSON.stringify(params.logs));
+  metering.record({
+    type: 'logs.ingested.bytes',
+    quantity: bytes,
+    organizationId: params.organizationId,
+    projectId: params.projectId,
+  });
+  metering.record({
+    type: 'logs.ingested.events',
+    quantity: params.eventCount,
+    organizationId: params.organizationId,
+    projectId: params.projectId,
+  });
+}
+
+export { MeteringRecorder } from './recorder.js';
+export { meteringService, MeteringService } from './service.js';
+export type { MeteringEvent, MeteringEventType } from './types.js';
+export type { UsageAggregateParams, UsageGroupBy, UsageRow } from './service.js';

--- a/packages/backend/src/modules/metering/recorder.ts
+++ b/packages/backend/src/modules/metering/recorder.ts
@@ -1,0 +1,91 @@
+import { db } from '../../database/index.js';
+import { config } from '../../config/index.js';
+import type { MeteringEvent } from './types.js';
+
+export interface MeteringRecorderOptions {
+  maxBuffer?: number;
+  flushIntervalMs?: number;
+  /** Hard ceiling above which new events are dropped (back-pressure safety). Defaults to maxBuffer * 10. */
+  hardCap?: number;
+}
+
+/**
+ * Non-blocking, loss-tolerant recorder. `record()` never awaits the DB.
+ * Buffered events are batch-inserted on size threshold, on an interval, and on shutdown.
+ * Metering is not audit: on flush failure or buffer overflow we drop and count.
+ */
+export class MeteringRecorder {
+  private buffer: MeteringEvent[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private dropped = 0;
+  private readonly maxBuffer: number;
+  private readonly flushIntervalMs: number;
+  private readonly hardCap: number;
+
+  constructor(opts: MeteringRecorderOptions = {}) {
+    this.maxBuffer = opts.maxBuffer ?? config.METERING_FLUSH_MAX_BUFFER;
+    this.flushIntervalMs = opts.flushIntervalMs ?? config.METERING_FLUSH_INTERVAL_MS;
+    this.hardCap = opts.hardCap ?? this.maxBuffer * 10;
+  }
+
+  record(event: MeteringEvent): void {
+    if (!config.METERING_ENABLED) return;
+    if (this.buffer.length >= this.hardCap) {
+      this.dropped++;
+      return;
+    }
+    this.buffer.push(event);
+    if (this.buffer.length >= this.maxBuffer) {
+      void this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer;
+    this.buffer = [];
+    try {
+      await db
+        .insertInto('metering_events')
+        .values(
+          batch.map((e) => ({
+            time: e.time ?? new Date(),
+            organization_id: e.organizationId,
+            project_id: e.projectId ?? null,
+            type: e.type,
+            quantity: e.quantity,
+            metadata: e.metadata ?? null,
+          }))
+        )
+        .execute();
+    } catch (err) {
+      this.dropped += batch.length;
+      console.error(`[Metering] Flush failed, dropped ${batch.length} event(s):`, err);
+    }
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+    // Don't keep the event loop alive just for metering flushes.
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  get droppedCount(): number {
+    return this.dropped;
+  }
+
+  get bufferSize(): number {
+    return this.buffer.length;
+  }
+}

--- a/packages/backend/src/modules/metering/routes.ts
+++ b/packages/backend/src/modules/metering/routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authenticate } from '../auth/middleware.js';
 import { OrganizationsService } from '../organizations/service.js';
 import { meteringService } from './service.js';
+import { getUsageBreakdown } from './breakdown.js';
 import type { MeteringEventType } from './types.js';
 
 const organizationsService = new OrganizationsService();
@@ -13,6 +14,12 @@ const usageQuerySchema = z.object({
   to: z.string().datetime(),
   groupBy: z.enum(['type', 'project', 'day']).default('type'),
   type: z.string().optional(),
+});
+
+const breakdownQuerySchema = z.object({
+  organizationId: z.string().uuid(),
+  from: z.string().datetime(),
+  to: z.string().datetime(),
 });
 
 async function checkMembership(userId: string, orgId: string): Promise<boolean> {
@@ -39,6 +46,30 @@ export async function usageRoutes(fastify: FastifyInstance) {
       });
 
       return reply.send({ usage });
+    } catch (e) {
+      if (e instanceof z.ZodError) {
+        return reply.status(400).send({ error: 'Validation error', details: e.errors });
+      }
+      throw e;
+    }
+  });
+
+  // "What is being ingested" breakdown: by metering type, by project (with name),
+  // by service and by level (logs composition).
+  fastify.get('/breakdown', async (request: any, reply) => {
+    try {
+      const q = breakdownQuerySchema.parse(request.query);
+      if (!(await checkMembership(request.user.id, q.organizationId))) {
+        return reply.status(403).send({ error: 'Forbidden' });
+      }
+
+      const breakdown = await getUsageBreakdown({
+        organizationId: q.organizationId,
+        from: new Date(q.from),
+        to: new Date(q.to),
+      });
+
+      return reply.send({ breakdown });
     } catch (e) {
       if (e instanceof z.ZodError) {
         return reply.status(400).send({ error: 'Validation error', details: e.errors });

--- a/packages/backend/src/modules/metering/routes.ts
+++ b/packages/backend/src/modules/metering/routes.ts
@@ -1,0 +1,49 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { authenticate } from '../auth/middleware.js';
+import { OrganizationsService } from '../organizations/service.js';
+import { meteringService } from './service.js';
+import type { MeteringEventType } from './types.js';
+
+const organizationsService = new OrganizationsService();
+
+const usageQuerySchema = z.object({
+  organizationId: z.string().uuid(),
+  from: z.string().datetime(),
+  to: z.string().datetime(),
+  groupBy: z.enum(['type', 'project', 'day']).default('type'),
+  type: z.string().optional(),
+});
+
+async function checkMembership(userId: string, orgId: string): Promise<boolean> {
+  const orgs = await organizationsService.getUserOrganizations(userId);
+  return orgs.some((o) => o.id === orgId);
+}
+
+export async function usageRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', authenticate);
+
+  fastify.get('/', async (request: any, reply) => {
+    try {
+      const q = usageQuerySchema.parse(request.query);
+      if (!(await checkMembership(request.user.id, q.organizationId))) {
+        return reply.status(403).send({ error: 'Forbidden' });
+      }
+
+      const usage = await meteringService.aggregate({
+        organizationId: q.organizationId,
+        from: new Date(q.from),
+        to: new Date(q.to),
+        groupBy: q.groupBy,
+        type: q.type as MeteringEventType | undefined,
+      });
+
+      return reply.send({ usage });
+    } catch (e) {
+      if (e instanceof z.ZodError) {
+        return reply.status(400).send({ error: 'Validation error', details: e.errors });
+      }
+      throw e;
+    }
+  });
+}

--- a/packages/backend/src/modules/metering/service.ts
+++ b/packages/backend/src/modules/metering/service.ts
@@ -1,0 +1,78 @@
+import { sql } from 'kysely';
+import { db } from '../../database/index.js';
+import type { MeteringEventType } from './types.js';
+
+export type UsageGroupBy = 'type' | 'project' | 'day';
+
+export interface UsageAggregateParams {
+  organizationId: string;
+  from: Date;
+  to: Date;
+  groupBy: UsageGroupBy;
+  type?: MeteringEventType;
+}
+
+export interface UsageRow {
+  type: string;
+  project_id?: string | null;
+  bucket?: string;
+  quantity: number;
+}
+
+interface RawRow {
+  type: string;
+  project_id?: string | null;
+  bucket?: Date | string;
+  quantity: number | string;
+}
+
+export class MeteringService {
+  /**
+   * Aggregate usage for a single organization over [from, to).
+   * Query-time grouping (no continuous aggregates). Always org-scoped.
+   */
+  async aggregate(params: UsageAggregateParams): Promise<UsageRow[]> {
+    const { organizationId, from, to, groupBy, type } = params;
+    const typeFilter = type ? sql`AND type = ${type}` : sql``;
+
+    let query;
+    if (groupBy === 'project') {
+      query = sql<RawRow>`
+        SELECT project_id, type, SUM(quantity)::float8 AS quantity
+        FROM metering_events
+        WHERE organization_id = ${organizationId}
+          AND time >= ${from} AND time < ${to} ${typeFilter}
+        GROUP BY project_id, type
+        ORDER BY project_id, type`;
+    } else if (groupBy === 'day') {
+      // UTC calendar-day buckets, independent of the DB session timezone.
+      // `time AT TIME ZONE 'UTC'` yields the UTC wall-clock; to_char gives a stable string.
+      query = sql<RawRow>`
+        SELECT to_char(date_trunc('day', time AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS bucket,
+               type, SUM(quantity)::float8 AS quantity
+        FROM metering_events
+        WHERE organization_id = ${organizationId}
+          AND time >= ${from} AND time < ${to} ${typeFilter}
+        GROUP BY bucket, type
+        ORDER BY bucket, type`;
+    } else {
+      query = sql<RawRow>`
+        SELECT type, SUM(quantity)::float8 AS quantity
+        FROM metering_events
+        WHERE organization_id = ${organizationId}
+          AND time >= ${from} AND time < ${to} ${typeFilter}
+        GROUP BY type
+        ORDER BY type`;
+    }
+
+    const result = await query.execute(db);
+    return result.rows.map((r) => ({
+      type: r.type,
+      project_id: r.project_id ?? null,
+      bucket: r.bucket instanceof Date ? r.bucket.toISOString() : (r.bucket as string | undefined),
+      quantity: typeof r.quantity === 'number' ? r.quantity : parseFloat(r.quantity),
+    }));
+  }
+}
+
+export const meteringService = new MeteringService();

--- a/packages/backend/src/modules/metering/types.ts
+++ b/packages/backend/src/modules/metering/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Resource usage metering event types (#212).
+ * The full set is declared up front so deferred recording sites
+ * (spans, metric cardinality, storage snapshots) need no type change.
+ * Only `logs.ingested.*` are wired in this plan.
+ */
+export type MeteringEventType =
+  | 'logs.ingested.bytes'
+  | 'logs.ingested.events'
+  | 'spans.ingested'
+  | 'metrics.cardinality'
+  | 'storage.snapshot';
+
+export interface MeteringEvent {
+  type: MeteringEventType;
+  quantity: number;
+  organizationId: string;
+  projectId?: string;
+  metadata?: Record<string, unknown>;
+  /** Defaults to now() at flush time if omitted. */
+  time?: Date;
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -34,6 +34,7 @@ import { correlationRoutes, patternRoutes } from './modules/correlation/index.js
 import { piiMaskingRoutes } from './modules/pii-masking/index.js';
 import { pipelineRoutes } from './modules/log-pipeline/index.js';
 import { customDashboardsRoutes } from './modules/custom-dashboards/index.js';
+import { usageRoutes, meteringRecorder } from './modules/metering/index.js';
 import { monitoringRoutes, heartbeatRoutes, publicStatusRoutes } from './modules/monitoring/index.js';
 import { statusIncidentRoutes } from './modules/status-incidents/routes.js';
 import { maintenanceRoutes } from './modules/maintenances/routes.js';
@@ -191,6 +192,7 @@ export async function build(opts = {}) {
   await fastify.register(piiMaskingRoutes, { prefix: '/api' });
   await fastify.register(pipelineRoutes, { prefix: '/api/v1/log-pipelines' });
   await fastify.register(customDashboardsRoutes, { prefix: '/api/v1/custom-dashboards' });
+  await fastify.register(usageRoutes, { prefix: '/api/v1/usage' });
   await fastify.register(otlpRoutes);
   await fastify.register(otlpTraceRoutes);
   await fastify.register(otlpMetricRoutes);
@@ -217,6 +219,7 @@ async function start() {
   auditLogService.start();
   await enrichmentService.initialize();
   await notificationManager.initialize(config.DATABASE_URL);
+  meteringRecorder.start();
 
   const authMode = await settingsService.getAuthMode();
   if (authMode === 'none') {
@@ -228,6 +231,7 @@ async function start() {
 
   const shutdown = async () => {
     console.log('[Server] Shutting down gracefully...');
+    await meteringRecorder.stop();
     await auditLogService.shutdown();
     await notificationManager.shutdown();
     await shutdownInternalLogging();

--- a/packages/backend/src/tests/helpers/db.ts
+++ b/packages/backend/src/tests/helpers/db.ts
@@ -6,6 +6,7 @@ import { db } from '../../database/index.js';
  */
 export async function truncateAllTables() {
     const tables = [
+        'metering_events',
         'logs',
         'alert_history',
         'sigma_rules',

--- a/packages/backend/src/tests/modules/metering/breakdown.test.ts
+++ b/packages/backend/src/tests/modules/metering/breakdown.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { db } from '../../../database/index.js';
+import { reservoirReady } from '../../../database/reservoir.js';
+import { getUsageBreakdown } from '../../../modules/metering/breakdown.js';
+import { createTestContext, createTestProject } from '../../helpers/factories.js';
+
+describe('getUsageBreakdown', () => {
+  let orgId: string;
+  let proj1: { id: string; name: string };
+  let proj2: { id: string; name: string };
+
+  beforeAll(async () => {
+    await reservoirReady;
+  });
+
+  beforeEach(async () => {
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    proj1 = { id: ctx.project.id, name: ctx.project.name };
+    const p2 = await createTestProject({ organizationId: orgId });
+    proj2 = { id: p2.id, name: p2.name };
+
+    await db.deleteFrom('metering_events').where('organization_id', '=', orgId).execute();
+    await db.deleteFrom('logs').where('project_id', 'in', [proj1.id, proj2.id]).execute();
+
+    // metering: project1 = 100 events / 3000 bytes; project2 = 50 events / 1500 bytes
+    await db.insertInto('metering_events').values([
+      { time: new Date(), organization_id: orgId, project_id: proj1.id, type: 'logs.ingested.events', quantity: 100, metadata: null },
+      { time: new Date(), organization_id: orgId, project_id: proj1.id, type: 'logs.ingested.bytes', quantity: 3000, metadata: null },
+      { time: new Date(), organization_id: orgId, project_id: proj2.id, type: 'logs.ingested.events', quantity: 50, metadata: null },
+      { time: new Date(), organization_id: orgId, project_id: proj2.id, type: 'logs.ingested.bytes', quantity: 1500, metadata: null },
+    ]).execute();
+
+    // logs: project1 -> 3x api/info + 1x api/error ; project2 -> 2x web/info
+    const now = new Date();
+    const mkLog = (projectId: string, service: string, level: string) => ({
+      project_id: projectId, service, level: level as any, message: 'm', time: now,
+    });
+    await db.insertInto('logs').values([
+      mkLog(proj1.id, 'api', 'info'),
+      mkLog(proj1.id, 'api', 'info'),
+      mkLog(proj1.id, 'api', 'info'),
+      mkLog(proj1.id, 'api', 'error'),
+      mkLog(proj2.id, 'web', 'info'),
+      mkLog(proj2.id, 'web', 'info'),
+    ] as any).execute();
+  });
+
+  it('breaks down by metering type', async () => {
+    const b = await getUsageBreakdown({
+      organizationId: orgId,
+      from: new Date(Date.now() - 60 * 60 * 1000),
+      to: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const byType = Object.fromEntries(b.byType.map((t) => [t.type, t.quantity]));
+    expect(byType['logs.ingested.events']).toBe(150);
+    expect(byType['logs.ingested.bytes']).toBe(4500);
+  });
+
+  it('breaks down by project with names, sorted by events desc', async () => {
+    const b = await getUsageBreakdown({
+      organizationId: orgId,
+      from: new Date(Date.now() - 60 * 60 * 1000),
+      to: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    expect(b.byProject).toHaveLength(2);
+    expect(b.byProject[0]).toMatchObject({ projectId: proj1.id, projectName: proj1.name, events: 100, bytes: 3000 });
+    expect(b.byProject[1]).toMatchObject({ projectId: proj2.id, projectName: proj2.name, events: 50, bytes: 1500 });
+  });
+
+  it('breaks down ingested logs by service and by level', async () => {
+    const b = await getUsageBreakdown({
+      organizationId: orgId,
+      from: new Date(Date.now() - 60 * 60 * 1000),
+      to: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const svc = Object.fromEntries(b.byService.map((s) => [s.value, s.count]));
+    expect(svc['api']).toBe(4);
+    expect(svc['web']).toBe(2);
+    expect(b.byService[0].value).toBe('api'); // sorted desc
+
+    const lvl = Object.fromEntries(b.byLevel.map((l) => [l.value, l.count]));
+    expect(lvl['info']).toBe(5);
+    expect(lvl['error']).toBe(1);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/config.test.ts
+++ b/packages/backend/src/tests/modules/metering/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { configSchema } from '../../../config/index.js';
+
+describe('metering config', () => {
+  const base = {
+    DATABASE_URL: 'postgres://u:p@localhost:5432/db',
+    API_KEY_SECRET: 'x'.repeat(32),
+  };
+
+  it('defaults metering on with sane buffer settings', () => {
+    const cfg = configSchema.parse(base);
+    expect(cfg.METERING_ENABLED).toBe(true);
+    expect(cfg.METERING_FLUSH_INTERVAL_MS).toBe(5000);
+    expect(cfg.METERING_FLUSH_MAX_BUFFER).toBe(500);
+  });
+
+  it('parses overrides from env strings', () => {
+    const cfg = configSchema.parse({
+      ...base,
+      METERING_ENABLED: 'false',
+      METERING_FLUSH_INTERVAL_MS: '1000',
+      METERING_FLUSH_MAX_BUFFER: '10',
+    });
+    expect(cfg.METERING_ENABLED).toBe(false);
+    expect(cfg.METERING_FLUSH_INTERVAL_MS).toBe(1000);
+    expect(cfg.METERING_FLUSH_MAX_BUFFER).toBe(10);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/ingestion-site.test.ts
+++ b/packages/backend/src/tests/modules/metering/ingestion-site.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { db } from '../../../database/index.js';
+import { reservoirReady } from '../../../database/reservoir.js';
+import { ingestionService } from '../../../modules/ingestion/service.js';
+import { meteringRecorder } from '../../../modules/metering/index.js';
+import type { LogInput } from '@logtide/shared';
+import { createTestContext } from '../../helpers/factories.js';
+
+describe('ingestion records usage metering', () => {
+  let orgId: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    await reservoirReady;
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    projectId = ctx.project.id;
+  });
+
+  it('writes logs.ingested.events and logs.ingested.bytes after ingest', async () => {
+    const logs: LogInput[] = [
+      { time: new Date(), service: 'api', level: 'info', message: 'a' },
+      { time: new Date(), service: 'api', level: 'info', message: 'b' },
+      { time: new Date(), service: 'api', level: 'warn', message: 'c' },
+    ];
+
+    const inserted = await ingestionService.ingestLogs(logs, projectId);
+    expect(inserted).toBe(3);
+
+    await meteringRecorder.flush();
+
+    const rows = await db
+      .selectFrom('metering_events')
+      .selectAll()
+      .where('organization_id', '=', orgId)
+      .execute();
+
+    const byType = Object.fromEntries(rows.map((r) => [r.type, Number(r.quantity)]));
+    expect(byType['logs.ingested.events']).toBe(3);
+    expect(byType['logs.ingested.bytes']).toBeGreaterThan(0);
+    expect(rows.every((r) => r.project_id === projectId)).toBe(true);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/migration.test.ts
+++ b/packages/backend/src/tests/modules/metering/migration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../../../database/index.js';
+import { createTestContext } from '../../helpers/factories.js';
+
+describe('metering_events table', () => {
+  let orgId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    projectId = ctx.project.id;
+  });
+
+  it('accepts a metering event row and reads it back', async () => {
+    await db
+      .insertInto('metering_events')
+      .values({
+        time: new Date('2026-06-01T00:00:00Z'),
+        organization_id: orgId,
+        project_id: projectId,
+        type: 'logs.ingested.events',
+        quantity: 42,
+        metadata: { source: 'test' },
+      })
+      .execute();
+
+    const rows = await db
+      .selectFrom('metering_events')
+      .selectAll()
+      .where('organization_id', '=', orgId)
+      .execute();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('logs.ingested.events');
+    expect(Number(rows[0].quantity)).toBe(42);
+    expect(rows[0].project_id).toBe(projectId);
+  });
+
+  it('allows a null project_id', async () => {
+    await db
+      .insertInto('metering_events')
+      .values({
+        time: new Date('2026-06-01T00:00:00Z'),
+        organization_id: orgId,
+        project_id: null,
+        type: 'storage.snapshot',
+        quantity: 1,
+        metadata: null,
+      })
+      .execute();
+
+    const rows = await db
+      .selectFrom('metering_events')
+      .selectAll()
+      .where('organization_id', '=', orgId)
+      .execute();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].project_id).toBeNull();
+  });
+});

--- a/packages/backend/src/tests/modules/metering/record-ingestion.test.ts
+++ b/packages/backend/src/tests/modules/metering/record-ingestion.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../../../database/index.js';
+import { recordLogIngestion, meteringRecorder } from '../../../modules/metering/index.js';
+import type { LogInput } from '@logtide/shared';
+import { createTestContext } from '../../helpers/factories.js';
+
+describe('recordLogIngestion', () => {
+  let orgId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    projectId = ctx.project.id;
+  });
+
+  it('records bytes and events for an ingested batch', async () => {
+    const logs: LogInput[] = [
+      { time: new Date(), service: 'api', level: 'info', message: 'hello' },
+      { time: new Date(), service: 'api', level: 'error', message: 'boom' },
+    ];
+
+    recordLogIngestion({ logs, eventCount: logs.length, organizationId: orgId, projectId });
+    await meteringRecorder.flush();
+
+    const rows = await db
+      .selectFrom('metering_events')
+      .selectAll()
+      .where('organization_id', '=', orgId)
+      .orderBy('type')
+      .execute();
+
+    expect(rows).toHaveLength(2);
+    const byType = Object.fromEntries(rows.map((r) => [r.type, Number(r.quantity)]));
+    expect(byType['logs.ingested.events']).toBe(2);
+    expect(byType['logs.ingested.bytes']).toBe(Buffer.byteLength(JSON.stringify(logs)));
+    expect(rows.every((r) => r.project_id === projectId)).toBe(true);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/recorder.test.ts
+++ b/packages/backend/src/tests/modules/metering/recorder.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../../../database/index.js';
+import { MeteringRecorder } from '../../../modules/metering/recorder.js';
+import { createTestContext } from '../../helpers/factories.js';
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+describe('MeteringRecorder', () => {
+  let orgId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    projectId = ctx.project.id;
+  });
+
+  it('buffers without writing until flush', async () => {
+    const rec = new MeteringRecorder({ maxBuffer: 1000 });
+    rec.record({ type: 'logs.ingested.events', quantity: 5, organizationId: orgId, projectId });
+
+    expect(rec.bufferSize).toBe(1);
+    let rows = await db.selectFrom('metering_events').selectAll().where('organization_id', '=', orgId).execute();
+    expect(rows).toHaveLength(0);
+
+    await rec.flush();
+    expect(rec.bufferSize).toBe(0);
+    rows = await db.selectFrom('metering_events').selectAll().where('organization_id', '=', orgId).execute();
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].quantity)).toBe(5);
+  });
+
+  it('flush on empty buffer is a no-op', async () => {
+    const rec = new MeteringRecorder({ maxBuffer: 1000 });
+    await expect(rec.flush()).resolves.toBeUndefined();
+  });
+
+  it('auto-flushes when buffer reaches maxBuffer', async () => {
+    const rec = new MeteringRecorder({ maxBuffer: 2 });
+    rec.record({ type: 'logs.ingested.events', quantity: 1, organizationId: orgId, projectId });
+    rec.record({ type: 'logs.ingested.events', quantity: 1, organizationId: orgId, projectId });
+    await tick();
+    const rows = await db.selectFrom('metering_events').selectAll().where('organization_id', '=', orgId).execute();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('drops events past the hard cap and counts them (loss-tolerant)', () => {
+    const rec = new MeteringRecorder({ maxBuffer: 1_000_000, hardCap: 2 });
+    rec.record({ type: 'logs.ingested.events', quantity: 1, organizationId: orgId, projectId });
+    rec.record({ type: 'logs.ingested.events', quantity: 1, organizationId: orgId, projectId });
+    rec.record({ type: 'logs.ingested.events', quantity: 1, organizationId: orgId, projectId });
+    expect(rec.bufferSize).toBe(2);
+    expect(rec.droppedCount).toBe(1);
+  });
+
+  it('stop() flushes the remaining buffer', async () => {
+    const rec = new MeteringRecorder({ maxBuffer: 1000 });
+    rec.record({ type: 'logs.ingested.bytes', quantity: 99, organizationId: orgId, projectId });
+    await rec.stop();
+    const rows = await db.selectFrom('metering_events').selectAll().where('organization_id', '=', orgId).execute();
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].quantity)).toBe(99);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/routes.test.ts
+++ b/packages/backend/src/tests/modules/metering/routes.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import crypto from 'crypto';
+import { db } from '../../../database/index.js';
+import { usageRoutes } from '../../../modules/metering/routes.js';
+import { createTestContext } from '../../helpers/factories.js';
+
+async function createTestSession(userId: string) {
+  const token = crypto.randomBytes(32).toString('hex');
+  await db
+    .insertInto('sessions')
+    .values({ user_id: userId, token, expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000) })
+    .execute();
+  return token;
+}
+
+describe('GET /api/v1/usage', () => {
+  let app: FastifyInstance;
+  let orgId: string;
+  let projectId: string;
+  let token: string;
+
+  beforeAll(async () => {
+    app = Fastify();
+    await app.register(usageRoutes, { prefix: '/api/v1/usage' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const ctx = await createTestContext();
+    orgId = ctx.organization.id;
+    projectId = ctx.project.id;
+    token = await createTestSession(ctx.user.id);
+
+    await db.insertInto('metering_events').values([
+      { time: new Date('2026-06-01T01:00:00Z'), organization_id: orgId, project_id: projectId, type: 'logs.ingested.events', quantity: 10, metadata: null },
+      { time: new Date('2026-06-01T02:00:00Z'), organization_id: orgId, project_id: projectId, type: 'logs.ingested.bytes', quantity: 2048, metadata: null },
+    ]).execute();
+  });
+
+  it('returns aggregated usage grouped by type', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/v1/usage?organizationId=${orgId}&from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z&groupBy=type`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    const byType = Object.fromEntries(body.usage.map((r: any) => [r.type, r.quantity]));
+    expect(byType['logs.ingested.events']).toBe(10);
+    expect(byType['logs.ingested.bytes']).toBe(2048);
+  });
+
+  it('rejects a non-member with 403', async () => {
+    const other = await createTestContext();
+    const otherToken = await createTestSession(other.user.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/v1/usage?organizationId=${orgId}&from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z&groupBy=type`,
+      headers: { Authorization: `Bearer ${otherToken}` },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 on a missing required param', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/v1/usage?organizationId=${orgId}&groupBy=type`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/backend/src/tests/modules/metering/service.test.ts
+++ b/packages/backend/src/tests/modules/metering/service.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../../../database/index.js';
+import { meteringService } from '../../../modules/metering/service.js';
+import { createTestContext } from '../../helpers/factories.js';
+
+describe('MeteringService.aggregate', () => {
+  let orgA: string;
+  let projectA: string;
+  let orgB: string;
+
+  async function insert(rows: Array<{
+    org: string; project?: string | null; type: string; quantity: number; time: string;
+  }>) {
+    await db.insertInto('metering_events').values(
+      rows.map((r) => ({
+        time: new Date(r.time),
+        organization_id: r.org,
+        project_id: r.project ?? null,
+        type: r.type,
+        quantity: r.quantity,
+        metadata: null,
+      }))
+    ).execute();
+  }
+
+  beforeEach(async () => {
+    await db.deleteFrom('metering_events').execute();
+    const a = await createTestContext();
+    orgA = a.organization.id;
+    projectA = a.project.id;
+    const b = await createTestContext();
+    orgB = b.organization.id;
+  });
+
+  it('groups by type and sums quantity', async () => {
+    await insert([
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 10, time: '2026-06-01T01:00:00Z' },
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 5, time: '2026-06-01T02:00:00Z' },
+      { org: orgA, project: projectA, type: 'logs.ingested.bytes', quantity: 2048, time: '2026-06-01T02:00:00Z' },
+    ]);
+
+    const rows = await meteringService.aggregate({
+      organizationId: orgA,
+      from: new Date('2026-06-01T00:00:00Z'),
+      to: new Date('2026-06-02T00:00:00Z'),
+      groupBy: 'type',
+    });
+
+    const byType = Object.fromEntries(rows.map((r) => [r.type, r.quantity]));
+    expect(byType['logs.ingested.events']).toBe(15);
+    expect(byType['logs.ingested.bytes']).toBe(2048);
+  });
+
+  it('isolates organizations (org A never sees org B usage)', async () => {
+    await insert([
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 10, time: '2026-06-01T01:00:00Z' },
+      { org: orgB, project: null, type: 'logs.ingested.events', quantity: 999, time: '2026-06-01T01:00:00Z' },
+    ]);
+
+    const rows = await meteringService.aggregate({
+      organizationId: orgA,
+      from: new Date('2026-06-01T00:00:00Z'),
+      to: new Date('2026-06-02T00:00:00Z'),
+      groupBy: 'type',
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].quantity).toBe(10);
+  });
+
+  it('groups by day buckets', async () => {
+    await insert([
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 3, time: '2026-06-01T05:00:00Z' },
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 4, time: '2026-06-01T23:00:00Z' },
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 7, time: '2026-06-02T05:00:00Z' },
+    ]);
+
+    const rows = await meteringService.aggregate({
+      organizationId: orgA,
+      from: new Date('2026-06-01T00:00:00Z'),
+      to: new Date('2026-06-03T00:00:00Z'),
+      groupBy: 'day',
+    });
+
+    const byDay = rows.map((r) => ({ day: (r.bucket ?? '').slice(0, 10), q: r.quantity }));
+    expect(byDay).toContainEqual({ day: '2026-06-01', q: 7 });
+    expect(byDay).toContainEqual({ day: '2026-06-02', q: 7 });
+  });
+
+  it('filters by type when provided', async () => {
+    await insert([
+      { org: orgA, project: projectA, type: 'logs.ingested.events', quantity: 10, time: '2026-06-01T01:00:00Z' },
+      { org: orgA, project: projectA, type: 'logs.ingested.bytes', quantity: 2048, time: '2026-06-01T01:00:00Z' },
+    ]);
+
+    const rows = await meteringService.aggregate({
+      organizationId: orgA,
+      from: new Date('2026-06-01T00:00:00Z'),
+      to: new Date('2026-06-02T00:00:00Z'),
+      groupBy: 'type',
+      type: 'logs.ingested.bytes',
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('logs.ingested.bytes');
+    expect(rows[0].quantity).toBe(2048);
+  });
+});

--- a/packages/frontend/src/lib/api/usage.ts
+++ b/packages/frontend/src/lib/api/usage.ts
@@ -1,0 +1,98 @@
+import { getApiBaseUrl } from '$lib/config';
+import { getAuthToken } from '$lib/utils/auth';
+
+export type UsageGroupBy = 'type' | 'project' | 'day';
+
+export interface UsageRecord {
+  type: string;
+  project_id: string | null;
+  bucket?: string;
+  quantity: number;
+}
+
+export interface UsageResponse {
+  usage: UsageRecord[];
+}
+
+export interface UsageParams {
+  organizationId: string;
+  from: string;
+  to: string;
+  groupBy: UsageGroupBy;
+  type?: string;
+}
+
+async function request(endpoint: string): Promise<Response> {
+  const token = getAuthToken();
+  const response = await fetch(`${getApiBaseUrl()}${endpoint}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error ?? `HTTP ${response.status}`);
+  }
+
+  return response;
+}
+
+export async function getUsage(params: UsageParams): Promise<UsageResponse> {
+  const p = new URLSearchParams({
+    organizationId: params.organizationId,
+    from: params.from,
+    to: params.to,
+    groupBy: params.groupBy,
+  });
+  if (params.type) p.set('type', params.type);
+
+  const response = await request(`/usage?${p}`);
+  return response.json();
+}
+
+export interface TypeUsage {
+  type: string;
+  quantity: number;
+}
+
+export interface ProjectUsage {
+  projectId: string;
+  projectName: string;
+  events: number;
+  bytes: number;
+}
+
+export interface ValueCount {
+  value: string;
+  count: number;
+}
+
+export interface UsageBreakdown {
+  byType: TypeUsage[];
+  byProject: ProjectUsage[];
+  byService: ValueCount[];
+  byLevel: ValueCount[];
+}
+
+export interface BreakdownResponse {
+  breakdown: UsageBreakdown;
+}
+
+export interface BreakdownParams {
+  organizationId: string;
+  from: string;
+  to: string;
+}
+
+export async function getUsageBreakdown(params: BreakdownParams): Promise<BreakdownResponse> {
+  const p = new URLSearchParams({
+    organizationId: params.organizationId,
+    from: params.from,
+    to: params.to,
+  });
+
+  const response = await request(`/usage/breakdown?${p}`);
+  return response.json();
+}

--- a/packages/frontend/src/routes/dashboard/admin/+layout@.svelte
+++ b/packages/frontend/src/routes/dashboard/admin/+layout@.svelte
@@ -8,6 +8,7 @@
         Settings,
         KeyRound,
         HeartPulse,
+        BarChart3,
     } from "@lucide/svelte";
     import Menu from "@lucide/svelte/icons/menu";
     import X from "@lucide/svelte/icons/x";
@@ -47,6 +48,11 @@
             name: "Auth Providers",
             href: "/dashboard/admin/auth-providers",
             icon: KeyRound,
+        },
+        {
+            name: "Usage",
+            href: "/dashboard/admin/usage",
+            icon: BarChart3,
         },
         {
             name: "Settings",

--- a/packages/frontend/src/routes/dashboard/admin/usage/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/admin/usage/+page.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { adminAPI, type OrganizationBasic } from '$lib/api/admin';
+    import { getUsage, getUsageBreakdown, type UsageRecord, type UsageBreakdown } from '$lib/api/usage';
+    import {
+        Card,
+        CardContent,
+        CardHeader,
+        CardTitle,
+        CardDescription,
+    } from '$lib/components/ui/card';
+    import {
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow,
+    } from '$lib/components/ui/table';
+    import { Button } from '$lib/components/ui/button';
+    import Spinner from '$lib/components/Spinner.svelte';
+    import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+    import Building2 from '@lucide/svelte/icons/building-2';
+
+    // TODO(#214): per-org entitlements editor goes here once feature #214 backend is shipped
+
+    const RANGES = [
+        { label: 'Last 7 days', days: 7 },
+        { label: 'Last 30 days', days: 30 },
+        { label: 'Last 90 days', days: 90 },
+    ] as const;
+
+    type RangeDays = (typeof RANGES)[number]['days'];
+
+    let orgs = $state<OrganizationBasic[]>([]);
+    let orgsLoading = $state(true);
+    let orgsError = $state('');
+    let selectedOrgId = $state<string>('');
+
+    let selectedDays = $state<RangeDays>(30);
+
+    let loading = $state(false);
+    let error = $state('');
+
+    let byDayEvents = $state<UsageRecord[]>([]);
+    let byDayBytes = $state<UsageRecord[]>([]);
+    let breakdown = $state<UsageBreakdown | null>(null);
+
+    onMount(async () => {
+        orgsLoading = true;
+        orgsError = '';
+        try {
+            const res = await adminAPI.getOrganizations(1, 200);
+            orgs = res.organizations;
+            if (orgs.length > 0) {
+                selectedOrgId = orgs[0].id;
+            }
+        } catch (e) {
+            orgsError = e instanceof Error ? e.message : 'Failed to load organizations';
+        } finally {
+            orgsLoading = false;
+        }
+    });
+
+    $effect(() => {
+        if (selectedOrgId) {
+            // Depend on selectedDays so re-runs when range changes too
+            void load(selectedOrgId, selectedDays);
+        }
+    });
+
+    async function load(orgId: string, days: number) {
+        if (!orgId) return;
+        loading = true;
+        error = '';
+        try {
+            const to = new Date().toISOString();
+            const from = new Date(Date.now() - days * 86_400_000).toISOString();
+
+            const [dayEvt, dayByt, bd] = await Promise.all([
+                getUsage({ organizationId: orgId, from, to, groupBy: 'day', type: 'logs.ingested.events' }),
+                getUsage({ organizationId: orgId, from, to, groupBy: 'day', type: 'logs.ingested.bytes' }),
+                getUsageBreakdown({ organizationId: orgId, from, to }),
+            ]);
+
+            byDayEvents = dayEvt.usage;
+            byDayBytes = dayByt.usage;
+            breakdown = bd.breakdown;
+        } catch (e) {
+            error = e instanceof Error ? e.message : 'Failed to load usage data';
+        } finally {
+            loading = false;
+        }
+    }
+
+    let totalEvents = $derived(byDayEvents.reduce((s, r) => s + r.quantity, 0));
+    let totalBytes = $derived(byDayBytes.reduce((s, r) => s + r.quantity, 0));
+
+    interface DayRow { date: string; events: number; bytes: number; }
+
+    let dailyRows = $derived.by<DayRow[]>(() => {
+        const map = new Map<string, DayRow>();
+        for (const r of byDayEvents) {
+            const d = r.bucket ?? '';
+            if (!map.has(d)) map.set(d, { date: d, events: 0, bytes: 0 });
+            map.get(d)!.events += r.quantity;
+        }
+        for (const r of byDayBytes) {
+            const d = r.bucket ?? '';
+            if (!map.has(d)) map.set(d, { date: d, events: 0, bytes: 0 });
+            map.get(d)!.bytes += r.quantity;
+        }
+        return [...map.values()].sort((a, b) => b.date.localeCompare(a.date));
+    });
+
+    function formatBytes(n: number): string {
+        if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(2)} GB`;
+        if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(2)} MB`;
+        if (n >= 1_024) return `${(n / 1_024).toFixed(1)} KB`;
+        return `${n} B`;
+    }
+
+    function formatCount(n: number): string {
+        if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+        if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+        return n.toLocaleString();
+    }
+
+    function formatDate(iso: string): string {
+        if (!iso) return '';
+        return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    }
+
+    function formatTypeQty(type: string, qty: number): string {
+        return type.endsWith('.bytes') ? formatBytes(qty) : formatCount(qty);
+    }
+
+    let selectedOrgName = $derived(orgs.find((o) => o.id === selectedOrgId)?.name ?? '');
+</script>
+
+<svelte:head>
+    <title>Usage - Admin - LogTide</title>
+</svelte:head>
+
+<div class="container mx-auto p-6 space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold tracking-tight">Usage</h1>
+        <p class="text-sm text-muted-foreground mt-0.5">
+            Metering data per organization
+        </p>
+    </div>
+
+    {#if orgsLoading}
+        <div class="flex justify-center py-12">
+            <Spinner />
+        </div>
+    {:else if orgsError}
+        <p class="text-sm text-destructive">{orgsError}</p>
+    {:else if orgs.length === 0}
+        <Card>
+            <CardContent class="py-12 text-center">
+                <Building2 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+                <p class="mt-3 text-sm text-muted-foreground">No organizations found.</p>
+            </CardContent>
+        </Card>
+    {:else}
+        <!-- Controls -->
+        <div class="flex flex-wrap items-center gap-3">
+            <!-- Org selector -->
+            <div class="space-y-1">
+                <label for="org-select" class="text-xs font-medium text-muted-foreground">Organization</label>
+                <select
+                    id="org-select"
+                    bind:value={selectedOrgId}
+                    class="flex h-9 w-64 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                    {#each orgs as org (org.id)}
+                        <option value={org.id}>{org.name}</option>
+                    {/each}
+                </select>
+            </div>
+
+            <!-- Range selector -->
+            <div class="space-y-1">
+                <span class="text-xs font-medium text-muted-foreground">Range</span>
+                <div class="flex items-center gap-1 rounded-md border p-1 bg-muted/50">
+                    {#each RANGES as range}
+                        <button
+                            type="button"
+                            onclick={() => { selectedDays = range.days; }}
+                            class="px-3 py-1 rounded text-sm font-medium transition-colors {selectedDays === range.days
+                                ? 'bg-background shadow-sm text-foreground'
+                                : 'text-muted-foreground hover:text-foreground'}"
+                        >
+                            {range.label}
+                        </button>
+                    {/each}
+                </div>
+            </div>
+
+            <div class="self-end">
+                <Button variant="outline" size="sm" onclick={() => load(selectedOrgId, selectedDays)} disabled={loading}>
+                    <RotateCcw class="h-4 w-4 mr-1.5 {loading ? 'animate-spin' : ''}" />
+                    Refresh
+                </Button>
+            </div>
+        </div>
+
+        {#if error}
+            <p class="text-sm text-destructive">{error}</p>
+        {/if}
+
+        <!-- Summary cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Card>
+                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle class="text-sm font-medium">Events ingested</CardTitle>
+                    <BarChart3 class="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                    {#if loading}
+                        <Spinner size="sm" />
+                    {:else}
+                        <div class="text-2xl font-bold">{formatCount(totalEvents)}</div>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            {selectedOrgName}
+                            &middot; {RANGES.find((r) => r.days === selectedDays)?.label ?? ''}
+                        </p>
+                    {/if}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle class="text-sm font-medium">Bytes ingested</CardTitle>
+                    <BarChart3 class="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                    {#if loading}
+                        <Spinner size="sm" />
+                    {:else}
+                        <div class="text-2xl font-bold">{formatBytes(totalBytes)}</div>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            {selectedOrgName}
+                            &middot; {RANGES.find((r) => r.days === selectedDays)?.label ?? ''}
+                        </p>
+                    {/if}
+                </CardContent>
+            </Card>
+        </div>
+
+        <!-- By event type (metering signal) -->
+        <Card>
+            <CardHeader class="pb-3">
+                <CardTitle class="text-base">By event type</CardTitle>
+                <CardDescription>Volume per ingested signal type</CardDescription>
+            </CardHeader>
+            <CardContent class="p-0">
+                {#if loading}
+                    <div class="flex justify-center py-10"><Spinner /></div>
+                {:else if !breakdown || breakdown.byType.length === 0}
+                    <div class="py-12 text-center">
+                        <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+                        <p class="mt-3 text-sm text-muted-foreground">No data for this period.</p>
+                    </div>
+                {:else}
+                    <div class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Type</TableHead>
+                                    <TableHead class="text-right">Quantity</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {#each breakdown.byType as row (row.type)}
+                                    <TableRow>
+                                        <TableCell class="font-mono text-sm">{row.type}</TableCell>
+                                        <TableCell class="text-right font-mono text-sm">{formatTypeQty(row.type, row.quantity)}</TableCell>
+                                    </TableRow>
+                                {/each}
+                            </TableBody>
+                        </Table>
+                    </div>
+                {/if}
+            </CardContent>
+        </Card>
+
+        <!-- Daily breakdown -->
+        <Card>
+            <CardHeader class="pb-3">
+                <CardTitle class="text-base">Daily breakdown</CardTitle>
+                <CardDescription>Ingestion per day for {selectedOrgName}</CardDescription>
+            </CardHeader>
+            <CardContent class="p-0">
+                {#if loading}
+                    <div class="flex justify-center py-10">
+                        <Spinner />
+                    </div>
+                {:else if dailyRows.length === 0}
+                    <div class="py-12 text-center">
+                        <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+                        <p class="mt-3 text-sm text-muted-foreground">No usage data for this period.</p>
+                    </div>
+                {:else}
+                    <div class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Date</TableHead>
+                                    <TableHead class="text-right">Events</TableHead>
+                                    <TableHead class="text-right">Bytes</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {#each dailyRows as row (row.date)}
+                                    <TableRow>
+                                        <TableCell class="text-sm">{formatDate(row.date)}</TableCell>
+                                        <TableCell class="text-right font-mono text-sm">{formatCount(row.events)}</TableCell>
+                                        <TableCell class="text-right font-mono text-sm">{formatBytes(row.bytes)}</TableCell>
+                                    </TableRow>
+                                {/each}
+                            </TableBody>
+                        </Table>
+                    </div>
+                {/if}
+            </CardContent>
+        </Card>
+
+        <!-- By project (with name) -->
+        <Card>
+            <CardHeader class="pb-3">
+                <CardTitle class="text-base">Breakdown by project</CardTitle>
+                <CardDescription>Ingestion totals per project for {selectedOrgName}</CardDescription>
+            </CardHeader>
+            <CardContent class="p-0">
+                {#if loading}
+                    <div class="flex justify-center py-10">
+                        <Spinner />
+                    </div>
+                {:else if !breakdown || breakdown.byProject.length === 0}
+                    <div class="py-12 text-center">
+                        <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+                        <p class="mt-3 text-sm text-muted-foreground">No project data for this period.</p>
+                    </div>
+                {:else}
+                    <div class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Project</TableHead>
+                                    <TableHead class="text-right">Events</TableHead>
+                                    <TableHead class="text-right">Bytes</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {#each breakdown.byProject as row (row.projectId)}
+                                    <TableRow>
+                                        <TableCell class="text-sm">{row.projectName}</TableCell>
+                                        <TableCell class="text-right font-mono text-sm">{formatCount(row.events)}</TableCell>
+                                        <TableCell class="text-right font-mono text-sm">{formatBytes(row.bytes)}</TableCell>
+                                    </TableRow>
+                                {/each}
+                            </TableBody>
+                        </Table>
+                    </div>
+                {/if}
+            </CardContent>
+        </Card>
+
+        <!-- By service / by level -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <Card>
+                <CardHeader class="pb-3">
+                    <CardTitle class="text-base">By service</CardTitle>
+                    <CardDescription>Which services produced the logs</CardDescription>
+                </CardHeader>
+                <CardContent class="p-0">
+                    {#if loading}
+                        <div class="flex justify-center py-10"><Spinner /></div>
+                    {:else if !breakdown || breakdown.byService.length === 0}
+                        <div class="py-12 text-center">
+                            <p class="text-sm text-muted-foreground">No data for this period.</p>
+                        </div>
+                    {:else}
+                        <div class="overflow-x-auto">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Service</TableHead>
+                                        <TableHead class="text-right">Events</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {#each breakdown.byService as row (row.value)}
+                                        <TableRow>
+                                            <TableCell class="text-sm">{row.value}</TableCell>
+                                            <TableCell class="text-right font-mono text-sm">{formatCount(row.count)}</TableCell>
+                                        </TableRow>
+                                    {/each}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    {/if}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader class="pb-3">
+                    <CardTitle class="text-base">By level</CardTitle>
+                    <CardDescription>Log level distribution</CardDescription>
+                </CardHeader>
+                <CardContent class="p-0">
+                    {#if loading}
+                        <div class="flex justify-center py-10"><Spinner /></div>
+                    {:else if !breakdown || breakdown.byLevel.length === 0}
+                        <div class="py-12 text-center">
+                            <p class="text-sm text-muted-foreground">No data for this period.</p>
+                        </div>
+                    {:else}
+                        <div class="overflow-x-auto">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Level</TableHead>
+                                        <TableHead class="text-right">Events</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {#each breakdown.byLevel as row (row.value)}
+                                        <TableRow>
+                                            <TableCell class="text-sm capitalize">{row.value}</TableCell>
+                                            <TableCell class="text-right font-mono text-sm">{formatCount(row.count)}</TableCell>
+                                        </TableRow>
+                                    {/each}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    {/if}
+                </CardContent>
+            </Card>
+        </div>
+    {/if}
+</div>

--- a/packages/frontend/src/routes/dashboard/settings/+layout.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/+layout.svelte
@@ -13,6 +13,7 @@
   import GitBranch from '@lucide/svelte/icons/git-branch';
   import Settings from '@lucide/svelte/icons/settings';
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
+  import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -83,6 +84,12 @@
       label: 'Team',
       items: [
         { label: 'Members', href: '/dashboard/settings/members', icon: Users },
+      ],
+    },
+    {
+      label: 'Billing & Usage',
+      items: [
+        { label: 'Usage', href: '/dashboard/settings/usage', icon: BarChart3 },
       ],
     },
     {

--- a/packages/frontend/src/routes/dashboard/settings/usage/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/usage/+page.svelte
@@ -1,0 +1,404 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { organizationStore } from '$lib/stores/organization';
+  import { getUsage, getUsageBreakdown, type UsageRecord, type UsageBreakdown } from '$lib/api/usage';
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    CardDescription,
+  } from '$lib/components/ui/card';
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from '$lib/components/ui/table';
+  import { Button } from '$lib/components/ui/button';
+  import Spinner from '$lib/components/Spinner.svelte';
+  import type { OrganizationWithRole } from '@logtide/shared';
+  import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
+  import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+
+  // TODO(#214): entitlements/limits editor goes here once feature #214 backend is shipped
+
+  const RANGES = [
+    { label: 'Last 7 days', days: 7 },
+    { label: 'Last 30 days', days: 30 },
+    { label: 'Last 90 days', days: 90 },
+  ] as const;
+
+  type RangeDays = (typeof RANGES)[number]['days'];
+
+  let currentOrg = $state<OrganizationWithRole | null>(null);
+  let selectedDays = $state<RangeDays>(30);
+
+  let loading = $state(false);
+  let error = $state('');
+
+  // Raw API data per groupBy
+  let byDayEvents = $state<UsageRecord[]>([]);
+  let byDayBytes = $state<UsageRecord[]>([]);
+  let breakdown = $state<UsageBreakdown | null>(null);
+
+  let lastLoadedOrgId = $state<string | null>(null);
+  let lastLoadedDays = $state<number | null>(null);
+
+  const unsubOrg = organizationStore.subscribe((state) => {
+    currentOrg = state.currentOrganization;
+  });
+
+  onDestroy(() => {
+    unsubOrg();
+  });
+
+  $effect(() => {
+    if (
+      browser &&
+      currentOrg &&
+      (currentOrg.id !== lastLoadedOrgId || selectedDays !== lastLoadedDays)
+    ) {
+      lastLoadedOrgId = currentOrg.id;
+      lastLoadedDays = selectedDays;
+      void load();
+    }
+  });
+
+  async function load() {
+    if (!currentOrg) return;
+    loading = true;
+    error = '';
+    try {
+      const to = new Date().toISOString();
+      const from = new Date(Date.now() - selectedDays * 86_400_000).toISOString();
+      const orgId = currentOrg.id;
+
+      const [dayEvt, dayByt, bd] = await Promise.all([
+        getUsage({ organizationId: orgId, from, to, groupBy: 'day', type: 'logs.ingested.events' }),
+        getUsage({ organizationId: orgId, from, to, groupBy: 'day', type: 'logs.ingested.bytes' }),
+        getUsageBreakdown({ organizationId: orgId, from, to }),
+      ]);
+
+      byDayEvents = dayEvt.usage;
+      byDayBytes = dayByt.usage;
+      breakdown = bd.breakdown;
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load usage data';
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Totals
+  let totalEvents = $derived(byDayEvents.reduce((s, r) => s + r.quantity, 0));
+  let totalBytes = $derived(byDayBytes.reduce((s, r) => s + r.quantity, 0));
+
+  // By-day table: merge events + bytes into one row per date
+  interface DayRow {
+    date: string;
+    events: number;
+    bytes: number;
+  }
+
+  let dailyRows = $derived.by<DayRow[]>(() => {
+    const map = new Map<string, DayRow>();
+    for (const r of byDayEvents) {
+      const d = r.bucket ?? '';
+      if (!map.has(d)) map.set(d, { date: d, events: 0, bytes: 0 });
+      map.get(d)!.events += r.quantity;
+    }
+    for (const r of byDayBytes) {
+      const d = r.bucket ?? '';
+      if (!map.has(d)) map.set(d, { date: d, events: 0, bytes: 0 });
+      map.get(d)!.bytes += r.quantity;
+    }
+    return [...map.values()].sort((a, b) => b.date.localeCompare(a.date));
+  });
+
+  function formatBytes(n: number): string {
+    if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(2)} GB`;
+    if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(2)} MB`;
+    if (n >= 1_024) return `${(n / 1_024).toFixed(1)} KB`;
+    return `${n} B`;
+  }
+
+  function formatCount(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return n.toLocaleString();
+  }
+
+  function formatDate(iso: string): string {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  function formatTypeQty(type: string, qty: number): string {
+    return type.endsWith('.bytes') ? formatBytes(qty) : formatCount(qty);
+  }
+</script>
+
+<svelte:head>
+  <title>Usage - LogTide</title>
+</svelte:head>
+
+<div class="space-y-6">
+  <!-- Header row with range selector -->
+  <div class="flex items-center justify-between flex-wrap gap-3">
+    <div class="flex items-center gap-1 rounded-md border p-1 bg-muted/50">
+      {#each RANGES as range}
+        <button
+          type="button"
+          onclick={() => { selectedDays = range.days; }}
+          class="px-3 py-1 rounded text-sm font-medium transition-colors {selectedDays === range.days
+            ? 'bg-background shadow-sm text-foreground'
+            : 'text-muted-foreground hover:text-foreground'}"
+        >
+          {range.label}
+        </button>
+      {/each}
+    </div>
+    <Button variant="outline" size="sm" onclick={() => load()} disabled={loading}>
+      <RotateCcw class="h-4 w-4 mr-1.5 {loading ? 'animate-spin' : ''}" />
+      Refresh
+    </Button>
+  </div>
+
+  {#if error}
+    <p class="text-sm text-destructive">{error}</p>
+  {/if}
+
+  <!-- Summary cards -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <Card>
+      <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle class="text-sm font-medium">Events ingested</CardTitle>
+        <BarChart3 class="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        {#if loading}
+          <Spinner size="sm" />
+        {:else}
+          <div class="text-2xl font-bold">{formatCount(totalEvents)}</div>
+          <p class="text-xs text-muted-foreground mt-1">
+            {RANGES.find((r) => r.days === selectedDays)?.label ?? ''}
+          </p>
+        {/if}
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle class="text-sm font-medium">Bytes ingested</CardTitle>
+        <BarChart3 class="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        {#if loading}
+          <Spinner size="sm" />
+        {:else}
+          <div class="text-2xl font-bold">{formatBytes(totalBytes)}</div>
+          <p class="text-xs text-muted-foreground mt-1">
+            {RANGES.find((r) => r.days === selectedDays)?.label ?? ''}
+          </p>
+        {/if}
+      </CardContent>
+    </Card>
+  </div>
+
+  <!-- By event type (metering signal) -->
+  <Card>
+    <CardHeader class="pb-3">
+      <CardTitle class="text-base">By event type</CardTitle>
+      <CardDescription>Volume per ingested signal type</CardDescription>
+    </CardHeader>
+    <CardContent class="p-0">
+      {#if loading}
+        <div class="flex justify-center py-10"><Spinner /></div>
+      {:else if !breakdown || breakdown.byType.length === 0}
+        <div class="py-12 text-center">
+          <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+          <p class="mt-3 text-sm text-muted-foreground">No data for this period.</p>
+        </div>
+      {:else}
+        <div class="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Type</TableHead>
+                <TableHead class="text-right">Quantity</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {#each breakdown.byType as row (row.type)}
+                <TableRow>
+                  <TableCell class="font-mono text-sm">{row.type}</TableCell>
+                  <TableCell class="text-right font-mono text-sm">{formatTypeQty(row.type, row.quantity)}</TableCell>
+                </TableRow>
+              {/each}
+            </TableBody>
+          </Table>
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+
+  <!-- Daily breakdown -->
+  <Card>
+    <CardHeader class="pb-3">
+      <CardTitle class="text-base">Daily breakdown</CardTitle>
+      <CardDescription>Ingestion per day for the selected range</CardDescription>
+    </CardHeader>
+    <CardContent class="p-0">
+      {#if loading}
+        <div class="flex justify-center py-10">
+          <Spinner />
+        </div>
+      {:else if dailyRows.length === 0}
+        <div class="py-12 text-center">
+          <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+          <p class="mt-3 text-sm text-muted-foreground">No usage data for this period.</p>
+        </div>
+      {:else}
+        <div class="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead class="text-right">Events</TableHead>
+                <TableHead class="text-right">Bytes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {#each dailyRows as row (row.date)}
+                <TableRow>
+                  <TableCell class="text-sm">{formatDate(row.date)}</TableCell>
+                  <TableCell class="text-right font-mono text-sm">{formatCount(row.events)}</TableCell>
+                  <TableCell class="text-right font-mono text-sm">{formatBytes(row.bytes)}</TableCell>
+                </TableRow>
+              {/each}
+            </TableBody>
+          </Table>
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+
+  <!-- By project (with name) -->
+  <Card>
+    <CardHeader class="pb-3">
+      <CardTitle class="text-base">Breakdown by project</CardTitle>
+      <CardDescription>Ingestion totals per project for the selected range</CardDescription>
+    </CardHeader>
+    <CardContent class="p-0">
+      {#if loading}
+        <div class="flex justify-center py-10">
+          <Spinner />
+        </div>
+      {:else if !breakdown || breakdown.byProject.length === 0}
+        <div class="py-12 text-center">
+          <BarChart3 class="mx-auto h-10 w-10 text-muted-foreground/40" />
+          <p class="mt-3 text-sm text-muted-foreground">No project data for this period.</p>
+        </div>
+      {:else}
+        <div class="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Project</TableHead>
+                <TableHead class="text-right">Events</TableHead>
+                <TableHead class="text-right">Bytes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {#each breakdown.byProject as row (row.projectId)}
+                <TableRow>
+                  <TableCell class="text-sm">{row.projectName}</TableCell>
+                  <TableCell class="text-right font-mono text-sm">{formatCount(row.events)}</TableCell>
+                  <TableCell class="text-right font-mono text-sm">{formatBytes(row.bytes)}</TableCell>
+                </TableRow>
+              {/each}
+            </TableBody>
+          </Table>
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+
+  <!-- By service / by level -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <Card>
+      <CardHeader class="pb-3">
+        <CardTitle class="text-base">By service</CardTitle>
+        <CardDescription>Which services produced the logs</CardDescription>
+      </CardHeader>
+      <CardContent class="p-0">
+        {#if loading}
+          <div class="flex justify-center py-10"><Spinner /></div>
+        {:else if !breakdown || breakdown.byService.length === 0}
+          <div class="py-12 text-center">
+            <p class="text-sm text-muted-foreground">No data for this period.</p>
+          </div>
+        {:else}
+          <div class="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Service</TableHead>
+                  <TableHead class="text-right">Events</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {#each breakdown.byService as row (row.value)}
+                  <TableRow>
+                    <TableCell class="text-sm">{row.value}</TableCell>
+                    <TableCell class="text-right font-mono text-sm">{formatCount(row.count)}</TableCell>
+                  </TableRow>
+                {/each}
+              </TableBody>
+            </Table>
+          </div>
+        {/if}
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader class="pb-3">
+        <CardTitle class="text-base">By level</CardTitle>
+        <CardDescription>Log level distribution</CardDescription>
+      </CardHeader>
+      <CardContent class="p-0">
+        {#if loading}
+          <div class="flex justify-center py-10"><Spinner /></div>
+        {:else if !breakdown || breakdown.byLevel.length === 0}
+          <div class="py-12 text-center">
+            <p class="text-sm text-muted-foreground">No data for this period.</p>
+          </div>
+        {:else}
+          <div class="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Level</TableHead>
+                  <TableHead class="text-right">Events</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {#each breakdown.byLevel as row (row.value)}
+                  <TableRow>
+                    <TableCell class="text-sm capitalize">{row.value}</TableCell>
+                    <TableCell class="text-right font-mono text-sm">{formatCount(row.count)}</TableCell>
+                  </TableRow>
+                {/each}
+              </TableBody>
+            </Table>
+          </div>
+        {/if}
+      </CardContent>
+    </Card>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Implements the resource-usage metering backend (#212) plus the Usage UI in settings.

**Backend**
- `metering_events` TimescaleDB hypertable + Kysely type (migration 045)
- Non-blocking, loss-tolerant buffered `MeteringRecorder` (batch insert, flush on size/interval/shutdown)
- Recording site wired into log ingestion (`logs.ingested.bytes` + `logs.ingested.events`), fire-and-forget
- `MeteringService.aggregate` query-time grouping (type/project/day, UTC day buckets), org-scoped
- `GET /api/v1/usage` (membership-guarded) read API
- `GET /api/v1/usage/breakdown` (by metering type, by project with name, by service, by level) via the reservoir abstraction
- Recorder start/stop wired into server boot + graceful shutdown

**Frontend**
- Usage section under Settings (`/dashboard/settings/usage`) and an admin read-only view (`/dashboard/admin/usage`) with org picker
- Breakdown sections: by event type, by project (name), by service, by level

Scope note: continuous aggregates and the `storage.snapshot` recording site were deliberately deferred (reservoir exposes no per-project bytes today). Quota enforcement is out of scope here and lands with #214.

## Test plan
- [ ] Backend metering suite green (`vitest run src/tests/modules/metering`) - 21 tests
- [ ] No regression in the ingestion suite
- [ ] `GET /api/v1/usage` and `/usage/breakdown` return correct, org-isolated data
- [ ] Usage UI renders for a normal user and for an admin