### PR TITLE
Generic outbound webhook delivery infrastructure (#218)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,49 @@
+# Outbound Webhooks
+
+LogTide delivers events (alerts, anomalies, errors, monitor status changes, security incidents, and notification-channel webhooks) to your endpoints through a centralized dispatcher with SSRF protection, retry with exponential backoff, a dead-letter queue, and delivery logging.
+
+## Delivery semantics
+
+- **Retries:** transient failures (network errors, timeouts, HTTP 5xx, 429) are retried with exponential backoff (1s, 5s, 25s, 2m, 10m), up to a configurable maximum (`WEBHOOK_MAX_ATTEMPTS`, default 5). Non-transient failures (other 4xx) are not retried.
+- **Dead-letter queue:** after the final failed attempt a delivery is marked `dead`. Dead and failed deliveries can be replayed from the dashboard (Settings → Webhook Deliveries).
+- **Idempotency:** each delivery carries a stable id. The same logical event is not enqueued twice, so a receiver can safely deduplicate on the event id.
+- **Timeout:** each attempt times out after `WEBHOOK_REQUEST_TIMEOUT_MS` (default 10s).
+
+## Verifying webhook signatures
+
+When a signing secret is configured for a webhook, LogTide signs each delivery so you can verify it came from LogTide and was not tampered with:
+
+- `X-Logtide-Timestamp: <unix seconds>`
+- `X-Logtide-Signature: t=<unix>,v1=<hex hmac>`
+
+The signature is `HMAC-SHA256(secret, "<timestamp>.<raw request body>")`, hex-encoded.
+
+```js
+import crypto from 'crypto';
+
+function verify(secret, headers, rawBody) {
+  const ts = headers['x-logtide-timestamp'];
+  const sig = headers['x-logtide-signature'].split('v1=')[1];
+  const expected = crypto.createHmac('sha256', secret).update(`${ts}.${rawBody}`).digest('hex');
+  const a = Buffer.from(expected, 'hex');
+  const b = Buffer.from(sig, 'hex');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+```
+
+Verify against the **raw** request body (before JSON parsing), since any reserialization can change the bytes and break the signature. Reject deliveries whose timestamp is older than your tolerance (e.g. 5 minutes) to prevent replay.
+
+## SSRF protection
+
+Outbound targets are resolved and validated before each request; loopback, private, link-local (including cloud metadata), CGNAT, multicast, and reserved IPv4/IPv6 ranges are rejected, and every redirect hop is revalidated. Self-hosted deployments that need to reach internal endpoints can opt in with `MONITOR_ALLOW_PRIVATE_TARGETS=true`.
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `WEBHOOK_MAX_ATTEMPTS` | `5` | Maximum delivery attempts before the dead-letter queue. |
+| `WEBHOOK_PER_ORG_CONCURRENCY` | `5` | Concurrent deliveries per organization. |
+| `WEBHOOK_GLOBAL_CONCURRENCY` | `50` | Concurrent deliveries across all organizations. |
+| `WEBHOOK_DELIVERY_LOG_LIMIT` | `1000` | Attempts retained per delivery in the delivery log. |
+| `WEBHOOK_REQUEST_TIMEOUT_MS` | `10000` | Per-attempt request timeout in milliseconds. |
+| `MONITOR_ALLOW_PRIVATE_TARGETS` | `false` | Allow delivery to private/internal addresses (self-hosted). |

--- a/packages/backend/migrations/047_webhook_deliveries.sql
+++ b/packages/backend/migrations/047_webhook_deliveries.sql
@@ -1,0 +1,35 @@
+-- migrations/047_webhook_deliveries.sql
+-- Generic outbound webhook delivery infrastructure (#218).
+-- One logical delivery per enqueue; one row per HTTP attempt. DLQ = status='dead'.
+
+CREATE TABLE webhook_deliveries (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL,
+  event_type      TEXT NOT NULL,
+  event_id        TEXT NOT NULL,
+  url             TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'pending',
+  attempt_count   INT  NOT NULL DEFAULT 0,
+  max_attempts    INT  NOT NULL DEFAULT 5,
+  next_attempt_at TIMESTAMPTZ,
+  last_error      TEXT,
+  metadata        JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_webhook_deliveries_org_created ON webhook_deliveries(organization_id, created_at DESC);
+CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries(status);
+
+CREATE TABLE webhook_delivery_attempts (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  delivery_id      UUID NOT NULL REFERENCES webhook_deliveries(id) ON DELETE CASCADE,
+  attempt_number   INT NOT NULL,
+  status_code      INT,
+  duration_ms      INT,
+  response_excerpt TEXT,
+  error            TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_webhook_delivery_attempts_delivery ON webhook_delivery_attempts(delivery_id, created_at DESC);

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -79,6 +79,13 @@ const configSchema = z.object({
   // deployments that legitimately monitor internal services can opt in.
   MONITOR_ALLOW_PRIVATE_TARGETS: z.string().default('false').transform((val) => val === 'true'),
 
+  // Outbound webhook dispatcher (#218).
+  WEBHOOK_MAX_ATTEMPTS: z.string().default('5').transform(Number),
+  WEBHOOK_PER_ORG_CONCURRENCY: z.string().default('5').transform(Number),
+  WEBHOOK_GLOBAL_CONCURRENCY: z.string().default('50').transform(Number),
+  WEBHOOK_DELIVERY_LOG_LIMIT: z.string().default('1000').transform(Number),
+  WEBHOOK_REQUEST_TIMEOUT_MS: z.string().default('10000').transform(Number),
+
   // Lifecycle hooks (#216). Comma-separated paths to .js/.mjs modules loaded
   // at boot (server AND worker). Each default-exports (hooks) => void.
   // A missing or throwing module is FATAL at boot, by design.

--- a/packages/backend/src/database/types.ts
+++ b/packages/backend/src/database/types.ts
@@ -881,6 +881,41 @@ export interface OrganizationDefaultChannelsTable {
 }
 
 // ============================================================================
+// OUTBOUND WEBHOOK DELIVERY TABLES (#218)
+// ============================================================================
+
+export interface WebhookDeliveriesTable {
+  id: Generated<string>;
+  organization_id: string;
+  event_type: string;
+  event_id: string;
+  url: string;
+  status: Generated<string>; // 'pending' | 'delivered' | 'failed' | 'dead'
+  attempt_count: Generated<number>;
+  max_attempts: Generated<number>;
+  next_attempt_at: ColumnType<Date | null, Date | null, Date | null>;
+  last_error: string | null;
+  metadata: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null,
+    Record<string, unknown> | null
+  >;
+  created_at: Generated<Timestamp>;
+  updated_at: Generated<Timestamp>;
+}
+
+export interface WebhookDeliveryAttemptsTable {
+  id: Generated<string>;
+  delivery_id: string;
+  attempt_number: number;
+  status_code: number | null;
+  duration_ms: number | null;
+  response_excerpt: string | null;
+  error: string | null;
+  created_at: Generated<Timestamp>;
+}
+
+// ============================================================================
 // PII MASKING TABLES
 // ============================================================================
 
@@ -1155,4 +1190,7 @@ export interface Database {
   metering_events: MeteringEventsTable;
   // Per-organization feature entitlements (#214)
   organization_entitlements: OrganizationEntitlementsTable;
+  // Outbound webhook delivery (#218)
+  webhook_deliveries: WebhookDeliveriesTable;
+  webhook_delivery_attempts: WebhookDeliveryAttemptsTable;
 }

--- a/packages/backend/src/modules/notification-channels/providers/webhook-provider.ts
+++ b/packages/backend/src/modules/notification-channels/providers/webhook-provider.ts
@@ -5,9 +5,7 @@
 
 import type { NotificationProvider, NotificationContext, DeliveryResult } from './interface.js';
 import type { WebhookChannelConfig, ChannelConfig } from '@logtide/shared';
-import { safeFetch, SsrfBlockedError } from '../../../utils/ssrf-guard.js';
-import { config } from '../../../config/index.js';
-import { hooks, HookRejectionError } from '../../../hooks/index.js';
+import { deliverOnce } from '../../webhooks/index.js';
 
 export class WebhookProvider implements NotificationProvider {
   readonly type = 'webhook' as const;
@@ -19,98 +17,40 @@ export class WebhookProvider implements NotificationProvider {
 
     const webhookConfig = channelConfig as WebhookChannelConfig;
 
-    try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'User-Agent': 'LogTide/1.0',
-        ...(webhookConfig.headers || {}),
-      };
-
-      // Add authentication if configured
-      if (webhookConfig.auth) {
-        if (webhookConfig.auth.type === 'bearer' && webhookConfig.auth.token) {
-          headers['Authorization'] = `Bearer ${webhookConfig.auth.token}`;
-        } else if (
-          webhookConfig.auth.type === 'basic' &&
-          webhookConfig.auth.username &&
-          webhookConfig.auth.password
-        ) {
-          const credentials = Buffer.from(
-            `${webhookConfig.auth.username}:${webhookConfig.auth.password}`
-          ).toString('base64');
-          headers['Authorization'] = `Basic ${credentials}`;
-        }
+    // Build auth headers, then hand off to the shared deliverOnce primitive
+    // (#218): it runs the beforeWebhookDispatch hook, applies the SSRF guard,
+    // and signs the body. This keeps the synchronous DeliveryResult contract
+    // the "Test Channel" button relies on while centralizing delivery.
+    const headers: Record<string, string> = { ...(webhookConfig.headers || {}) };
+    if (webhookConfig.auth) {
+      if (webhookConfig.auth.type === 'bearer' && webhookConfig.auth.token) {
+        headers['Authorization'] = `Bearer ${webhookConfig.auth.token}`;
+      } else if (
+        webhookConfig.auth.type === 'basic' &&
+        webhookConfig.auth.username &&
+        webhookConfig.auth.password
+      ) {
+        const credentials = Buffer.from(
+          `${webhookConfig.auth.username}:${webhookConfig.auth.password}`
+        ).toString('base64');
+        headers['Authorization'] = `Basic ${credentials}`;
       }
-
-      const payload = this.buildPayload(context);
-
-      // Lifecycle hook (#216): last interception point before the outbound
-      // call. headers/body are mutable; url stays readonly (safeFetch still
-      // SSRF-validates regardless).
-      if (hooks.hasHandlers('beforeWebhookDispatch')) {
-        let targetHost: string;
-        try {
-          targetHost = new URL(webhookConfig.url).hostname;
-        } catch {
-          return { success: false, error: 'Invalid webhook configuration' };
-        }
-        try {
-          await hooks.run('beforeWebhookDispatch', {
-            organizationId: context.organizationId || null,
-            channelId: context.channelId,
-            url: webhookConfig.url,
-            targetHost,
-            headers,
-            body: payload,
-          });
-        } catch (e) {
-          if (e instanceof HookRejectionError) {
-            return { success: false, error: `Webhook dispatch rejected: ${e.message}` };
-          }
-          return { success: false, error: 'Webhook dispatch blocked: hook failed' };
-        }
-      }
-
-      // safeFetch validates the URL (and every redirect hop) against the SSRF
-      // guard before connecting. Private/internal targets are rejected unless
-      // MONITOR_ALLOW_PRIVATE_TARGETS is set for self-hosted deployments.
-      const response = await safeFetch(
-        webhookConfig.url,
-        {
-          method: webhookConfig.method || 'POST',
-          headers,
-          body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(10000), // 10s timeout
-        },
-        { allowPrivate: config.MONITOR_ALLOW_PRIVATE_TARGETS }
-      );
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        console.error(`[WebhookProvider] HTTP ${response.status}: ${errorText}`);
-        return {
-          success: false,
-          error: `HTTP ${response.status}: ${response.statusText}`,
-        };
-      }
-
-      console.log(`[WebhookProvider] Sent to ${webhookConfig.url}`);
-
-      return {
-        success: true,
-        metadata: {
-          statusCode: response.status,
-          url: webhookConfig.url,
-        },
-      };
-    } catch (error) {
-      if (error instanceof SsrfBlockedError) {
-        return { success: false, error: 'Webhook URLs pointing to private/internal addresses are not allowed' };
-      }
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      console.error(`[WebhookProvider] Failed: ${errorMessage}`);
-      return { success: false, error: errorMessage };
     }
+
+    const result = await deliverOnce({
+      url: webhookConfig.url,
+      body: this.buildPayload(context),
+      organizationId: context.organizationId ?? null,
+      eventType: context.eventType,
+      method: webhookConfig.method,
+      headers,
+      channelId: context.channelId,
+    });
+
+    if (result.success) {
+      return { success: true, metadata: { statusCode: result.statusCode, url: webhookConfig.url } };
+    }
+    return { success: false, error: result.error };
   }
 
   validateConfig(config: unknown): config is WebhookChannelConfig {

--- a/packages/backend/src/modules/webhooks/concurrency.ts
+++ b/packages/backend/src/modules/webhooks/concurrency.ts
@@ -1,0 +1,63 @@
+/**
+ * In-process per-organization concurrency limiter for webhook delivery (#218).
+ *
+ * Caps how many deliveries run at once for a single org so one tenant's slow
+ * receiver can't saturate the worker pool, plus an overall global cap. Purely
+ * in-memory: state dies with the process (crash-safe), no Redis dependency, so
+ * it works on both queue backends. A cross-instance cap is future work.
+ */
+
+interface LimiterOptions {
+  perOrg: number;
+  global: number;
+}
+
+export class OrgConcurrencyLimiter {
+  private readonly perOrg: number;
+  private readonly global: number;
+  private globalActive = 0;
+  private orgActive = new Map<string, number>();
+  private waiters: Array<{ orgId: string; resolve: () => void }> = [];
+
+  constructor(opts: LimiterOptions) {
+    this.perOrg = Math.max(1, opts.perOrg);
+    this.global = Math.max(1, opts.global);
+  }
+
+  async run<T>(orgId: string, task: () => Promise<T>): Promise<T> {
+    await this.acquire(orgId);
+    try {
+      return await task();
+    } finally {
+      this.release(orgId);
+    }
+  }
+
+  private canRun(orgId: string): boolean {
+    return this.globalActive < this.global && (this.orgActive.get(orgId) ?? 0) < this.perOrg;
+  }
+
+  private acquire(orgId: string): Promise<void> {
+    if (this.canRun(orgId)) {
+      this.globalActive++;
+      this.orgActive.set(orgId, (this.orgActive.get(orgId) ?? 0) + 1);
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push({ orgId, resolve });
+    });
+  }
+
+  private release(orgId: string): void {
+    this.globalActive--;
+    this.orgActive.set(orgId, Math.max(0, (this.orgActive.get(orgId) ?? 1) - 1));
+
+    // Wake the first waiter that can now run.
+    const idx = this.waiters.findIndex((w) => this.canRun(w.orgId));
+    if (idx === -1) return;
+    const [waiter] = this.waiters.splice(idx, 1);
+    this.globalActive++;
+    this.orgActive.set(waiter.orgId, (this.orgActive.get(waiter.orgId) ?? 0) + 1);
+    waiter.resolve();
+  }
+}

--- a/packages/backend/src/modules/webhooks/dispatcher.ts
+++ b/packages/backend/src/modules/webhooks/dispatcher.ts
@@ -4,13 +4,16 @@
  * `deliverOnce` is the single-attempt primitive shared by the synchronous
  * notification-channel provider and the queued retry layer: it runs the
  * beforeWebhookDispatch hook, signs the body, and sends via the SSRF guard.
- * `enqueue` (added later) layers persistence + retry + DLQ on top.
+ * `enqueue` layers persistence + retry + DLQ on top.
  */
+import { createHash } from 'crypto';
 import { config } from '../../config/index.js';
 import { safeFetch, SsrfBlockedError } from '../../utils/ssrf-guard.js';
 import { hooks, HookRejectionError } from '../../hooks/index.js';
 import { buildSignatureHeaders } from './signing.js';
-import type { DeliverOnceParams, DeliverOnceResult } from './types.js';
+import { createQueue } from '../../queue/connection.js';
+import { webhookDeliveryService } from './service.js';
+import type { DeliverOnceParams, DeliverOnceResult, EnqueueParams, WebhookDeliveryJobData } from './types.js';
 
 const RESPONSE_EXCERPT_MAX = 500;
 
@@ -44,7 +47,7 @@ export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnc
         url: params.url,
         targetHost,
         headers,
-        body: params.body,
+        body: params.body as Record<string, unknown>,
       });
     } catch (e) {
       const msg = e instanceof HookRejectionError ? `rejected: ${e.message}` : 'blocked: hook failed';
@@ -96,3 +99,53 @@ export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnc
     };
   }
 }
+
+export const WEBHOOK_DELIVERY_QUEUE = 'webhook-delivery';
+const webhookQueue = createQueue<WebhookDeliveryJobData>(WEBHOOK_DELIVERY_QUEUE);
+
+function deriveEventId(params: EnqueueParams): string {
+  if (params.eventId) return params.eventId;
+  return createHash('sha256')
+    .update(`${params.url}\n${JSON.stringify(params.payload ?? {})}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+export const webhookDispatcher = {
+  deliverOnce,
+
+  /**
+   * Persist a delivery row and enqueue it. Deterministic jobKey
+   * (webhook:<org>:<eventType>:<eventId>) deduplicates upstream double-enqueues.
+   * Retries are driven manually by the job re-enqueueing itself, so the queue's
+   * own retry is disabled (maxAttempts: 1).
+   */
+  async enqueue(params: EnqueueParams): Promise<{ deliveryId: string }> {
+    const eventId = deriveEventId(params);
+    const delivery = await webhookDeliveryService.createDelivery({
+      organizationId: params.organizationId,
+      eventType: params.eventType,
+      eventId,
+      url: params.url,
+      maxAttempts: params.maxAttempts ?? config.WEBHOOK_MAX_ATTEMPTS,
+      metadata: {
+        payload: params.payload as Record<string, unknown>,
+        signingSecret: params.signingSecret ?? null,
+        headers: params.headers ?? null,
+        channelId: params.channelId ?? null,
+        ruleId: params.ruleId ?? null,
+        ...(params.metadata ?? {}),
+      },
+    });
+    await webhookQueue.add('deliver', { deliveryId: delivery.id }, {
+      jobKey: `webhook:${params.organizationId}:${params.eventType}:${eventId}`,
+      maxAttempts: 1,
+    });
+    return { deliveryId: delivery.id };
+  },
+
+  /** Re-enqueue an already-persisted delivery (used by manual replay). */
+  async enqueueExisting(deliveryId: string): Promise<void> {
+    await webhookQueue.add('deliver', { deliveryId }, { maxAttempts: 1 });
+  },
+};

--- a/packages/backend/src/modules/webhooks/dispatcher.ts
+++ b/packages/backend/src/modules/webhooks/dispatcher.ts
@@ -144,8 +144,14 @@ export const webhookDispatcher = {
     return { deliveryId: delivery.id };
   },
 
-  /** Re-enqueue an already-persisted delivery (used by manual replay). */
+  /**
+   * Re-enqueue an already-persisted delivery (used by manual replay). The
+   * jobKey dedupes rapid double-replays of the same delivery.
+   */
   async enqueueExisting(deliveryId: string): Promise<void> {
-    await webhookQueue.add('deliver', { deliveryId }, { maxAttempts: 1 });
+    await webhookQueue.add('deliver', { deliveryId }, {
+      jobKey: `webhook-replay:${deliveryId}`,
+      maxAttempts: 1,
+    });
   },
 };

--- a/packages/backend/src/modules/webhooks/dispatcher.ts
+++ b/packages/backend/src/modules/webhooks/dispatcher.ts
@@ -19,19 +19,16 @@ const RESPONSE_EXCERPT_MAX = 500;
 
 export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnceResult> {
   const started = Date.now();
-  const bodyString = JSON.stringify(params.body ?? {});
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'User-Agent': 'LogTide/1.0',
     ...(params.headers ?? {}),
   };
-  if (params.signingSecret) {
-    const unix = Math.floor(Date.now() / 1000);
-    Object.assign(headers, buildSignatureHeaders(params.signingSecret, bodyString, unix));
-  }
 
   // Lifecycle hook (#216): last interception point before the outbound call.
+  // Runs BEFORE the body is serialized and signed so that header/body mutations
+  // made by the hook reach the actual request (and are covered by the signature).
   if (hooks.hasHandlers('beforeWebhookDispatch')) {
     let targetHost: string;
     try {
@@ -53,6 +50,13 @@ export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnc
       const msg = e instanceof HookRejectionError ? `rejected: ${e.message}` : 'blocked: hook failed';
       return { success: false, durationMs: Date.now() - started, error: `Webhook dispatch ${msg}`, retryable: false };
     }
+  }
+
+  // Serialize and sign AFTER the hook so mutations are included.
+  const bodyString = JSON.stringify(params.body ?? {});
+  if (params.signingSecret) {
+    const unix = Math.floor(Date.now() / 1000);
+    Object.assign(headers, buildSignatureHeaders(params.signingSecret, bodyString, unix));
   }
 
   try {

--- a/packages/backend/src/modules/webhooks/dispatcher.ts
+++ b/packages/backend/src/modules/webhooks/dispatcher.ts
@@ -59,7 +59,7 @@ export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnc
     const response = await safeFetch(
       params.url,
       {
-        method: 'POST',
+        method: params.method ?? 'POST',
         headers,
         body: bodyString,
         signal: AbortSignal.timeout(config.WEBHOOK_REQUEST_TIMEOUT_MS),
@@ -111,6 +111,16 @@ function deriveEventId(params: EnqueueParams): string {
     .slice(0, 32);
 }
 
+/**
+ * Build the queue job id. BullMQ forbids ':' in custom job ids (it is the Redis
+ * key separator), and event ids can embed URLs, so the readable composite is
+ * hashed to a stable, collision-resistant, separator-safe id.
+ */
+function buildJobKey(organizationId: string, eventType: string, eventId: string): string {
+  const digest = createHash('sha256').update(`${organizationId}:${eventType}:${eventId}`).digest('hex');
+  return `webhook-${digest}`;
+}
+
 export const webhookDispatcher = {
   deliverOnce,
 
@@ -138,7 +148,7 @@ export const webhookDispatcher = {
       },
     });
     await webhookQueue.add('deliver', { deliveryId: delivery.id }, {
-      jobKey: `webhook:${params.organizationId}:${params.eventType}:${eventId}`,
+      jobKey: buildJobKey(params.organizationId, params.eventType, eventId),
       maxAttempts: 1,
     });
     return { deliveryId: delivery.id };
@@ -150,7 +160,7 @@ export const webhookDispatcher = {
    */
   async enqueueExisting(deliveryId: string): Promise<void> {
     await webhookQueue.add('deliver', { deliveryId }, {
-      jobKey: `webhook-replay:${deliveryId}`,
+      jobKey: `webhook-replay-${deliveryId}`,
       maxAttempts: 1,
     });
   },

--- a/packages/backend/src/modules/webhooks/dispatcher.ts
+++ b/packages/backend/src/modules/webhooks/dispatcher.ts
@@ -1,0 +1,98 @@
+/**
+ * Webhook dispatcher (#218).
+ *
+ * `deliverOnce` is the single-attempt primitive shared by the synchronous
+ * notification-channel provider and the queued retry layer: it runs the
+ * beforeWebhookDispatch hook, signs the body, and sends via the SSRF guard.
+ * `enqueue` (added later) layers persistence + retry + DLQ on top.
+ */
+import { config } from '../../config/index.js';
+import { safeFetch, SsrfBlockedError } from '../../utils/ssrf-guard.js';
+import { hooks, HookRejectionError } from '../../hooks/index.js';
+import { buildSignatureHeaders } from './signing.js';
+import type { DeliverOnceParams, DeliverOnceResult } from './types.js';
+
+const RESPONSE_EXCERPT_MAX = 500;
+
+export async function deliverOnce(params: DeliverOnceParams): Promise<DeliverOnceResult> {
+  const started = Date.now();
+  const bodyString = JSON.stringify(params.body ?? {});
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'LogTide/1.0',
+    ...(params.headers ?? {}),
+  };
+  if (params.signingSecret) {
+    const unix = Math.floor(Date.now() / 1000);
+    Object.assign(headers, buildSignatureHeaders(params.signingSecret, bodyString, unix));
+  }
+
+  // Lifecycle hook (#216): last interception point before the outbound call.
+  if (hooks.hasHandlers('beforeWebhookDispatch')) {
+    let targetHost: string;
+    try {
+      targetHost = new URL(params.url).hostname;
+    } catch {
+      return { success: false, durationMs: Date.now() - started, error: 'Invalid webhook URL', retryable: false };
+    }
+    try {
+      await hooks.run('beforeWebhookDispatch', {
+        organizationId: params.organizationId,
+        channelId: params.channelId,
+        ruleId: params.ruleId,
+        url: params.url,
+        targetHost,
+        headers,
+        body: params.body,
+      });
+    } catch (e) {
+      const msg = e instanceof HookRejectionError ? `rejected: ${e.message}` : 'blocked: hook failed';
+      return { success: false, durationMs: Date.now() - started, error: `Webhook dispatch ${msg}`, retryable: false };
+    }
+  }
+
+  try {
+    const response = await safeFetch(
+      params.url,
+      {
+        method: 'POST',
+        headers,
+        body: bodyString,
+        signal: AbortSignal.timeout(config.WEBHOOK_REQUEST_TIMEOUT_MS),
+      },
+      { allowPrivate: config.MONITOR_ALLOW_PRIVATE_TARGETS }
+    );
+
+    const durationMs = Date.now() - started;
+    if (response.ok) {
+      return { success: true, statusCode: response.status, durationMs, retryable: false };
+    }
+    const excerpt = (await response.text().catch(() => '')).slice(0, RESPONSE_EXCERPT_MAX);
+    return {
+      success: false,
+      statusCode: response.status,
+      durationMs,
+      responseExcerpt: excerpt,
+      error: `HTTP ${response.status} ${response.statusText}`,
+      retryable: response.status >= 500 || response.status === 429,
+    };
+  } catch (e) {
+    const durationMs = Date.now() - started;
+    if (e instanceof SsrfBlockedError) {
+      return {
+        success: false,
+        durationMs,
+        error: 'Webhook URLs pointing to private/internal addresses are not allowed',
+        retryable: false,
+      };
+    }
+    // Network errors and timeouts (AbortError) are transient.
+    return {
+      success: false,
+      durationMs,
+      error: e instanceof Error ? e.message : 'Unknown error',
+      retryable: true,
+    };
+  }
+}

--- a/packages/backend/src/modules/webhooks/index.ts
+++ b/packages/backend/src/modules/webhooks/index.ts
@@ -1,0 +1,3 @@
+export { webhookDispatcher, deliverOnce, WEBHOOK_DELIVERY_QUEUE } from './dispatcher.js';
+export { webhookDeliveryService } from './service.js';
+export type { EnqueueParams, DeliverOnceParams, DeliverOnceResult, WebhookDeliveryJobData } from './types.js';

--- a/packages/backend/src/modules/webhooks/routes.ts
+++ b/packages/backend/src/modules/webhooks/routes.ts
@@ -1,0 +1,107 @@
+/**
+ * Webhook delivery API (#218): list deliveries (incl. DLQ via status=dead),
+ * fetch a delivery with its attempts, and replay a dead/failed delivery.
+ */
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { authenticate } from '../auth/middleware.js';
+import { OrganizationsService } from '../organizations/service.js';
+import { webhookDeliveryService } from './service.js';
+import { webhookDispatcher } from './dispatcher.js';
+
+const organizationsService = new OrganizationsService();
+
+// ============================================================================
+// VALIDATION SCHEMAS
+// ============================================================================
+
+const listQuerySchema = z.object({
+  organizationId: z.string().uuid(),
+  status: z.enum(['pending', 'delivered', 'failed', 'dead']).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+async function checkOrganizationMembership(userId: string, organizationId: string): Promise<boolean> {
+  const organizations = await organizationsService.getUserOrganizations(userId);
+  return organizations.some((org) => org.id === organizationId);
+}
+
+async function checkAdminRole(userId: string, organizationId: string): Promise<boolean> {
+  return organizationsService.isOwnerOrAdmin(organizationId, userId);
+}
+
+// ============================================================================
+// ROUTES
+// ============================================================================
+
+export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', authenticate);
+
+  /**
+   * GET /api/v1/webhooks/deliveries
+   * List deliveries for an org, optionally filtered by status (dead = DLQ).
+   */
+  fastify.get('/deliveries', async (request: any, reply) => {
+    const parsed = listQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid query', details: parsed.error.errors });
+    }
+    const { organizationId, status, limit, offset } = parsed.data;
+
+    const isMember = await checkOrganizationMembership(request.user.id, organizationId);
+    if (!isMember) {
+      return reply.status(403).send({ error: 'Not a member of this organization' });
+    }
+
+    const deliveries = await webhookDeliveryService.listDeliveries(organizationId, { status, limit, offset });
+    return reply.send({ deliveries });
+  });
+
+  /**
+   * GET /api/v1/webhooks/deliveries/:id
+   * Fetch a single delivery with its attempt log.
+   */
+  fastify.get('/deliveries/:id', async (request: any, reply) => {
+    const { id } = request.params as { id: string };
+
+    const delivery = await webhookDeliveryService.getDelivery(id);
+    if (!delivery) return reply.status(404).send({ error: 'Delivery not found' });
+
+    const isMember = await checkOrganizationMembership(request.user.id, delivery.organization_id);
+    if (!isMember) {
+      return reply.status(403).send({ error: 'Not a member of this organization' });
+    }
+
+    const attempts = await webhookDeliveryService.listAttempts(id);
+    return reply.send({ delivery, attempts });
+  });
+
+  /**
+   * POST /api/v1/webhooks/deliveries/:id/replay
+   * Re-enqueue a failed or dead delivery. Admin only.
+   */
+  fastify.post('/deliveries/:id/replay', async (request: any, reply) => {
+    const { id } = request.params as { id: string };
+
+    const delivery = await webhookDeliveryService.getDelivery(id);
+    if (!delivery) return reply.status(404).send({ error: 'Delivery not found' });
+
+    const isAdmin = await checkAdminRole(request.user.id, delivery.organization_id);
+    if (!isAdmin) {
+      return reply.status(403).send({ error: 'Only admins can replay deliveries' });
+    }
+
+    if (delivery.status !== 'dead' && delivery.status !== 'failed') {
+      return reply.status(409).send({ error: 'Only failed or dead deliveries can be replayed' });
+    }
+
+    const reset = await webhookDeliveryService.resetForReplay(id);
+    await webhookDispatcher.enqueueExisting(id);
+    return reply.send({ delivery: reset });
+  });
+}

--- a/packages/backend/src/modules/webhooks/routes.ts
+++ b/packages/backend/src/modules/webhooks/routes.ts
@@ -6,7 +6,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { authenticate } from '../auth/middleware.js';
 import { OrganizationsService } from '../organizations/service.js';
-import { webhookDeliveryService } from './service.js';
+import { webhookDeliveryService, redactDeliveryForApi } from './service.js';
 import { webhookDispatcher } from './dispatcher.js';
 
 const organizationsService = new OrganizationsService();
@@ -59,7 +59,7 @@ export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
     }
 
     const deliveries = await webhookDeliveryService.listDeliveries(organizationId, { status, limit, offset });
-    return reply.send({ deliveries });
+    return reply.send({ deliveries: deliveries.map(redactDeliveryForApi) });
   });
 
   /**
@@ -78,7 +78,7 @@ export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
     }
 
     const attempts = await webhookDeliveryService.listAttempts(id);
-    return reply.send({ delivery, attempts });
+    return reply.send({ delivery: redactDeliveryForApi(delivery), attempts });
   });
 
   /**
@@ -102,6 +102,6 @@ export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
 
     const reset = await webhookDeliveryService.resetForReplay(id);
     await webhookDispatcher.enqueueExisting(id);
-    return reply.send({ delivery: reset });
+    return reply.send({ delivery: redactDeliveryForApi(reset) });
   });
 }

--- a/packages/backend/src/modules/webhooks/service.ts
+++ b/packages/backend/src/modules/webhooks/service.ts
@@ -103,10 +103,10 @@ export const webhookDeliveryService = {
       .execute();
   },
 
-  async markDead(id: string, lastError: string): Promise<void> {
+  async markDead(id: string, attemptCount: number, lastError: string): Promise<void> {
     await db
       .updateTable('webhook_deliveries')
-      .set({ status: 'dead', next_attempt_at: null, last_error: lastError, updated_at: new Date() })
+      .set({ status: 'dead', attempt_count: attemptCount, next_attempt_at: null, last_error: lastError, updated_at: new Date() })
       .where('id', '=', id)
       .execute();
   },

--- a/packages/backend/src/modules/webhooks/service.ts
+++ b/packages/backend/src/modules/webhooks/service.ts
@@ -1,0 +1,140 @@
+/**
+ * Persistence for webhook deliveries (#218). One logical delivery row plus a
+ * bounded per-delivery attempt log. The DLQ is simply status='dead'.
+ */
+import { db } from '../../database/connection.js';
+import type { Selectable } from 'kysely';
+import type { WebhookDeliveriesTable, WebhookDeliveryAttemptsTable } from '../../database/types.js';
+
+export type DeliveryRow = Selectable<WebhookDeliveriesTable>;
+export type DeliveryAttemptRow = Selectable<WebhookDeliveryAttemptsTable>;
+
+interface CreateDeliveryInput {
+  organizationId: string;
+  eventType: string;
+  eventId: string;
+  url: string;
+  maxAttempts: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface RecordAttemptInput {
+  attemptNumber: number;
+  statusCode?: number | null;
+  durationMs?: number | null;
+  responseExcerpt?: string | null;
+  error?: string | null;
+}
+
+interface ListOptions {
+  status?: string;
+  limit: number;
+  offset: number;
+}
+
+export const webhookDeliveryService = {
+  async createDelivery(input: CreateDeliveryInput): Promise<DeliveryRow> {
+    return db
+      .insertInto('webhook_deliveries')
+      .values({
+        organization_id: input.organizationId,
+        event_type: input.eventType,
+        event_id: input.eventId,
+        url: input.url,
+        status: 'pending',
+        attempt_count: 0,
+        max_attempts: input.maxAttempts,
+        metadata: input.metadata ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+  },
+
+  async getDelivery(id: string): Promise<DeliveryRow | undefined> {
+    return db.selectFrom('webhook_deliveries').selectAll().where('id', '=', id).executeTakeFirst();
+  },
+
+  async recordAttempt(deliveryId: string, input: RecordAttemptInput, logLimit: number): Promise<void> {
+    await db
+      .insertInto('webhook_delivery_attempts')
+      .values({
+        delivery_id: deliveryId,
+        attempt_number: input.attemptNumber,
+        status_code: input.statusCode ?? null,
+        duration_ms: input.durationMs ?? null,
+        response_excerpt: input.responseExcerpt ?? null,
+        error: input.error ?? null,
+      })
+      .execute();
+
+    // Prune to the last `logLimit` attempts for this delivery.
+    // Order by created_at desc, attempt_number desc for determinism when timestamps collide.
+    const keep = await db
+      .selectFrom('webhook_delivery_attempts')
+      .select('id')
+      .where('delivery_id', '=', deliveryId)
+      .orderBy('created_at', 'desc')
+      .orderBy('attempt_number', 'desc')
+      .limit(logLimit)
+      .execute();
+    const keepIds = keep.map((r) => r.id);
+    if (keepIds.length > 0) {
+      await db
+        .deleteFrom('webhook_delivery_attempts')
+        .where('delivery_id', '=', deliveryId)
+        .where('id', 'not in', keepIds)
+        .execute();
+    }
+  },
+
+  async markDelivered(id: string): Promise<void> {
+    await db
+      .updateTable('webhook_deliveries')
+      .set({ status: 'delivered', updated_at: new Date(), next_attempt_at: null })
+      .where('id', '=', id)
+      .execute();
+  },
+
+  async markRetrying(id: string, attemptCount: number, nextAttemptAt: Date, lastError: string): Promise<void> {
+    await db
+      .updateTable('webhook_deliveries')
+      .set({ status: 'failed', attempt_count: attemptCount, next_attempt_at: nextAttemptAt, last_error: lastError, updated_at: new Date() })
+      .where('id', '=', id)
+      .execute();
+  },
+
+  async markDead(id: string, lastError: string): Promise<void> {
+    await db
+      .updateTable('webhook_deliveries')
+      .set({ status: 'dead', next_attempt_at: null, last_error: lastError, updated_at: new Date() })
+      .where('id', '=', id)
+      .execute();
+  },
+
+  async resetForReplay(id: string): Promise<DeliveryRow | undefined> {
+    return db
+      .updateTable('webhook_deliveries')
+      .set({ status: 'pending', attempt_count: 0, next_attempt_at: null, last_error: null, updated_at: new Date() })
+      .where('id', '=', id)
+      .returningAll()
+      .executeTakeFirst();
+  },
+
+  async listDeliveries(organizationId: string, opts: ListOptions): Promise<DeliveryRow[]> {
+    let q = db
+      .selectFrom('webhook_deliveries')
+      .selectAll()
+      .where('organization_id', '=', organizationId);
+    if (opts.status) q = q.where('status', '=', opts.status);
+    return q.orderBy('created_at', 'desc').limit(opts.limit).offset(opts.offset).execute();
+  },
+
+  async listAttempts(deliveryId: string): Promise<DeliveryAttemptRow[]> {
+    return db
+      .selectFrom('webhook_delivery_attempts')
+      .selectAll()
+      .where('delivery_id', '=', deliveryId)
+      .orderBy('created_at', 'desc')
+      .execute();
+  },
+};

--- a/packages/backend/src/modules/webhooks/service.ts
+++ b/packages/backend/src/modules/webhooks/service.ts
@@ -138,3 +138,16 @@ export const webhookDeliveryService = {
       .execute();
   },
 };
+
+/**
+ * Strip delivery-internal secrets from a row's metadata before it crosses the
+ * API boundary. The worker reads `signingSecret`/`headers` from metadata to send
+ * the request, but those must never be returned to API clients.
+ */
+export function redactDeliveryForApi<T extends DeliveryRow | undefined>(row: T): T {
+  if (!row) return row;
+  const metadata = row.metadata as Record<string, unknown> | null;
+  if (!metadata) return row;
+  const { signingSecret: _s, headers: _h, ...safe } = metadata;
+  return { ...row, metadata: safe };
+}

--- a/packages/backend/src/modules/webhooks/signing.ts
+++ b/packages/backend/src/modules/webhooks/signing.ts
@@ -1,0 +1,38 @@
+/**
+ * HMAC-SHA256 signing for outbound webhooks (#218).
+ *
+ * Signed string is `${unixSeconds}.${body}`. Receivers verify by recomputing
+ * the HMAC over the same string with their shared secret. Headers:
+ *   X-Logtide-Signature: t=<unix>,v1=<hexHmac>
+ *   X-Logtide-Timestamp: <unix>
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export function signBody(secret: string, unixSeconds: number, body: string): string {
+  return createHmac('sha256', secret).update(`${unixSeconds}.${body}`).digest('hex');
+}
+
+export function verifySignature(
+  secret: string,
+  unixSeconds: number,
+  body: string,
+  signature: string
+): boolean {
+  const expected = signBody(secret, unixSeconds, body);
+  const a = Buffer.from(expected, 'hex');
+  const b = Buffer.from(signature, 'hex');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function buildSignatureHeaders(
+  secret: string,
+  body: string,
+  unixSeconds: number
+): Record<string, string> {
+  const sig = signBody(secret, unixSeconds, body);
+  return {
+    'X-Logtide-Timestamp': String(unixSeconds),
+    'X-Logtide-Signature': `t=${unixSeconds},v1=${sig}`,
+  };
+}

--- a/packages/backend/src/modules/webhooks/types.ts
+++ b/packages/backend/src/modules/webhooks/types.ts
@@ -5,6 +5,8 @@ export interface DeliverOnceParams {
   eventType: string;
   signingSecret?: string;
   headers?: Record<string, string>;
+  /** HTTP method, defaults to POST. */
+  method?: string;
   /** Extra context forwarded to the beforeWebhookDispatch hook. */
   channelId?: string;
   ruleId?: string;

--- a/packages/backend/src/modules/webhooks/types.ts
+++ b/packages/backend/src/modules/webhooks/types.ts
@@ -1,0 +1,40 @@
+export interface DeliverOnceParams {
+  url: string;
+  body: unknown;
+  organizationId: string | null;
+  eventType: string;
+  signingSecret?: string;
+  headers?: Record<string, string>;
+  /** Extra context forwarded to the beforeWebhookDispatch hook. */
+  channelId?: string;
+  ruleId?: string;
+}
+
+export interface DeliverOnceResult {
+  success: boolean;
+  statusCode?: number;
+  durationMs: number;
+  responseExcerpt?: string;
+  error?: string;
+  /** Whether a failure is worth retrying (network/timeout/5xx/429). */
+  retryable: boolean;
+}
+
+export interface EnqueueParams {
+  url: string;
+  payload: unknown;
+  organizationId: string;
+  eventType: string;
+  /** Stable id for idempotency. Defaults to a hash of url+payload if omitted. */
+  eventId?: string;
+  signingSecret?: string;
+  headers?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+  maxAttempts?: number;
+  channelId?: string;
+  ruleId?: string;
+}
+
+export interface WebhookDeliveryJobData {
+  deliveryId: string;
+}

--- a/packages/backend/src/queue/jobs/alert-notification.ts
+++ b/packages/backend/src/queue/jobs/alert-notification.ts
@@ -5,8 +5,7 @@ import { db } from '../../database/connection.js';
 import nodemailer from 'nodemailer';
 import { config } from '../../config/index.js';
 import { generateAlertEmail, getFrontendUrl } from '../../lib/email-templates.js';
-import { safeFetch, SsrfBlockedError } from '../../utils/ssrf-guard.js';
-import { hooks } from '../../hooks/index.js';
+import { webhookDispatcher } from '../../modules/webhooks/index.js';
 import type { EmailChannelConfig, WebhookChannelConfig } from '@logtide/shared';
 
 export interface AlertNotificationData {
@@ -222,77 +221,30 @@ async function sendWebhookNotification(data: AlertNotificationData, channelId?: 
 
   const frontendUrl = getFrontendUrl();
 
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'User-Agent': 'LogTide/1.0',
-  };
-  const body: Record<string, unknown> = {
-    event_type: data.baseline_metadata ? 'anomaly' : 'alert',
-    alert_name: data.rule_name,
-    log_count: data.log_count,
-    threshold: data.threshold,
-    time_window: data.time_window,
-    organization_id: data.organization_id,
-    project_id: data.project_id,
-    baseline_metadata: data.baseline_metadata || null,
-    link: `${frontendUrl}/dashboard/alerts`,
-    timestamp: new Date().toISOString(),
-  };
-
-  // Lifecycle hook (#216): same interception point as WebhookProvider.
-  // A rejection (or broken hook) propagates and is recorded as a delivery
-  // failure by the caller; the HTTP call never happens.
-  if (hooks.hasHandlers('beforeWebhookDispatch')) {
-    let targetHost: string;
-    try {
-      targetHost = new URL(data.webhook_url).hostname;
-    } catch {
-      throw new Error(`Invalid webhook URL: ${data.webhook_url}`);
-    }
-    await hooks.run('beforeWebhookDispatch', {
-      organizationId: data.organization_id,
-      ruleId: data.rule_id,
-      channelId,
-      url: data.webhook_url,
-      targetHost,
-      headers,
-      body,
-    });
-  }
-
-  // SSRF protection: route delivery through the centralized outbound guard
-  // (safeFetch resolves the host, rejects loopback/private/link-local/CGNAT/
-  // reserved IPv4+IPv6 ranges, and revalidates every redirect hop), matching
-  // the WebhookProvider. The same MONITOR_ALLOW_PRIVATE_TARGETS opt-in governs
-  // both paths so self-hosted deployments can still target internal endpoints.
-  let response: Response;
-  try {
-    response = await safeFetch(
-      data.webhook_url,
-      {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(10000),
-      },
-      { allowPrivate: config.MONITOR_ALLOW_PRIVATE_TARGETS }
-    );
-  } catch (e) {
-    if (e instanceof SsrfBlockedError) {
-      throw new Error('Webhook URLs pointing to private/internal addresses are not allowed');
-    }
-    if (e instanceof TypeError) {
-      throw new Error(`Invalid webhook URL: ${data.webhook_url}`);
-    }
-    throw e;
-  }
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => '');
-    throw new Error(`Webhook request failed: HTTP ${response.status}${errorText ? ` - ${errorText}` : ''}`);
-  }
-
-  console.log(`Webhook notification sent to: ${data.webhook_url}`);
+  // Route through the centralized dispatcher (#218): SSRF guard, HMAC signing,
+  // retry/backoff, DLQ, delivery logging, and the beforeWebhookDispatch hook
+  // (#216) all live in one place now. Same payload as before, no regression.
+  await webhookDispatcher.enqueue({
+    url: data.webhook_url,
+    organizationId: data.organization_id,
+    eventType: data.baseline_metadata ? 'anomaly' : 'alert',
+    eventId: `${data.historyId || data.rule_id}:${data.webhook_url}`,
+    channelId,
+    ruleId: data.rule_id,
+    metadata: { ruleName: data.rule_name },
+    payload: {
+      event_type: data.baseline_metadata ? 'anomaly' : 'alert',
+      alert_name: data.rule_name,
+      log_count: data.log_count,
+      threshold: data.threshold,
+      time_window: data.time_window,
+      organization_id: data.organization_id,
+      project_id: data.project_id,
+      baseline_metadata: data.baseline_metadata || null,
+      link: `${frontendUrl}/dashboard/alerts`,
+      timestamp: new Date().toISOString(),
+    },
+  });
 }
 
 async function createInAppNotifications(data: AlertNotificationData, projectName: string | null) {

--- a/packages/backend/src/queue/jobs/error-notification.ts
+++ b/packages/backend/src/queue/jobs/error-notification.ts
@@ -14,6 +14,7 @@ import { notificationsService } from '../../modules/notifications/service.js';
 import { notificationChannelsService } from '../../modules/notification-channels/index.js';
 import { createQueue } from '../connection.js';
 import { generateErrorEmail, getFrontendUrl } from '../../lib/email-templates.js';
+import { webhookDispatcher } from '../../modules/webhooks/index.js';
 import type { ExceptionLanguage } from '../../modules/exceptions/types.js';
 import type { EmailChannelConfig, WebhookChannelConfig } from '@logtide/shared';
 
@@ -63,13 +64,15 @@ async function sendErrorWebhook(
 ): Promise<void> {
   const frontendUrl = getFrontendUrl();
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'LogTide/1.0',
-    },
-    body: JSON.stringify({
+  // Route through the centralized dispatcher (#218): SSRF guard, HMAC signing,
+  // retry/backoff, DLQ, and delivery logging. Previously this used raw fetch
+  // with no SSRF protection. Same payload as before.
+  await webhookDispatcher.enqueue({
+    url,
+    organizationId: data.organizationId,
+    eventType: 'error',
+    eventId: `${errorGroupId}:${url}`,
+    payload: {
       event_type: 'error',
       title: `${data.isNewErrorGroup ? 'New Error' : 'Error'}: ${data.exceptionType}`,
       message: data.exceptionMessage || `An error occurred in ${data.service}`,
@@ -89,13 +92,8 @@ async function sendErrorWebhook(
       is_new: data.isNewErrorGroup,
       link: `${frontendUrl}/dashboard/errors/${errorGroupId}`,
       timestamp: new Date().toISOString(),
-    }),
-    signal: AbortSignal.timeout(10000),
+    },
   });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
 }
 
 /**

--- a/packages/backend/src/queue/jobs/incident-notification.ts
+++ b/packages/backend/src/queue/jobs/incident-notification.ts
@@ -6,6 +6,7 @@ import { notificationsService } from '../../modules/notifications/service.js';
 import { notificationChannelsService } from '../../modules/notification-channels/index.js';
 import { createQueue } from '../connection.js';
 import { generateIncidentEmail, getFrontendUrl } from '../../lib/email-templates.js';
+import { webhookDispatcher } from '../../modules/webhooks/index.js';
 import type { Severity } from '../../database/types.js';
 import type { EmailChannelConfig, WebhookChannelConfig } from '@logtide/shared';
 
@@ -55,13 +56,14 @@ function createTransporter() {
 async function sendIncidentWebhook(url: string, job: IncidentNotificationJob, orgName: string): Promise<void> {
   const frontendUrl = getFrontendUrl();
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'LogTide/1.0',
-    },
-    body: JSON.stringify({
+  // Route through the centralized dispatcher (#218): SSRF guard, HMAC signing,
+  // retry/backoff, DLQ, and delivery logging. Same payload as before.
+  await webhookDispatcher.enqueue({
+    url,
+    organizationId: job.organizationId,
+    eventType: 'incident',
+    eventId: `${job.incidentId}:${url}`,
+    payload: {
       event_type: 'incident',
       title: job.title,
       message: job.description || `Security incident: ${job.title}`,
@@ -74,13 +76,8 @@ async function sendIncidentWebhook(url: string, job: IncidentNotificationJob, or
       affected_services: job.affectedServices,
       link: `${frontendUrl}/dashboard/security/incidents/${job.incidentId}`,
       timestamp: new Date().toISOString(),
-    }),
-    signal: AbortSignal.timeout(10000),
+    },
   });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
 }
 
 /**

--- a/packages/backend/src/queue/jobs/monitor-notification.ts
+++ b/packages/backend/src/queue/jobs/monitor-notification.ts
@@ -6,6 +6,7 @@ import { notificationsService } from '../../modules/notifications/service.js';
 import { notificationChannelsService } from '../../modules/notification-channels/index.js';
 import { createQueue } from '../connection.js';
 import { generateMonitorEmail, getFrontendUrl } from '../../lib/email-templates.js';
+import { webhookDispatcher } from '../../modules/webhooks/index.js';
 import type { Severity, EmailChannelConfig, WebhookChannelConfig } from '@logtide/shared';
 
 export interface MonitorNotificationJob {
@@ -51,13 +52,14 @@ async function sendMonitorWebhook(url: string, job: MonitorNotificationJob, orgN
   const frontendUrl = getFrontendUrl();
   const isDown = job.status === 'down';
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'LogTide/1.0',
-    },
-    body: JSON.stringify({
+  // Route through the centralized dispatcher (#218): SSRF guard, HMAC signing,
+  // retry/backoff, DLQ, and delivery logging. Same payload as before.
+  await webhookDispatcher.enqueue({
+    url,
+    organizationId: job.organizationId,
+    eventType: 'monitoring',
+    eventId: `${job.monitorId}:${job.status}:${url}`,
+    payload: {
       event_type: 'monitor_status_change',
       monitor_id: job.monitorId,
       monitor_name: job.monitorName,
@@ -78,13 +80,8 @@ async function sendMonitorWebhook(url: string, job: MonitorNotificationJob, orgN
       downtime_duration: job.downtimeDuration,
       link: `${frontendUrl}/dashboard/monitoring`,
       timestamp: new Date().toISOString(),
-    }),
-    signal: AbortSignal.timeout(10000),
+    },
   });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
 }
 
 export async function processMonitorNotification(job: IJob<MonitorNotificationJob>): Promise<void> {

--- a/packages/backend/src/queue/jobs/webhook-delivery.ts
+++ b/packages/backend/src/queue/jobs/webhook-delivery.ts
@@ -73,5 +73,10 @@ export async function processWebhookDelivery(job: IJob<WebhookDeliveryJobData>):
   const delay = BACKOFF_SCHEDULE_MS[Math.min(attemptNumber - 1, BACKOFF_SCHEDULE_MS.length - 1)];
   const nextAttemptAt = new Date(Date.now() + delay);
   await webhookDeliveryService.markRetrying(delivery.id, attemptNumber, nextAttemptAt, result.error ?? 'delivery failed');
-  await queue.add('deliver', { deliveryId: delivery.id }, { delay, maxAttempts: 1 });
+  // Per-attempt jobKey dedupes a retry if two workers race the same job.
+  await queue.add('deliver', { deliveryId: delivery.id }, {
+    delay,
+    maxAttempts: 1,
+    jobKey: `webhook-retry-${delivery.id}-${attemptNumber}`,
+  });
 }

--- a/packages/backend/src/queue/jobs/webhook-delivery.ts
+++ b/packages/backend/src/queue/jobs/webhook-delivery.ts
@@ -1,0 +1,77 @@
+/**
+ * Queued webhook delivery (#218). One attempt per job run; on a retryable
+ * failure the job re-enqueues itself with the next backoff delay until
+ * max_attempts, then the delivery goes to the DLQ (status='dead'). This manual
+ * re-enqueue keeps retry behaviour identical on both queue backends.
+ */
+import type { IJob } from '../abstractions/types.js';
+import { config } from '../../config/index.js';
+import { createQueue } from '../connection.js';
+import { deliverOnce, WEBHOOK_DELIVERY_QUEUE } from '../../modules/webhooks/dispatcher.js';
+import { webhookDeliveryService } from '../../modules/webhooks/service.js';
+import { OrgConcurrencyLimiter } from '../../modules/webhooks/concurrency.js';
+import type { WebhookDeliveryJobData } from '../../modules/webhooks/types.js';
+
+export const BACKOFF_SCHEDULE_MS = [1_000, 5_000, 25_000, 120_000, 600_000];
+
+const limiter = new OrgConcurrencyLimiter({
+  perOrg: config.WEBHOOK_PER_ORG_CONCURRENCY,
+  global: config.WEBHOOK_GLOBAL_CONCURRENCY,
+});
+
+const queue = createQueue<WebhookDeliveryJobData>(WEBHOOK_DELIVERY_QUEUE);
+
+export async function processWebhookDelivery(job: IJob<WebhookDeliveryJobData>): Promise<void> {
+  const delivery = await webhookDeliveryService.getDelivery(job.data.deliveryId);
+  if (!delivery) {
+    console.warn(`[WebhookDelivery] delivery ${job.data.deliveryId} not found, skipping`);
+    return;
+  }
+  if (delivery.status === 'delivered' || delivery.status === 'dead') {
+    return; // idempotent: already terminal
+  }
+
+  const meta = (delivery.metadata ?? {}) as Record<string, unknown>;
+  const attemptNumber = delivery.attempt_count + 1;
+
+  const result = await limiter.run(delivery.organization_id, () =>
+    deliverOnce({
+      url: delivery.url,
+      body: meta.payload,
+      organizationId: delivery.organization_id,
+      eventType: delivery.event_type,
+      signingSecret: (meta.signingSecret as string) ?? undefined,
+      headers: (meta.headers as Record<string, string>) ?? undefined,
+      channelId: (meta.channelId as string) ?? undefined,
+      ruleId: (meta.ruleId as string) ?? undefined,
+    })
+  );
+
+  await webhookDeliveryService.recordAttempt(
+    delivery.id,
+    {
+      attemptNumber,
+      statusCode: result.statusCode ?? null,
+      durationMs: result.durationMs,
+      responseExcerpt: result.responseExcerpt ?? null,
+      error: result.error ?? null,
+    },
+    config.WEBHOOK_DELIVERY_LOG_LIMIT
+  );
+
+  if (result.success) {
+    await webhookDeliveryService.markDelivered(delivery.id);
+    return;
+  }
+
+  const canRetry = result.retryable && attemptNumber < delivery.max_attempts;
+  if (!canRetry) {
+    await webhookDeliveryService.markDead(delivery.id, result.error ?? 'delivery failed');
+    return;
+  }
+
+  const delay = BACKOFF_SCHEDULE_MS[Math.min(attemptNumber - 1, BACKOFF_SCHEDULE_MS.length - 1)];
+  const nextAttemptAt = new Date(Date.now() + delay);
+  await webhookDeliveryService.markRetrying(delivery.id, attemptNumber, nextAttemptAt, result.error ?? 'delivery failed');
+  await queue.add('deliver', { deliveryId: delivery.id }, { delay, maxAttempts: 1 });
+}

--- a/packages/backend/src/queue/jobs/webhook-delivery.ts
+++ b/packages/backend/src/queue/jobs/webhook-delivery.ts
@@ -66,7 +66,7 @@ export async function processWebhookDelivery(job: IJob<WebhookDeliveryJobData>):
 
   const canRetry = result.retryable && attemptNumber < delivery.max_attempts;
   if (!canRetry) {
-    await webhookDeliveryService.markDead(delivery.id, result.error ?? 'delivery failed');
+    await webhookDeliveryService.markDead(delivery.id, attemptNumber, result.error ?? 'delivery failed');
     return;
   }
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -48,6 +48,7 @@ import { auditLogRoutes, auditLogService } from './modules/audit-log/index.js';
 import { bootstrapService } from './modules/bootstrap/index.js';
 import { runDataAvailabilityBackfill } from './modules/projects/data-availability-backfill.js';
 import { notificationChannelsRoutes } from './modules/notification-channels/index.js';
+import { webhookDeliveriesRoutes } from './modules/webhooks/routes.js';
 import internalLoggingPlugin from './plugins/internal-logging-plugin.js';
 import { initializeInternalLogging, shutdownInternalLogging } from './utils/internal-logger.js';
 import websocketPlugin from './plugins/websocket.js';
@@ -178,6 +179,7 @@ export async function build(opts = {}) {
   await fastify.register(projectsRoutes, { prefix: '/api/v1/projects' });
   await fastify.register(notificationsRoutes, { prefix: '/api/v1/notifications' });
   await fastify.register(notificationChannelsRoutes, { prefix: '/api/v1/notification-channels' });
+  await fastify.register(webhookDeliveriesRoutes, { prefix: '/api/v1/webhooks' });
   await fastify.register(onboardingRoutes, { prefix: '/api/v1/onboarding' });
   await fastify.register(alertsRoutes, { prefix: '/api/v1/alerts' });
   await fastify.register(detectionPacksRoutes, { prefix: '/api/v1/detection-packs' });

--- a/packages/backend/src/tests/modules/alerts/worker-reliability.test.ts
+++ b/packages/backend/src/tests/modules/alerts/worker-reliability.test.ts
@@ -8,11 +8,19 @@ import {
 import { alertsService } from '../../../modules/alerts/service.js';
 import { processAlertNotification, AlertNotificationData } from '../../../queue/jobs/alert-notification.js';
 
+// Mock webhookDispatcher so webhook enqueues don't hit real HTTP
+const { enqueueMock } = vi.hoisted(() => ({ enqueueMock: vi.fn() }));
+vi.mock('../../../modules/webhooks/index.js', () => ({
+    webhookDispatcher: { enqueue: enqueueMock },
+}));
+
 describe('Alert Worker Reliability', () => {
     let originalFetch: typeof global.fetch;
 
     beforeEach(async () => {
         originalFetch = global.fetch;
+        enqueueMock.mockReset();
+        enqueueMock.mockResolvedValue({ deliveryId: 'del-1' });
 
         await db.deleteFrom('logs').execute();
         await db.deleteFrom('alert_history').execute();
@@ -117,14 +125,14 @@ describe('Alert Worker Reliability', () => {
                 .returningAll()
                 .executeTakeFirstOrThrow();
 
-            // Create a webhook notification channel with invalid URL
+            // Create a webhook notification channel
             const [channel] = await db
                 .insertInto('notification_channels')
                 .values({
                     organization_id: organization.id,
-                    name: 'Failed Webhook Channel',
+                    name: 'Webhook Channel',
                     type: 'webhook',
-                    config: { url: 'http://localhost:99999/nonexistent' },
+                    config: { url: 'https://example.com/alert-hook' },
                     enabled: true,
                 })
                 .returningAll()
@@ -150,24 +158,31 @@ describe('Alert Worker Reliability', () => {
             const triggered = await alertsService.checkAlertRules();
             expect(triggered).toHaveLength(1);
 
-            // Process notification - the function records errors internally
-            // and may or may not throw depending on whether all notifications fail
-            try {
-                await processAlertNotification({ data: triggered[0] });
-            } catch (e) {
-                // Expected if webhook is the only notification method and it fails
-            }
+            // Process notification - with async webhook dispatch, the consumer job
+            // always completes without throwing even if the eventual HTTP delivery fails.
+            // The actual HTTP call (and any retry/error) happens inside the dispatcher
+            // worker, not here.
+            await expect(
+                processAlertNotification({ data: triggered[0] })
+            ).resolves.not.toThrow();
 
-            // Verify error was recorded in history
+            // The dispatcher should have been asked to enqueue the webhook
+            expect(enqueueMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    url: 'https://example.com/alert-hook',
+                    organizationId: organization.id,
+                    eventType: 'alert',
+                })
+            );
+
+            // History should be marked as notified (no synchronous error)
             const history = await db
                 .selectFrom('alert_history')
                 .selectAll()
                 .where('id', '=', triggered[0].historyId)
                 .executeTakeFirst();
 
-            // The alert should have an error recorded because webhook failed
-            expect(history?.error).toBeTruthy();
-            expect(history?.error).toContain('Webhook failed');
+            expect(history?.notified).toBe(true);
         });
     });
 

--- a/packages/backend/src/tests/modules/webhooks/concurrency.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/concurrency.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { OrgConcurrencyLimiter } from '../../../modules/webhooks/concurrency.js';
+
+describe('OrgConcurrencyLimiter', () => {
+  it('runs up to N tasks per org concurrently and queues the rest', async () => {
+    const limiter = new OrgConcurrencyLimiter({ perOrg: 2, global: 100 });
+    let active = 0;
+    let maxActive = 0;
+    const task = async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+    };
+    await Promise.all(Array.from({ length: 6 }, () => limiter.run('org-1', task)));
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it('isolates orgs from each other', async () => {
+    const limiter = new OrgConcurrencyLimiter({ perOrg: 1, global: 100 });
+    const order: string[] = [];
+    await Promise.all([
+      limiter.run('a', async () => { order.push('a'); }),
+      limiter.run('b', async () => { order.push('b'); }),
+    ]);
+    expect(order.sort()).toEqual(['a', 'b']);
+  });
+
+  it('releases a slot even when the task throws', async () => {
+    const limiter = new OrgConcurrencyLimiter({ perOrg: 1, global: 100 });
+    await expect(limiter.run('org-1', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    await expect(limiter.run('org-1', async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/packages/backend/src/tests/modules/webhooks/deliver-once.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/deliver-once.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../config/index.js', () => ({
+  config: { MONITOR_ALLOW_PRIVATE_TARGETS: false, WEBHOOK_REQUEST_TIMEOUT_MS: 10000 },
+}));
+
+const { safeFetchMock } = vi.hoisted(() => ({ safeFetchMock: vi.fn() }));
+vi.mock('../../../utils/ssrf-guard.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/ssrf-guard.js')>(
+    '../../../utils/ssrf-guard.js'
+  );
+  return { ...actual, safeFetch: safeFetchMock };
+});
+
+const hooksMock = vi.hoisted(() => ({ hasHandlers: vi.fn(() => false), run: vi.fn() }));
+vi.mock('../../../hooks/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../hooks/index.js')>(
+    '../../../hooks/index.js'
+  );
+  return { ...actual, hooks: hooksMock };
+});
+
+import { deliverOnce } from '../../../modules/webhooks/dispatcher.js';
+import { SsrfBlockedError } from '../../../utils/ssrf-guard.js';
+import { verifySignature } from '../../../modules/webhooks/signing.js';
+
+beforeEach(() => {
+  safeFetchMock.mockReset();
+  hooksMock.hasHandlers.mockReturnValue(false);
+  hooksMock.run.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+function okResponse(status = 200, text = 'ok') {
+  return { ok: status >= 200 && status < 300, status, statusText: 'OK', text: async () => text };
+}
+
+describe('deliverOnce', () => {
+  it('signs the body when a secret is provided', async () => {
+    safeFetchMock.mockResolvedValue(okResponse());
+    await deliverOnce({
+      url: 'https://example.com/hook',
+      body: { a: 1 },
+      organizationId: 'org-1',
+      eventType: 'alert',
+      signingSecret: 'whsec_x',
+    });
+    const [, init] = safeFetchMock.mock.calls[0];
+    const ts = Number(init.headers['X-Logtide-Timestamp']);
+    const sig = init.headers['X-Logtide-Signature'].split('v1=')[1];
+    expect(verifySignature('whsec_x', ts, init.body, sig)).toBe(true);
+  });
+
+  it('returns success for 2xx', async () => {
+    safeFetchMock.mockResolvedValue(okResponse(204, ''));
+    const r = await deliverOnce({ url: 'https://e.com', body: {}, organizationId: 'o', eventType: 'alert' });
+    expect(r.success).toBe(true);
+    expect(r.statusCode).toBe(204);
+  });
+
+  it('classifies 5xx as retryable and 4xx as non-retryable', async () => {
+    safeFetchMock.mockResolvedValueOnce(okResponse(503, 'down'));
+    const a = await deliverOnce({ url: 'https://e.com', body: {}, organizationId: 'o', eventType: 'alert' });
+    expect(a.success).toBe(false);
+    expect(a.retryable).toBe(true);
+
+    safeFetchMock.mockResolvedValueOnce(okResponse(400, 'bad'));
+    const b = await deliverOnce({ url: 'https://e.com', body: {}, organizationId: 'o', eventType: 'alert' });
+    expect(b.retryable).toBe(false);
+  });
+
+  it('maps SSRF block to a non-retryable failure', async () => {
+    safeFetchMock.mockRejectedValue(new SsrfBlockedError('blocked'));
+    const r = await deliverOnce({ url: 'http://169.254.169.254', body: {}, organizationId: 'o', eventType: 'alert' });
+    expect(r.success).toBe(false);
+    expect(r.retryable).toBe(false);
+    expect(r.error).toMatch(/private\/internal/);
+  });
+
+  it('treats hook rejection as a non-retryable failure', async () => {
+    const { HookRejectionError } = await import('../../../hooks/index.js');
+    hooksMock.hasHandlers.mockReturnValue(true);
+    hooksMock.run.mockRejectedValue(new HookRejectionError('nope'));
+    const r = await deliverOnce({ url: 'https://e.com', body: {}, organizationId: 'o', eventType: 'alert' });
+    expect(r.success).toBe(false);
+    expect(r.retryable).toBe(false);
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/tests/modules/webhooks/enqueue.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/enqueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { addMock, createDeliveryMock } = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  createDeliveryMock: vi.fn(),
+}));
+
+vi.mock('../../../queue/connection.js', () => ({
+  createQueue: vi.fn(() => ({ add: addMock, close: vi.fn() })),
+}));
+
+vi.mock('../../../modules/webhooks/service.js', () => ({
+  webhookDeliveryService: { createDelivery: createDeliveryMock },
+}));
+
+vi.mock('../../../config/index.js', () => ({ config: { WEBHOOK_MAX_ATTEMPTS: 5 } }));
+
+import { webhookDispatcher } from '../../../modules/webhooks/dispatcher.js';
+
+beforeEach(() => {
+  addMock.mockReset().mockResolvedValue({ id: 'job-1' });
+  createDeliveryMock.mockReset().mockResolvedValue({ id: 'del-1' });
+});
+
+describe('webhookDispatcher.enqueue', () => {
+  it('persists a delivery and enqueues a job with a deterministic jobKey', async () => {
+    await webhookDispatcher.enqueue({
+      url: 'https://e.com/hook', payload: { a: 1 }, organizationId: 'org-1', eventType: 'alert', eventId: 'evt-9',
+    });
+    expect(createDeliveryMock).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'org-1', eventType: 'alert', eventId: 'evt-9', url: 'https://e.com/hook', maxAttempts: 5,
+    }));
+    const [, jobData, opts] = addMock.mock.calls[0];
+    expect(jobData).toEqual({ deliveryId: 'del-1' });
+    expect(opts.jobKey).toBe('webhook:org-1:alert:evt-9');
+  });
+
+  it('derives a stable eventId when none is given', async () => {
+    await webhookDispatcher.enqueue({ url: 'https://e.com', payload: { a: 1 }, organizationId: 'o', eventType: 'alert' });
+    const firstKey = addMock.mock.calls[0][2].jobKey;
+    addMock.mockClear(); createDeliveryMock.mockClear();
+    await webhookDispatcher.enqueue({ url: 'https://e.com', payload: { a: 1 }, organizationId: 'o', eventType: 'alert' });
+    expect(addMock.mock.calls[0][2].jobKey).toBe(firstKey);
+  });
+});

--- a/packages/backend/src/tests/modules/webhooks/enqueue.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/enqueue.test.ts
@@ -32,7 +32,17 @@ describe('webhookDispatcher.enqueue', () => {
     }));
     const [, jobData, opts] = addMock.mock.calls[0];
     expect(jobData).toEqual({ deliveryId: 'del-1' });
-    expect(opts.jobKey).toBe('webhook:org-1:alert:evt-9');
+    // jobKey must be deterministic and contain no ':' (BullMQ forbids it in job ids).
+    expect(opts.jobKey).toMatch(/^webhook-[0-9a-f]{64}$/);
+  });
+
+  it('builds the same jobKey for the same org/eventType/eventId', async () => {
+    const args = { url: 'https://e.com/hook', payload: { a: 1 }, organizationId: 'org-1', eventType: 'alert', eventId: 'evt-9' };
+    await webhookDispatcher.enqueue(args);
+    const key1 = addMock.mock.calls[0][2].jobKey;
+    addMock.mockClear(); createDeliveryMock.mockClear();
+    await webhookDispatcher.enqueue(args);
+    expect(addMock.mock.calls[0][2].jobKey).toBe(key1);
   });
 
   it('derives a stable eventId when none is given', async () => {

--- a/packages/backend/src/tests/modules/webhooks/routes.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/routes.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { db } from '../../../database/index.js';
+import { webhookDeliveriesRoutes } from '../../../modules/webhooks/routes.js';
+import { webhookDeliveryService } from '../../../modules/webhooks/service.js';
+import { createTestContext, createTestUser } from '../../helpers/factories.js';
+import crypto from 'crypto';
+
+// Mock the dispatcher so enqueueExisting does not need a live Redis/BullMQ queue.
+vi.mock('../../../modules/webhooks/dispatcher.js', () => ({
+  webhookDispatcher: {
+    enqueueExisting: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Helper to create a session for a user
+async function createTestSession(userId: string) {
+  const token = crypto.randomBytes(32).toString('hex');
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+  await db
+    .insertInto('sessions')
+    .values({
+      user_id: userId,
+      token,
+      expires_at: expiresAt,
+    })
+    .execute();
+
+  return { token, expiresAt };
+}
+
+describe('Webhook Deliveries Routes', () => {
+  let app: FastifyInstance;
+  let authToken: string;
+  let testUser: any;
+  let testOrganization: any;
+
+  beforeAll(async () => {
+    app = Fastify();
+    await app.register(webhookDeliveriesRoutes, { prefix: '/api/v1/webhooks' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    // Clean up in dependency order
+    await db.deleteFrom('webhook_delivery_attempts').execute();
+    await db.deleteFrom('webhook_deliveries').execute();
+    await db.deleteFrom('organization_members').execute();
+    await db.deleteFrom('api_keys').execute();
+    await db.deleteFrom('projects').execute();
+    await db.deleteFrom('organizations').execute();
+    await db.deleteFrom('sessions').execute();
+    await db.deleteFrom('users').execute();
+
+    const context = await createTestContext();
+    testUser = context.user;
+    testOrganization = context.organization;
+
+    const session = await createTestSession(testUser.id);
+    authToken = session.token;
+  });
+
+  describe('GET /api/v1/webhooks/deliveries', () => {
+    it('should return 200 with deliveries for the org', async () => {
+      await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-1',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.deliveries).toHaveLength(1);
+      expect(body.deliveries[0].organization_id).toBe(testOrganization.id);
+    });
+
+    it('should filter deliveries by status', async () => {
+      await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-pending',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      const dead = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-dead',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      await webhookDeliveryService.markDead(dead.id, 3, 'too many failures');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries?organizationId=${testOrganization.id}&status=dead`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.deliveries).toHaveLength(1);
+      expect(body.deliveries[0].status).toBe('dead');
+    });
+
+    it('should return 400 when organizationId is missing', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/webhooks/deliveries',
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when organizationId is not a uuid', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/webhooks/deliveries?organizationId=not-a-uuid',
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 401 without auth token', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries?organizationId=${testOrganization.id}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should return 403 for non-member', async () => {
+      const otherUser = await createTestUser({ email: 'other@test.com' });
+      const otherSession = await createTestSession(otherUser.id);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${otherSession.token}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/v1/webhooks/deliveries/:id', () => {
+    it('should return 200 with delivery and attempts', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-2',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.delivery.id).toBe(delivery.id);
+      expect(Array.isArray(body.attempts)).toBe(true);
+    });
+
+    it('should return 404 for non-existent delivery', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/webhooks/deliveries/00000000-0000-0000-0000-000000000000',
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 403 for a delivery belonging to another org', async () => {
+      // Create delivery for a different org that this user is not a member of
+      const otherUser = await createTestUser({ email: 'other2@test.com' });
+      const otherOrg = await db
+        .insertInto('organizations')
+        .values({ name: 'Other Org', slug: `other-org-${Date.now()}`, owner_id: otherUser.id })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await db
+        .insertInto('organization_members')
+        .values({ user_id: otherUser.id, organization_id: otherOrg.id, role: 'owner' })
+        .execute();
+
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: otherOrg.id,
+        eventType: 'alert',
+        eventId: 'evt-other',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe('POST /api/v1/webhooks/deliveries/:id/replay', () => {
+    it('should replay a dead delivery', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-replay',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      await webhookDeliveryService.markDead(delivery.id, 3, 'test error');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}/replay`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.delivery.status).toBe('pending');
+    });
+
+    it('should replay a failed delivery', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-replay-failed',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      await webhookDeliveryService.markRetrying(delivery.id, 1, new Date(Date.now() + 60000), 'transient error');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}/replay`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.delivery.status).toBe('pending');
+    });
+
+    it('should return 409 when delivery is already delivered', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-delivered',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      await webhookDeliveryService.markDelivered(delivery.id);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}/replay`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+
+    it('should return 409 when delivery is still pending', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-pending-replay',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}/replay`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+
+    it('should return 404 for non-existent delivery', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/webhooks/deliveries/00000000-0000-0000-0000-000000000000/replay',
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 403 for non-admin member', async () => {
+      const delivery = await webhookDeliveryService.createDelivery({
+        organizationId: testOrganization.id,
+        eventType: 'alert',
+        eventId: 'evt-member-replay',
+        url: 'https://example.com/hook',
+        maxAttempts: 3,
+      });
+      await webhookDeliveryService.markDead(delivery.id, 3, 'test error');
+
+      const memberUser = await createTestUser({ email: 'member@test.com' });
+      await db
+        .insertInto('organization_members')
+        .values({
+          user_id: memberUser.id,
+          organization_id: testOrganization.id,
+          role: 'member',
+        })
+        .execute();
+      const memberSession = await createTestSession(memberUser.id);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/v1/webhooks/deliveries/${delivery.id}/replay`,
+        headers: { Authorization: `Bearer ${memberSession.token}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+});

--- a/packages/backend/src/tests/modules/webhooks/service.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/service.test.ts
@@ -1,7 +1,24 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { db } from '../../../database/index.js';
 import { createTestOrganization } from '../../helpers/factories.js';
-import { webhookDeliveryService } from '../../../modules/webhooks/service.js';
+import { webhookDeliveryService, redactDeliveryForApi } from '../../../modules/webhooks/service.js';
+
+describe('redactDeliveryForApi', () => {
+  it('strips signingSecret and headers from metadata, keeps the rest', () => {
+    const row = {
+      id: 'd', metadata: { payload: { a: 1 }, signingSecret: 'whsec_x', headers: { Authorization: 'Bearer z' }, ruleName: 'r' },
+    } as any;
+    const redacted = redactDeliveryForApi(row);
+    expect(redacted.metadata).toEqual({ payload: { a: 1 }, ruleName: 'r' });
+    expect(redacted.metadata).not.toHaveProperty('signingSecret');
+    expect(redacted.metadata).not.toHaveProperty('headers');
+  });
+
+  it('passes through undefined and null metadata safely', () => {
+    expect(redactDeliveryForApi(undefined)).toBeUndefined();
+    expect(redactDeliveryForApi({ id: 'd', metadata: null } as any).metadata).toBeNull();
+  });
+});
 
 describe('webhookDeliveryService', () => {
   let orgId: string;

--- a/packages/backend/src/tests/modules/webhooks/service.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/service.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../../../database/index.js';
+import { createTestOrganization } from '../../helpers/factories.js';
+import { webhookDeliveryService } from '../../../modules/webhooks/service.js';
+
+describe('webhookDeliveryService', () => {
+  let orgId: string;
+  beforeEach(async () => {
+    const org = await createTestOrganization({});
+    orgId = org.id;
+  });
+
+  it('creates a pending delivery', async () => {
+    const d = await webhookDeliveryService.createDelivery({
+      organizationId: orgId,
+      eventType: 'alert',
+      eventId: 'evt-1',
+      url: 'https://e.com/hook',
+      maxAttempts: 5,
+      metadata: { foo: 'bar' },
+    });
+    expect(d.status).toBe('pending');
+    expect(d.attempt_count).toBe(0);
+  });
+
+  it('records attempts and prunes beyond the log limit', async () => {
+    const d = await webhookDeliveryService.createDelivery({
+      organizationId: orgId, eventType: 'alert', eventId: 'evt-2', url: 'https://e.com/hook', maxAttempts: 5,
+    });
+    for (let i = 1; i <= 5; i++) {
+      await webhookDeliveryService.recordAttempt(d.id, {
+        attemptNumber: i, statusCode: 500, durationMs: 10, error: 'boom', responseExcerpt: 'x',
+      }, 3); // keep last 3
+    }
+    const attempts = await db.selectFrom('webhook_delivery_attempts')
+      .selectAll().where('delivery_id', '=', d.id).execute();
+    expect(attempts.length).toBe(3);
+  });
+
+  it('transitions status and lists by status', async () => {
+    const d = await webhookDeliveryService.createDelivery({
+      organizationId: orgId, eventType: 'alert', eventId: 'evt-3', url: 'https://e.com', maxAttempts: 5,
+    });
+    await webhookDeliveryService.markDead(d.id, 'gave up');
+    const dead = await webhookDeliveryService.listDeliveries(orgId, { status: 'dead', limit: 50, offset: 0 });
+    expect(dead.map((x) => x.id)).toContain(d.id);
+  });
+
+  it('replays a dead delivery back to pending', async () => {
+    const d = await webhookDeliveryService.createDelivery({
+      organizationId: orgId, eventType: 'alert', eventId: 'evt-4', url: 'https://e.com', maxAttempts: 5,
+    });
+    await webhookDeliveryService.markDead(d.id, 'gave up');
+    const reset = await webhookDeliveryService.resetForReplay(d.id);
+    expect(reset?.status).toBe('pending');
+    expect(reset?.attempt_count).toBe(0);
+  });
+});

--- a/packages/backend/src/tests/modules/webhooks/service.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/service.test.ts
@@ -41,7 +41,7 @@ describe('webhookDeliveryService', () => {
     const d = await webhookDeliveryService.createDelivery({
       organizationId: orgId, eventType: 'alert', eventId: 'evt-3', url: 'https://e.com', maxAttempts: 5,
     });
-    await webhookDeliveryService.markDead(d.id, 'gave up');
+    await webhookDeliveryService.markDead(d.id, 3, 'gave up');
     const dead = await webhookDeliveryService.listDeliveries(orgId, { status: 'dead', limit: 50, offset: 0 });
     expect(dead.map((x) => x.id)).toContain(d.id);
   });
@@ -50,7 +50,7 @@ describe('webhookDeliveryService', () => {
     const d = await webhookDeliveryService.createDelivery({
       organizationId: orgId, eventType: 'alert', eventId: 'evt-4', url: 'https://e.com', maxAttempts: 5,
     });
-    await webhookDeliveryService.markDead(d.id, 'gave up');
+    await webhookDeliveryService.markDead(d.id, 3, 'gave up');
     const reset = await webhookDeliveryService.resetForReplay(d.id);
     expect(reset?.status).toBe('pending');
     expect(reset?.attempt_count).toBe(0);

--- a/packages/backend/src/tests/modules/webhooks/signing.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/signing.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { signBody, verifySignature, buildSignatureHeaders } from '../../../modules/webhooks/signing.js';
+
+describe('webhook signing', () => {
+  const secret = 'whsec_test';
+  const body = JSON.stringify({ hello: 'world' });
+  const ts = 1700000000;
+
+  it('produces a stable HMAC over `${ts}.${body}`', () => {
+    const a = signBody(secret, ts, body);
+    const b = signBody(secret, ts, body);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('verifies a correct signature and rejects a tampered one', () => {
+    const sig = signBody(secret, ts, body);
+    expect(verifySignature(secret, ts, body, sig)).toBe(true);
+    expect(verifySignature(secret, ts, body, sig.replace(/.$/, '0'))).toBe(false);
+    expect(verifySignature(secret, ts, '{"hello":"mars"}', sig)).toBe(false);
+  });
+
+  it('builds the documented headers', () => {
+    const headers = buildSignatureHeaders(secret, body, ts);
+    expect(headers['X-Logtide-Timestamp']).toBe('1700000000');
+    expect(headers['X-Logtide-Signature']).toBe(`t=1700000000,v1=${signBody(secret, ts, body)}`);
+  });
+});

--- a/packages/backend/src/tests/queue/error-notification.test.ts
+++ b/packages/backend/src/tests/queue/error-notification.test.ts
@@ -14,9 +14,11 @@ vi.mock('nodemailer', () => ({
   },
 }));
 
-// Mock fetch for webhooks
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// Mock webhookDispatcher
+const { enqueueMock } = vi.hoisted(() => ({ enqueueMock: vi.fn() }));
+vi.mock('../../modules/webhooks/index.js', () => ({
+  webhookDispatcher: { enqueue: enqueueMock },
+}));
 
 describe('Error Notification Job', () => {
   let testOrganization: any;
@@ -26,8 +28,8 @@ describe('Error Notification Job', () => {
   beforeEach(async () => {
     // Reset mocks
     vi.clearAllMocks();
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    enqueueMock.mockReset();
+    enqueueMock.mockResolvedValue({ deliveryId: 'del-1' });
 
     // Clean up tables
     await db.deleteFrom('notifications').execute();
@@ -268,19 +270,17 @@ describe('Error Notification Job', () => {
 
       await processErrorNotification(job);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/error-hook',
+      expect(enqueueMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: 'POST',
+          url: 'https://example.com/error-hook',
+          eventType: 'error',
+          payload: expect.objectContaining({
+            event_type: 'error',
+            exception_type: 'TypeError',
+            is_new: true,
+          }),
         })
       );
-
-      // Check payload
-      const [, options] = mockFetch.mock.calls[0];
-      const body = JSON.parse(options.body);
-      expect(body.event_type).toBe('error');
-      expect(body.exception_type).toBe('TypeError');
-      expect(body.is_new).toBe(true);
     });
 
     it('should use organization defaults when no specific channels', async () => {
@@ -322,9 +322,11 @@ describe('Error Notification Job', () => {
 
       await processErrorNotification(job);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/default-error',
-        expect.anything()
+      expect(enqueueMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://example.com/default-error',
+          eventType: 'error',
+        })
       );
     });
 
@@ -354,7 +356,7 @@ describe('Error Notification Job', () => {
     });
 
     it('should handle webhook errors gracefully', async () => {
-      mockFetch.mockRejectedValue(new Error('Connection refused'));
+      enqueueMock.mockRejectedValue(new Error('Connection refused'));
 
       const errorGroup = await createTestErrorGroup();
 

--- a/packages/backend/src/tests/queue/incident-notification.test.ts
+++ b/packages/backend/src/tests/queue/incident-notification.test.ts
@@ -14,9 +14,12 @@ vi.mock('nodemailer', () => ({
   },
 }));
 
-// Mock fetch for webhooks
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// Mock webhookDispatcher — SSRF guard, hook execution, retry/backoff are
+// all handled inside the dispatcher and covered by deliver-once.test.ts (#218).
+const { enqueueMock } = vi.hoisted(() => ({ enqueueMock: vi.fn() }));
+vi.mock('../../modules/webhooks/index.js', () => ({
+  webhookDispatcher: { enqueue: enqueueMock },
+}));
 
 describe('Incident Notification Job', () => {
   let testOrganization: any;
@@ -25,8 +28,7 @@ describe('Incident Notification Job', () => {
   beforeEach(async () => {
     // Reset mocks
     vi.clearAllMocks();
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    enqueueMock.mockReset().mockResolvedValue({ deliveryId: 'del-1' });
 
     // Clean up tables
     await db.deleteFrom('notifications').execute();
@@ -203,13 +205,14 @@ describe('Incident Notification Job', () => {
 
       await processIncidentNotification(job);
 
-      // Should call webhook
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/incident-hook',
+      // Should enqueue webhook via dispatcher
+      expect(enqueueMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
+          url: 'https://example.com/incident-hook',
+          eventType: 'incident',
+          payload: expect.objectContaining({
+            event_type: 'incident',
+            title: 'Test Incident',
           }),
         })
       );
@@ -249,15 +252,18 @@ describe('Incident Notification Job', () => {
 
       await processIncidentNotification(job);
 
-      // Should use default webhook
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/default-hook',
-        expect.anything()
+      // Should enqueue via dispatcher using the default webhook URL
+      expect(enqueueMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://example.com/default-hook',
+          eventType: 'incident',
+        })
       );
     });
 
     it('should handle webhook errors gracefully', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      // Simulate a dispatcher enqueue failure (e.g. DB down during persistence)
+      enqueueMock.mockRejectedValueOnce(new Error('Network error'));
 
       const [channel] = await db
         .insertInto('notification_channels')

--- a/packages/backend/src/tests/queue/jobs/alert-notification.test.ts
+++ b/packages/backend/src/tests/queue/jobs/alert-notification.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { processAlertNotification, type AlertNotificationData } from '../../../queue/jobs/alert-notification.js';
-import { hooks, HookRejectionError } from '../../../hooks/index.js';
+import { hooks } from '../../../hooks/index.js';
 import { db } from '../../../database/index.js';
 import { createTestContext, createTestUser } from '../../helpers/factories.js';
 
@@ -13,32 +13,12 @@ vi.mock('nodemailer', () => ({
     },
 }));
 
-// Mock fetch for webhooks
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
-
-// safeFetch normally resolves DNS, validates against the SSRF range check and
-// revalidates every redirect hop. In these unit tests we don't hit the network
-// or DNS: re-run the real IP-range check for IP-literal hosts so the SSRF-block
-// assertions stay meaningful, treat hostnames as external, and delegate the
-// actual request to the mocked global.fetch (with the original string URL, which
-// the payload/header assertions rely on). Full DNS + redirect-hop coverage lives
-// in ssrf-guard.test.ts. SsrfBlockedError stays the real class.
-vi.mock('../../../utils/ssrf-guard.js', async (importOriginal) => {
-    const actual: any = await importOriginal();
-    const { isIP } = await import('net');
-    return {
-        ...actual,
-        safeFetch: async (rawUrl: string, init: any) => {
-            const raw = new URL(rawUrl).hostname;
-            const host = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
-            if (isIP(host) && actual.isBlockedAddress(host)) {
-                throw new actual.SsrfBlockedError(`Target address ${host} is in a blocked range`);
-            }
-            return (global.fetch as any)(rawUrl, init);
-        },
-    };
-});
+// Mock webhookDispatcher — SSRF guard, hook execution, retry/backoff are
+// all handled inside the dispatcher and covered by deliver-once.test.ts (#218).
+const { enqueueMock } = vi.hoisted(() => ({ enqueueMock: vi.fn() }));
+vi.mock('../../../modules/webhooks/index.js', () => ({
+    webhookDispatcher: { enqueue: enqueueMock },
+}));
 
 // Mock alertsService
 vi.mock('../../../modules/alerts/index.js', () => ({
@@ -88,7 +68,7 @@ describe('Alert Notification Job', () => {
         await db.deleteFrom('users').execute();
 
         vi.clearAllMocks();
-        mockFetch.mockReset();
+        enqueueMock.mockReset().mockResolvedValue({ deliveryId: 'del-1' });
         mockGetAlertRuleChannels.mockReset();
         mockGetAlertRuleChannels.mockResolvedValue([]);
         hooks.clear();
@@ -162,13 +142,8 @@ describe('Alert Notification Job', () => {
             );
         });
 
-        it('should send webhook notification when webhook channel is configured', async () => {
+        it('should enqueue webhook when webhook channel is configured', async () => {
             const { organization, project } = await createTestContext();
-
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                statusText: 'OK',
-            });
 
             // Mock notification channel with webhook
             mockGetAlertRuleChannels.mockResolvedValueOnce([{
@@ -193,23 +168,20 @@ describe('Alert Notification Job', () => {
 
             await processAlertNotification({ data: jobData });
 
-            expect(mockFetch).toHaveBeenCalledWith(
-                'https://hooks.example.com/alert',
+            expect(enqueueMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    method: 'POST',
-                    headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+                    url: 'https://hooks.example.com/alert',
+                    eventType: 'alert',
+                    payload: expect.objectContaining({
+                        alert_name: 'Webhook Alert Rule',
+                    }),
                 })
             );
         });
 
-        it('should handle webhook failure gracefully', async () => {
+        it('should enqueue webhook and complete job even if delivery is deferred', async () => {
             const { organization, project } = await createTestContext();
             const { alertsService } = await import('../../../modules/alerts/index.js');
-
-            mockFetch.mockResolvedValueOnce({
-                ok: false,
-                statusText: 'Internal Server Error',
-            });
 
             // Mock notification channel with webhook
             mockGetAlertRuleChannels.mockResolvedValueOnce([{
@@ -234,11 +206,12 @@ describe('Alert Notification Job', () => {
 
             await processAlertNotification({ data: jobData });
 
-            // Should mark as notified with error
-            expect(alertsService.markAsNotified).toHaveBeenCalledWith(
-                jobData.historyId,
-                expect.stringContaining('Webhook failed')
+            // Webhook delivery is now async (dispatcher handles retries);
+            // the consumer job should still enqueue and mark as notified without error.
+            expect(enqueueMock).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'https://hooks.example.com/failing' })
             );
+            expect(alertsService.markAsNotified).toHaveBeenCalledWith(jobData.historyId);
         });
 
         it('should skip email when no recipients configured', async () => {
@@ -354,13 +327,8 @@ describe('Alert Notification Job', () => {
             );
         });
 
-        it('should send both email and webhook notifications', async () => {
+        it('should send both email and enqueue webhook when both channels configured', async () => {
             const { organization, project } = await createTestContext();
-
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                statusText: 'OK',
-            });
 
             // Mock notification channels with both email and webhook
             mockGetAlertRuleChannels.mockResolvedValueOnce([
@@ -401,16 +369,13 @@ describe('Alert Notification Job', () => {
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining('Webhook notification sent')
             );
-            expect(mockFetch).toHaveBeenCalled();
+            expect(enqueueMock).toHaveBeenCalledWith(
+                expect.objectContaining({ url: 'https://hooks.example.com/alert' })
+            );
         });
 
         it('should include correct data in webhook payload', async () => {
             const { organization, project } = await createTestContext();
-
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                statusText: 'OK',
-            });
 
             // Mock notification channel with webhook
             mockGetAlertRuleChannels.mockResolvedValueOnce([{
@@ -435,14 +400,19 @@ describe('Alert Notification Job', () => {
 
             await processAlertNotification({ data: jobData });
 
-            const callArgs = mockFetch.mock.calls[0];
-            const body = JSON.parse(callArgs[1].body);
-
-            expect(body.alert_name).toBe('Webhook Payload Test');
-            expect(body.log_count).toBe(150);
-            expect(body.threshold).toBe(100);
-            expect(body.time_window).toBe(10);
-            expect(body.timestamp).toBeDefined();
+            expect(enqueueMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    url: 'https://hooks.example.com/alert',
+                    eventType: 'alert',
+                    payload: expect.objectContaining({
+                        alert_name: 'Webhook Payload Test',
+                        log_count: 150,
+                        threshold: 100,
+                        time_window: 10,
+                        timestamp: expect.any(String),
+                    }),
+                })
+            );
         });
 
         it('should ignore legacy email_recipients field and only use channels', async () => {
@@ -473,11 +443,11 @@ describe('Alert Notification Job', () => {
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining('No email recipients configured')
             );
-            // Should NOT send webhook despite legacy field
+            // Should NOT enqueue webhook despite legacy field
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining('No webhook configured')
             );
-            expect(mockFetch).not.toHaveBeenCalled();
+            expect(enqueueMock).not.toHaveBeenCalled();
         });
 
         it('should mark notification as complete after successful processing', async () => {
@@ -506,77 +476,7 @@ describe('Alert Notification Job', () => {
     });
 
     describe('SSRF protection and null historyId', () => {
-        it('should block webhook to private IP addresses', async () => {
-            const { organization, project } = await createTestContext();
-            const { alertsService } = await import('../../../modules/alerts/index.js');
-
-            // Mock notification channel with webhook pointing to loopback
-            mockGetAlertRuleChannels.mockResolvedValueOnce([{
-                id: '00000000-0000-0000-0000-000000000010',
-                type: 'webhook',
-                enabled: true,
-                config: { url: 'http://127.0.0.1/webhook' },
-            }]);
-
-            const jobData: AlertNotificationData = {
-                historyId: '00000000-0000-0000-0000-000000000001',
-                rule_id: '00000000-0000-0000-0000-000000000002',
-                rule_name: 'SSRF Loopback Test',
-                organization_id: organization.id,
-                project_id: project.id,
-                log_count: 100,
-                threshold: 50,
-                time_window: 5,
-                email_recipients: [],
-                webhook_url: undefined,
-            };
-
-            await processAlertNotification({ data: jobData });
-
-            // fetch should NOT have been called since the URL is blocked
-            expect(mockFetch).not.toHaveBeenCalled();
-            // markAsNotified should be called with an error about private addresses
-            expect(alertsService.markAsNotified).toHaveBeenCalledWith(
-                jobData.historyId,
-                expect.stringContaining('private/internal')
-            );
-        });
-
-        it('should block webhook to link-local addresses', async () => {
-            const { organization, project } = await createTestContext();
-            const { alertsService } = await import('../../../modules/alerts/index.js');
-
-            // Mock notification channel with webhook pointing to cloud metadata endpoint
-            mockGetAlertRuleChannels.mockResolvedValueOnce([{
-                id: '00000000-0000-0000-0000-000000000010',
-                type: 'webhook',
-                enabled: true,
-                config: { url: 'http://169.254.169.254/latest/meta-data/' },
-            }]);
-
-            const jobData: AlertNotificationData = {
-                historyId: '00000000-0000-0000-0000-000000000001',
-                rule_id: '00000000-0000-0000-0000-000000000002',
-                rule_name: 'SSRF Link-Local Test',
-                organization_id: organization.id,
-                project_id: project.id,
-                log_count: 100,
-                threshold: 50,
-                time_window: 5,
-                email_recipients: [],
-                webhook_url: undefined,
-            };
-
-            await processAlertNotification({ data: jobData });
-
-            // fetch should NOT have been called since the URL is blocked
-            expect(mockFetch).not.toHaveBeenCalled();
-            // markAsNotified should be called with an error about private addresses
-            expect(alertsService.markAsNotified).toHaveBeenCalledWith(
-                jobData.historyId,
-                expect.stringContaining('private/internal')
-            );
-        });
+        // SSRF/hook behavior moved to the webhook dispatcher (#218); covered by deliver-once.test.ts.
 
         it('should skip markAsNotified when historyId is null', async () => {
             const { organization, project } = await createTestContext();
@@ -623,137 +523,7 @@ describe('Alert Notification Job', () => {
                 jobData.historyId
             );
         });
-
-        it('should include HTTP status code in webhook error', async () => {
-            const { organization, project } = await createTestContext();
-            const { alertsService } = await import('../../../modules/alerts/index.js');
-
-            mockFetch.mockResolvedValueOnce({
-                ok: false,
-                status: 503,
-                statusText: '',
-                text: () => Promise.resolve('Service Unavailable'),
-            });
-
-            // Mock notification channel with webhook
-            mockGetAlertRuleChannels.mockResolvedValueOnce([{
-                id: '00000000-0000-0000-0000-000000000010',
-                type: 'webhook',
-                enabled: true,
-                config: { url: 'https://hooks.example.com/failing-503' },
-            }]);
-
-            const jobData: AlertNotificationData = {
-                historyId: '00000000-0000-0000-0000-000000000001',
-                rule_id: '00000000-0000-0000-0000-000000000002',
-                rule_name: 'HTTP Status Code Test',
-                organization_id: organization.id,
-                project_id: project.id,
-                log_count: 100,
-                threshold: 50,
-                time_window: 5,
-                email_recipients: [],
-                webhook_url: undefined,
-            };
-
-            await processAlertNotification({ data: jobData });
-
-            // markAsNotified should be called with an error containing the 503 status
-            expect(alertsService.markAsNotified).toHaveBeenCalledWith(
-                jobData.historyId,
-                expect.stringContaining('503')
-            );
-        });
     });
 
-    describe('beforeWebhookDispatch hook (legacy alert webhook)', () => {
-        it('hook receives ruleId and org; mutation reaches the outbound request', async () => {
-            const { organization, project } = await createTestContext();
-
-            mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', text: async () => '' });
-
-            mockGetAlertRuleChannels.mockResolvedValueOnce([{
-                id: '00000000-0000-0000-0000-000000000010',
-                type: 'webhook',
-                enabled: true,
-                config: { url: 'https://example.com/legacy-hook' },
-            }]);
-
-            let seen: any = null;
-            hooks.register('beforeWebhookDispatch', async (ctx) => {
-                seen = {
-                    ruleId: ctx.ruleId,
-                    organizationId: ctx.organizationId,
-                    targetHost: ctx.targetHost,
-                    channelId: ctx.channelId,
-                    url: ctx.url,
-                };
-                ctx.headers['X-Injected'] = 'yes';
-            });
-
-            const jobData: AlertNotificationData = {
-                historyId: '00000000-0000-0000-0000-000000000001',
-                rule_id: '00000000-0000-0000-0000-000000000002',
-                rule_name: 'Hook Test Rule',
-                organization_id: organization.id,
-                project_id: project.id,
-                log_count: 100,
-                threshold: 50,
-                time_window: 5,
-                email_recipients: [],
-                webhook_url: undefined,
-            };
-
-            await processAlertNotification({ data: jobData });
-
-            expect(seen).not.toBeNull();
-            expect(seen.targetHost).toBe('example.com');
-            expect(seen.ruleId).toBe(jobData.rule_id);
-            expect(seen.url).toBe('https://example.com/legacy-hook');
-            expect(seen.organizationId).toBe(organization.id);
-            expect(seen.channelId).toBe('00000000-0000-0000-0000-000000000010');
-            expect(mockFetch).toHaveBeenCalledTimes(1);
-            const [, init] = mockFetch.mock.calls[0];
-            expect(init.headers['X-Injected']).toBe('yes');
-        });
-
-        it('rejection blocks the legacy webhook delivery: no HTTP call', async () => {
-            const { organization, project } = await createTestContext();
-            const { alertsService } = await import('../../../modules/alerts/index.js');
-
-            mockGetAlertRuleChannels.mockResolvedValueOnce([{
-                id: '00000000-0000-0000-0000-000000000010',
-                type: 'webhook',
-                enabled: true,
-                config: { url: 'https://example.com/legacy-hook' },
-            }]);
-
-            hooks.register('beforeWebhookDispatch', async () => {
-                throw new HookRejectionError('policy.webhook_blocked', 'blocked');
-            });
-
-            const jobData: AlertNotificationData = {
-                historyId: '00000000-0000-0000-0000-000000000001',
-                rule_id: '00000000-0000-0000-0000-000000000002',
-                rule_name: 'Hook Rejection Test Rule',
-                organization_id: organization.id,
-                project_id: project.id,
-                log_count: 100,
-                threshold: 50,
-                time_window: 5,
-                email_recipients: [],
-                webhook_url: undefined,
-            };
-
-            // processAlertNotification swallows webhook errors into the errors array
-            // and calls markAsNotified with the error message; it does not rethrow.
-            await processAlertNotification({ data: jobData });
-
-            expect(mockFetch).not.toHaveBeenCalled();
-            expect(alertsService.markAsNotified).toHaveBeenCalledWith(
-                jobData.historyId,
-                expect.stringContaining('blocked')
-            );
-        });
-    });
+    // SSRF/hook behavior moved to the webhook dispatcher (#218); covered by deliver-once.test.ts.
 });

--- a/packages/backend/src/tests/queue/jobs/webhook-delivery.test.ts
+++ b/packages/backend/src/tests/queue/jobs/webhook-delivery.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { addMock, svc, deliverOnceMock } = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  svc: {
+    getDelivery: vi.fn(),
+    recordAttempt: vi.fn(),
+    markDelivered: vi.fn(),
+    markRetrying: vi.fn(),
+    markDead: vi.fn(),
+  },
+  deliverOnceMock: vi.fn(),
+}));
+
+vi.mock('../../../config/index.js', () => ({
+  config: { WEBHOOK_MAX_ATTEMPTS: 5, WEBHOOK_PER_ORG_CONCURRENCY: 5, WEBHOOK_GLOBAL_CONCURRENCY: 50, WEBHOOK_DELIVERY_LOG_LIMIT: 1000 },
+}));
+vi.mock('../../../queue/connection.js', () => ({ createQueue: vi.fn(() => ({ add: addMock, close: vi.fn() })) }));
+vi.mock('../../../modules/webhooks/service.js', () => ({ webhookDeliveryService: svc }));
+vi.mock('../../../modules/webhooks/dispatcher.js', () => ({ deliverOnce: deliverOnceMock, WEBHOOK_DELIVERY_QUEUE: 'webhook-delivery' }));
+
+import { processWebhookDelivery, BACKOFF_SCHEDULE_MS } from '../../../queue/jobs/webhook-delivery.js';
+import type { IJob } from '../../../queue/abstractions/types.js';
+import type { WebhookDeliveryJobData } from '../../../modules/webhooks/types.js';
+
+function delivery(over = {}) {
+  return { id: 'del-1', organization_id: 'org-1', event_type: 'alert', event_id: 'e', url: 'https://e.com', status: 'pending', attempt_count: 0, max_attempts: 5, metadata: { payload: { a: 1 } }, ...over };
+}
+
+beforeEach(() => {
+  Object.values(svc).forEach((m) => m.mockReset().mockResolvedValue(undefined));
+  addMock.mockReset().mockResolvedValue({ id: 'job' });
+  deliverOnceMock.mockReset();
+});
+
+describe('processWebhookDelivery', () => {
+  it('marks delivered on success', async () => {
+    svc.getDelivery.mockResolvedValue(delivery());
+    deliverOnceMock.mockResolvedValue({ success: true, statusCode: 200, durationMs: 5, retryable: false });
+    await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
+    expect(svc.markDelivered).toHaveBeenCalledWith('del-1');
+    expect(svc.recordAttempt).toHaveBeenCalledWith('del-1', expect.objectContaining({ attemptNumber: 1, statusCode: 200 }), 1000);
+  });
+
+  it('re-enqueues with backoff on a retryable failure', async () => {
+    svc.getDelivery.mockResolvedValue(delivery({ attempt_count: 0 }));
+    deliverOnceMock.mockResolvedValue({ success: false, statusCode: 503, durationMs: 5, error: 'HTTP 503', retryable: true });
+    await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
+    expect(svc.markRetrying).toHaveBeenCalledWith('del-1', 1, expect.any(Date), 'HTTP 503');
+    expect(addMock).toHaveBeenCalledWith('deliver', { deliveryId: 'del-1' }, expect.objectContaining({ delay: BACKOFF_SCHEDULE_MS[0] }));
+  });
+
+  it('marks dead when attempts are exhausted', async () => {
+    svc.getDelivery.mockResolvedValue(delivery({ attempt_count: 4, max_attempts: 5 }));
+    deliverOnceMock.mockResolvedValue({ success: false, statusCode: 503, durationMs: 5, error: 'HTTP 503', retryable: true });
+    await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
+    expect(svc.markDead).toHaveBeenCalledWith('del-1', 'HTTP 503');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('marks dead immediately on a non-retryable failure', async () => {
+    svc.getDelivery.mockResolvedValue(delivery({ attempt_count: 0 }));
+    deliverOnceMock.mockResolvedValue({ success: false, statusCode: 400, durationMs: 5, error: 'HTTP 400', retryable: false });
+    await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
+    expect(svc.markDead).toHaveBeenCalledWith('del-1', 'HTTP 400');
+  });
+
+  it('skips a delivery already delivered or dead (idempotent)', async () => {
+    svc.getDelivery.mockResolvedValue(delivery({ status: 'delivered' }));
+    await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
+    expect(deliverOnceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/tests/queue/jobs/webhook-delivery.test.ts
+++ b/packages/backend/src/tests/queue/jobs/webhook-delivery.test.ts
@@ -54,7 +54,7 @@ describe('processWebhookDelivery', () => {
     svc.getDelivery.mockResolvedValue(delivery({ attempt_count: 4, max_attempts: 5 }));
     deliverOnceMock.mockResolvedValue({ success: false, statusCode: 503, durationMs: 5, error: 'HTTP 503', retryable: true });
     await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
-    expect(svc.markDead).toHaveBeenCalledWith('del-1', 'HTTP 503');
+    expect(svc.markDead).toHaveBeenCalledWith('del-1', 5, 'HTTP 503');
     expect(addMock).not.toHaveBeenCalled();
   });
 
@@ -62,7 +62,7 @@ describe('processWebhookDelivery', () => {
     svc.getDelivery.mockResolvedValue(delivery({ attempt_count: 0 }));
     deliverOnceMock.mockResolvedValue({ success: false, statusCode: 400, durationMs: 5, error: 'HTTP 400', retryable: false });
     await processWebhookDelivery({ id: 'j', name: 'deliver', data: { deliveryId: 'del-1' } } as IJob<WebhookDeliveryJobData>);
-    expect(svc.markDead).toHaveBeenCalledWith('del-1', 'HTTP 400');
+    expect(svc.markDead).toHaveBeenCalledWith('del-1', 1, 'HTTP 400');
   });
 
   it('skips a delivery already delivered or dead (idempotent)', async () => {

--- a/packages/backend/src/worker.ts
+++ b/packages/backend/src/worker.ts
@@ -15,6 +15,8 @@ import { processMonitorNotification, type MonitorNotificationJob } from './queue
 import { processLogPipeline, type LogPipelineJobData } from './queue/jobs/log-pipeline.js';
 import { processDigestGeneration } from './queue/jobs/digest-generation.js';
 import type { DigestJobPayload } from './modules/digests/scheduler.js';
+import { processWebhookDelivery } from './queue/jobs/webhook-delivery.js';
+import type { WebhookDeliveryJobData } from './modules/webhooks/types.js';
 import { alertsService } from './modules/alerts/index.js';
 import { monitorService } from './modules/monitoring/index.js';
 import { maintenanceService } from './modules/maintenances/service.js';
@@ -88,6 +90,11 @@ const digestWorker = createWorker<DigestJobPayload>('digest-generation', async (
   await processDigestGeneration(job);
 });
 await digestScheduler.registerAllDigests();
+
+// Create worker for outbound webhook delivery (#218)
+const webhookDeliveryWorker = createWorker<WebhookDeliveryJobData>('webhook-delivery', async (job) => {
+  await processWebhookDelivery(job);
+});
 
 // Start workers (required for graphile-worker backend, no-op for BullMQ)
 console.log(`[Worker] Using queue backend: ${getQueueBackend()}`);
@@ -311,6 +318,17 @@ digestWorker.on('failed', (job, err) => {
       jobId: job?.id,
       organizationId: job?.data?.organizationId,
       frequency: job?.data?.frequency,
+    });
+  }
+});
+
+webhookDeliveryWorker.on('failed', (job, err) => {
+  console.error(`Webhook delivery job ${job?.id} failed:`, err);
+  if (isInternalLoggingEnabled()) {
+    hub.captureLog('error', `Webhook delivery job failed: ${err.message}`, {
+      error: { name: err.name, message: err.message, stack: err.stack },
+      jobId: job?.id,
+      deliveryId: job?.data?.deliveryId,
     });
   }
 });
@@ -719,6 +737,7 @@ async function gracefulShutdown(signal: string) {
     await monitorNotificationWorker.close();
     await pipelineWorker.close();
     await digestWorker.close();
+    await webhookDeliveryWorker.close();
     console.log('[Worker] Workers closed');
 
     // Close queue system (Redis/PostgreSQL connections)

--- a/packages/frontend/src/lib/api/webhook-deliveries.ts
+++ b/packages/frontend/src/lib/api/webhook-deliveries.ts
@@ -1,0 +1,130 @@
+import { getApiUrl } from '$lib/config';
+import { getAuthToken } from '$lib/utils/auth';
+import type { WebhookDelivery, WebhookDeliveryAttempt, WebhookDeliveryStatus } from '@logtide/shared';
+
+async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
+  const token = getAuthToken();
+  const headers: HeadersInit = {
+    ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(options.headers || {}),
+  };
+
+  return fetch(url, {
+    ...options,
+    headers,
+    credentials: 'include',
+  });
+}
+
+// snake_case row shapes returned by the backend
+interface DeliveryRow {
+  id: string;
+  organization_id: string;
+  event_type: string;
+  event_id: string;
+  url: string;
+  status: WebhookDeliveryStatus;
+  attempt_count: number;
+  max_attempts: number;
+  next_attempt_at: string | null;
+  last_error: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface AttemptRow {
+  id: string;
+  delivery_id: string;
+  attempt_number: number;
+  status_code: number | null;
+  duration_ms: number | null;
+  response_excerpt: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+function toDelivery(row: DeliveryRow): WebhookDelivery {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    eventType: row.event_type,
+    eventId: row.event_id,
+    url: row.url,
+    status: row.status,
+    attemptCount: row.attempt_count,
+    maxAttempts: row.max_attempts,
+    nextAttemptAt: row.next_attempt_at,
+    lastError: row.last_error,
+    metadata: row.metadata,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toAttempt(row: AttemptRow): WebhookDeliveryAttempt {
+  return {
+    id: row.id,
+    deliveryId: row.delivery_id,
+    attemptNumber: row.attempt_number,
+    statusCode: row.status_code,
+    durationMs: row.duration_ms,
+    responseExcerpt: row.response_excerpt,
+    error: row.error,
+    createdAt: row.created_at,
+  };
+}
+
+export async function listWebhookDeliveries(params: {
+  organizationId: string;
+  status?: WebhookDeliveryStatus;
+  limit?: number;
+  offset?: number;
+}): Promise<WebhookDelivery[]> {
+  const qs = new URLSearchParams({ organizationId: params.organizationId });
+  if (params.status) qs.set('status', params.status);
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+  if (params.offset !== undefined) qs.set('offset', String(params.offset));
+
+  const response = await fetchWithAuth(`${getApiUrl()}/api/v1/webhooks/deliveries?${qs}`);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to fetch deliveries' }));
+    throw new Error((error as { error?: string }).error || 'Failed to fetch deliveries');
+  }
+
+  const data = await response.json();
+  return (data.deliveries as DeliveryRow[]).map(toDelivery);
+}
+
+export async function getWebhookDelivery(
+  id: string
+): Promise<{ delivery: WebhookDelivery; attempts: WebhookDeliveryAttempt[] }> {
+  const response = await fetchWithAuth(`${getApiUrl()}/api/v1/webhooks/deliveries/${id}`);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to fetch delivery' }));
+    throw new Error((error as { error?: string }).error || 'Failed to fetch delivery');
+  }
+
+  const data = await response.json();
+  return {
+    delivery: toDelivery(data.delivery as DeliveryRow),
+    attempts: (data.attempts as AttemptRow[]).map(toAttempt),
+  };
+}
+
+export async function replayWebhookDelivery(id: string): Promise<WebhookDelivery> {
+  const response = await fetchWithAuth(`${getApiUrl()}/api/v1/webhooks/deliveries/${id}/replay`, {
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to replay delivery' }));
+    throw new Error((error as { error?: string }).error || 'Failed to replay delivery');
+  }
+
+  const data = await response.json();
+  return toDelivery(data.delivery as DeliveryRow);
+}

--- a/packages/frontend/src/lib/stores/webhook-deliveries.ts
+++ b/packages/frontend/src/lib/stores/webhook-deliveries.ts
@@ -1,0 +1,63 @@
+import { writable } from 'svelte/store';
+import type { WebhookDelivery, WebhookDeliveryStatus } from '@logtide/shared';
+import {
+  listWebhookDeliveries,
+  replayWebhookDelivery,
+} from '$lib/api/webhook-deliveries';
+
+export interface WebhookDeliveriesState {
+  deliveries: WebhookDelivery[];
+  loading: boolean;
+  error: string | null;
+  statusFilter: WebhookDeliveryStatus | '';
+}
+
+const initialState: WebhookDeliveriesState = {
+  deliveries: [],
+  loading: false,
+  error: null,
+  statusFilter: '',
+};
+
+function createWebhookDeliveriesStore() {
+  const { subscribe, update } = writable<WebhookDeliveriesState>(initialState);
+
+  return {
+    subscribe,
+
+    async load(organizationId: string, status?: WebhookDeliveryStatus) {
+      update((s) => ({ ...s, loading: true, error: null, statusFilter: status ?? '' }));
+
+      try {
+        const deliveries = await listWebhookDeliveries({ organizationId, status });
+        update((s) => ({ ...s, deliveries, loading: false }));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to load deliveries';
+        update((s) => ({ ...s, deliveries: [], loading: false, error: errorMessage }));
+      }
+    },
+
+    async replay(organizationId: string, id: string) {
+      try {
+        await replayWebhookDelivery(id);
+        // reload current filter state
+        let currentStatus: WebhookDeliveryStatus | '' = '';
+        update((s) => {
+          currentStatus = s.statusFilter;
+          return s;
+        });
+        const deliveries = await listWebhookDeliveries({
+          organizationId,
+          status: currentStatus || undefined,
+        });
+        update((s) => ({ ...s, deliveries }));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to replay delivery';
+        update((s) => ({ ...s, error: errorMessage }));
+        throw error;
+      }
+    },
+  };
+}
+
+export const webhookDeliveriesStore = createWebhookDeliveriesStore();

--- a/packages/frontend/src/routes/dashboard/settings/+layout.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/+layout.svelte
@@ -14,6 +14,7 @@
   import Settings from '@lucide/svelte/icons/settings';
   import ChevronRight from '@lucide/svelte/icons/chevron-right';
   import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
+  import Send from '@lucide/svelte/icons/send';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -78,6 +79,7 @@
       label: 'Notifications',
       items: [
         { label: 'Channels', href: '/dashboard/settings/channels', icon: BellRing },
+        { label: 'Webhook Deliveries', href: '/dashboard/settings/webhooks', icon: Send },
       ],
     },
     {

--- a/packages/frontend/src/routes/dashboard/settings/webhooks/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/webhooks/+page.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { authStore } from '$lib/stores/auth';
+	import { organizationStore } from '$lib/stores/organization';
+	import { webhookDeliveriesStore } from '$lib/stores/webhook-deliveries';
+	import type { WebhookDelivery, WebhookDeliveryStatus } from '@logtide/shared';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle,
+		CardDescription,
+	} from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow,
+	} from '$lib/components/ui/table';
+	import { Button } from '$lib/components/ui/button';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import type { OrganizationWithRole } from '@logtide/shared';
+	import Send from '@lucide/svelte/icons/send';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+
+	const STATUS_OPTIONS: { value: WebhookDeliveryStatus | ''; label: string }[] = [
+		{ value: '', label: 'All' },
+		{ value: 'pending', label: 'Pending' },
+		{ value: 'delivered', label: 'Delivered' },
+		{ value: 'failed', label: 'Failed (Retrying)' },
+		{ value: 'dead', label: 'Dead (DLQ)' },
+	];
+
+	const STATUS_COLORS: Record<WebhookDeliveryStatus, string> = {
+		pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+		delivered: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+		failed: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+		dead: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+	};
+
+	let token: string | null = null;
+	let currentOrg = $state<OrganizationWithRole | null>(null);
+	let lastLoadedOrgId = $state<string | null>(null);
+
+	let storeState = $state({
+		deliveries: [] as WebhookDelivery[],
+		loading: false,
+		error: null as string | null,
+		statusFilter: '' as WebhookDeliveryStatus | '',
+	});
+
+	let replayingId = $state<string | null>(null);
+	let replayError = $state('');
+
+	const unsubAuthStore = authStore.subscribe((state) => {
+		token = state.token;
+	});
+
+	const unsubOrgStore = organizationStore.subscribe((state) => {
+		currentOrg = state.currentOrganization;
+	});
+
+	const unsubDeliveries = webhookDeliveriesStore.subscribe((state) => {
+		storeState = state;
+	});
+
+	onDestroy(() => {
+		unsubAuthStore();
+		unsubOrgStore();
+		unsubDeliveries();
+	});
+
+	onMount(() => {
+		if (!token) {
+			goto('/login');
+		}
+	});
+
+	$effect(() => {
+		if (browser && currentOrg && currentOrg.id !== lastLoadedOrgId) {
+			lastLoadedOrgId = currentOrg.id;
+			void webhookDeliveriesStore.load(currentOrg.id);
+		}
+	});
+
+	function applyStatusFilter() {
+		if (!currentOrg) return;
+		const status = storeState.statusFilter || undefined;
+		void webhookDeliveriesStore.load(currentOrg.id, status);
+	}
+
+	async function handleReplay(delivery: WebhookDelivery) {
+		if (!currentOrg || replayingId) return;
+		replayingId = delivery.id;
+		replayError = '';
+		try {
+			await webhookDeliveriesStore.replay(currentOrg.id, delivery.id);
+		} catch (e) {
+			replayError = e instanceof Error ? e.message : 'Failed to replay delivery';
+		} finally {
+			replayingId = null;
+		}
+	}
+
+	function formatDate(iso: string) {
+		return new Date(iso).toLocaleString();
+	}
+
+	function truncateUrl(url: string, max = 48): string {
+		return url.length > max ? url.slice(0, max) + '…' : url;
+	}
+
+	let statusFilter = $state<WebhookDeliveryStatus | ''>('');
+
+	function onStatusChange() {
+		storeState = { ...storeState, statusFilter };
+		if (!currentOrg) return;
+		void webhookDeliveriesStore.load(currentOrg.id, statusFilter || undefined);
+	}
+</script>
+
+<svelte:head>
+	<title>Webhook Deliveries - LogTide</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<!-- Filters -->
+	<Card>
+		<CardHeader class="pb-3">
+			<div class="flex items-center justify-between">
+				<div>
+					<CardTitle class="text-base">Webhook Deliveries</CardTitle>
+					<CardDescription class="mt-1">
+						Outbound webhook dispatch history for your organization
+					</CardDescription>
+				</div>
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={() => currentOrg && void webhookDeliveriesStore.load(currentOrg.id, statusFilter || undefined)}
+				>
+					<RotateCcw class="h-4 w-4 mr-1" />
+					Refresh
+				</Button>
+			</div>
+		</CardHeader>
+		<CardContent>
+			<div class="flex items-end gap-3">
+				<div class="space-y-1">
+					<label for="status-filter" class="text-xs font-medium text-muted-foreground">
+						Status
+					</label>
+					<select
+						id="status-filter"
+						bind:value={statusFilter}
+						onchange={onStatusChange}
+						class="flex h-9 w-52 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					>
+						{#each STATUS_OPTIONS as opt}
+							<option value={opt.value}>{opt.label}</option>
+						{/each}
+					</select>
+				</div>
+			</div>
+		</CardContent>
+	</Card>
+
+	<!-- Table -->
+	<Card>
+		<CardContent class="p-0">
+			{#if storeState.loading}
+				<div class="flex justify-center py-12">
+					<Spinner />
+				</div>
+			{:else if storeState.error}
+				<p class="py-8 text-center text-sm text-destructive">{storeState.error}</p>
+			{:else if storeState.deliveries.length === 0}
+				<div class="py-12 text-center">
+					<Send class="mx-auto h-10 w-10 text-muted-foreground/40" />
+					<p class="mt-3 text-sm text-muted-foreground">No webhook deliveries found.</p>
+				</div>
+			{:else}
+				<div class="overflow-x-auto">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Event Type</TableHead>
+								<TableHead>URL</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead>Attempts</TableHead>
+								<TableHead>Created</TableHead>
+								<TableHead class="w-[80px]"></TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{#each storeState.deliveries as delivery (delivery.id)}
+								<TableRow>
+									<TableCell class="font-mono text-sm">{delivery.eventType}</TableCell>
+									<TableCell class="text-sm text-muted-foreground" title={delivery.url}>
+										{truncateUrl(delivery.url)}
+									</TableCell>
+									<TableCell>
+										<span
+											class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {STATUS_COLORS[delivery.status]}"
+										>
+											{delivery.status}
+										</span>
+									</TableCell>
+									<TableCell class="text-sm">
+										{delivery.attemptCount}/{delivery.maxAttempts}
+									</TableCell>
+									<TableCell class="whitespace-nowrap text-xs text-muted-foreground">
+										{formatDate(delivery.createdAt)}
+									</TableCell>
+									<TableCell>
+										{#if delivery.status === 'failed' || delivery.status === 'dead'}
+											<Button
+												variant="outline"
+												size="sm"
+												disabled={replayingId === delivery.id}
+												onclick={() => handleReplay(delivery)}
+											>
+												{#if replayingId === delivery.id}
+													<Spinner />
+												{:else}
+													Retry
+												{/if}
+											</Button>
+										{/if}
+									</TableCell>
+								</TableRow>
+							{/each}
+						</TableBody>
+					</Table>
+				</div>
+				{#if replayError}
+					<p class="px-6 py-3 text-sm text-destructive">{replayError}</p>
+				{/if}
+			{/if}
+		</CardContent>
+	</Card>
+</div>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -13,6 +13,9 @@ export * from './detection-pack.js';
 // Re-export notification channel types
 export * from './notification-channel.js';
 
+// Re-export webhook delivery types
+export * from './webhook-delivery.js';
+
 // Re-export custom dashboard types
 export * from './dashboard.js';
 export * from './dashboard-migrations.js';

--- a/packages/shared/src/types/webhook-delivery.ts
+++ b/packages/shared/src/types/webhook-delivery.ts
@@ -1,0 +1,31 @@
+/** Lifecycle status of a logical webhook delivery. */
+export type WebhookDeliveryStatus = 'pending' | 'delivered' | 'failed' | 'dead';
+
+/** A logical delivery (one per enqueue), as returned by the API. */
+export interface WebhookDelivery {
+  id: string;
+  organizationId: string;
+  eventType: string;
+  eventId: string;
+  url: string;
+  status: WebhookDeliveryStatus;
+  attemptCount: number;
+  maxAttempts: number;
+  nextAttemptAt: string | null;
+  lastError: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A single HTTP attempt against a delivery. */
+export interface WebhookDeliveryAttempt {
+  id: string;
+  deliveryId: string;
+  attemptNumber: number;
+  statusCode: number | null;
+  durationMs: number | null;
+  responseExcerpt: string | null;
+  error: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
Refs #218.

Reusable `webhookDispatcher` that centralizes outbound HTTP delivery, plus migration of every existing webhook sender onto it.

## What it does
- **HMAC signing** — `X-Logtide-Signature: t=<unix>,v1=<hex>` over `<unix>.<body>` (timing-safe verify, documented for receivers)
- **Retry + backoff** — exponential 1s/5s/25s/2m/10m, transient-only (network/timeout/5xx/429), driven by manual re-enqueue so it works on both queue backends (BullMQ + graphile-worker)
- **Dead-letter queue** — `status='dead'` after final failure; list + replay from the dashboard
- **SSRF protection** — reuses the existing `safeFetch` guard via a shared `deliverOnce` primitive
- **Per-org concurrency** — in-process semaphore + global cap (no new infra)
- **Delivery log** — bounded attempt log per delivery; org-scoped API + dashboard view

## Migration
All five senders now route through the dispatcher: alert, error, monitor, incident, and the notification-channel WebhookProvider. The error/monitor/incident paths previously used raw `fetch` with **no SSRF guard** — that gap is now closed. Payloads are unchanged (no behavioral regression).

## Notable
- DLQ is a `status`, not a separate table (cleaner replay, no duplication)
- BullMQ forbids `:` in job ids, so the dedup jobKey is hashed (`webhook-<sha256>`)
- API redacts `signingSecret`/`headers` from delivery metadata
- New migration `047_webhook_deliveries.sql` (two tables)

## Tests
Full backend suite green except 4 pre-existing locale failures in `digests/generator.test.ts` (en-US comma grouping vs the dev machine's locale; unrelated, pass in CI). New unit/integration coverage for signing, concurrency, deliverOnce, persistence, the queued processor, routes, and each migrated consumer.