### PR TITLE
release 1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,15 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand(\"ping\")'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.0.1] - 2026-06-19
+
+A security and correctness release from a comprehensive, multi-engine bug audit of the 1.0 line. The headline items are two cross-tenant data-exposure fixes that were live in 1.0.0, alongside a broad sweep of detection, ingestion, storage, alerting and frontend correctness fixes. No database migrations; this is a drop-in upgrade. The storage-layer fixes were validated against real ClickHouse and MongoDB (and TimescaleDB), and CI now runs the MongoDB reservoir integration suite.
+
+### Security
+- **Cross-tenant log exposure via the WebSocket live-tail** (`GET /api/v1/logs/ws`): the handler validated only the session token and then streamed whatever `projectId` the client passed, never checking project/organization membership, so any authenticated user could live-tail any project's logs by supplying its id. It now enforces the same `verifyProjectAccess` membership check as the REST query routes (regression test added). Was live on the 1.0.0 line
+- **Cross-tenant leak of notification-channel secrets**: `GET /notification-channels/alert-rules/:id` and `/sigma-rules/:id` returned the channel `config` verbatim (including webhook `auth` tokens/passwords) with no membership check. They now resolve the rule's organization, require membership, and scope the read to that org
+- **PII masking fail-open**: `maskText` skipped all content rules for pure-alphanumeric strings, so a separator-less credit-card number (e.g. `4111111111111111`) was stored unmasked. The all-alphanumeric early-exit is removed; only too-short strings are skipped
+- **OIDC account-takeover**: linking an external identity to an existing local account by email now requires the provider to assert the email is verified (`email_verified === true`), preventing takeover via an unverified IdP email; LDAP is treated as authoritative
+- **Cross-tenant `?projectId` / association gaps** closed: the correlation batch-identifiers endpoint now intersects the requested project with the caller's accessible projects (and requires read access); status-incident and scheduled-maintenance creation, organization-default channels, and alert/sigma/monitor channel associations now validate that the project/channels belong to the caller's organization
+- **Session invalidation**: disabling a user, resetting their password, and changing a user's admin role now invalidate the cached session (previously the cached profile stayed valid for up to the cache TTL); the frontend logout now revokes the server-side session token instead of only clearing local state
+- **Hardening**: emails are stored and compared case-insensitively across registration/login/profile-update; the global `CACHE_TTL` override no longer clamps semantic TTLs (sessions, OIDC state, settings); the webhook envelope id is validated as a UUID; SigmaHQ category sync matches on a directory boundary; OTLP trace/span ids of invalid length are rejected
 
 ### Fixed
-- **ClickHouse "Query with id = ... is already running" under concurrent queries** (#213 regression): the request-context propagation derived the ClickHouse `query_id` deterministically from `requestId + operation`, so two same-operation queries running concurrently within one request (common on dashboard and multi-query endpoints) reused the same id and ClickHouse rejected the second. The `query_id` now keeps the request id + operation as a readable prefix (correlation is also carried in the SQL `log_comment`) and appends a random suffix so every query gets a unique id. ClickHouse-only; Timescale (SQL comment) and MongoDB (`$comment`) were unaffected
+- **ClickHouse "Query with id = ... is already running" under concurrent queries** (#213 regression): the request-context propagation derived the ClickHouse `query_id` deterministically from `requestId + operation`, so two same-operation queries running concurrently within one request reused the same id and ClickHouse rejected the second. The `query_id` now keeps the request id + operation as a readable prefix (correlation is also carried in the SQL `log_comment`) and appends a random suffix so every query is unique. ClickHouse-only
+- **Sigma condition operator precedence**: `parseExpression` folded AND/OR strictly left-to-right, so `a or b and c` evaluated as `(a or b) and c`. AND now binds tighter than OR, matching the Sigma spec
+- **Infinite loop on ingestion**: a custom identifier pattern that can match the empty string (e.g. `\d*`) no longer hangs the worker (zero-width-match guard plus a forced global flag)
+- **Trace summary races**: `upsertTrace` is now race-free on TimescaleDB (single atomic `INSERT ... ON CONFLICT`) and ClickHouse (the summary is recomputed from the spans table instead of read-modify-write), so concurrent span batches no longer lose span counts
+- **ClickHouse**: added the missing `session_id` column (was written and filtered on but did not exist), parse zone-less datetimes as UTC, report the true latest value in the metrics overview (was the average) with NaN guards
+- **MongoDB**: `deleteMetricsByTimeRange` only deletes the matched metrics' exemplars (was all exemplars in the window); the metrics overview sorts before `$last`; metadata `distinct` no longer drops numeric/boolean values; `ingestReturning` returns the rows that did land on a partial bulk-write failure
+- **Rate-of-change alerts**: the baseline now applies the rule's metadata filters (previously only the current rate did, deflating the deviation ratio), and a `minBaselineValue` of 0 is honored instead of defaulting to 10
+- **Dashboards**: personal dashboards are scoped to their creator (no longer readable/editable by any org member); `metric_stat` sums across buckets for sum/count aggregations; top-error percentages are computed against the true total; the capability usage page renders a zero limit as fully restricted, not unlimited
+- **Pagination/counts**: admin organization/project search counts apply the search filter; correlation lookups report the true total; the ClickHouse trace error-rate uses a consistent denominator; `getTopServices` honors the `to` bound
+- **Live tail**: SSE polling bypasses the 60s query cache and guards against overlapping polls; the live-tail WebSocket URL works behind a reverse proxy; the traces and search live tails no longer corrupt pagination or index-keyed row state
+- **Infra/correctness**: BullMQ and graphile queue retry-attempt defaults are aligned; webhook deliveries can only be replayed from the terminal `dead` state (no double delivery); the audit flush buffer is bounded on persistent DB failure; alert-notification jobs are deduplicated by history id; admin org-role changes are restricted consistently with member removal; tenant-table updates in the log-pipeline and service-dependency queries are project-scoped
+
+### Changed
+- The reservoir storage abstraction gains `getTraceServices` (distinct trace services with no result cap) implemented on all three engines and used by the traces service, replacing the previous 10k-trace paging
+- CI now provisions a MongoDB service for the reservoir integration suite, so all three storage engines are exercised on every run
+
+### Notes
+- Deferred to a follow-up (#255): Sigma compound field modifiers (`field|base64|contains` chains) and a true service-map p95 (needs a mergeable t-digest sketch in the continuous aggregate)
 
 ## [1.0.0-beta] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@
   <a href="https://codecov.io/gh/logtide-dev/logtide"><img src="https://codecov.io/gh/logtide-dev/logtide/branch/main/graph/badge.svg" alt="Coverage"></a>
   <a href="https://hub.docker.com/r/logtide/backend"><img src="https://img.shields.io/docker/v/logtide/backend?label=docker&logo=docker" alt="Docker"></a>
   <a href="https://artifacthub.io/packages/helm/logtide/logtide"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/logtide" alt="Artifact Hub"></a>
-  <img src="https://img.shields.io/badge/version-1.0.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.0.1-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-AGPLv3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/status-beta-success.svg" alt="Status">
 </div>
 
 <br />
 
-> **🌊 LogTide 1.0.0 (public beta):** unified **Logs, Traces & Metrics** with a built-in **SIEM**, multi-engine storage (TimescaleDB / ClickHouse / MongoDB), uptime monitoring, parsing pipelines, and custom dashboards.
+> **🌊 LogTide 1.0.1 (public beta):** unified **Logs, Traces & Metrics** with a built-in **SIEM**, multi-engine storage (TimescaleDB / ClickHouse / MongoDB), uptime monitoring, parsing pipelines, and custom dashboards.
 
 ---
 
@@ -124,7 +124,7 @@ We host it for you. Perfect for testing. [**Sign up at logtide.dev**](https://lo
 
 ---
 
-## ✨ Core Features (v1.0.0)
+## ✨ Core Features (v1.0.1)
 
 ### Monitoring, Pipelines & Dashboards
 * 🩺 **Uptime Monitoring & Status Pages:** HTTP/TCP/heartbeat monitors with configurable thresholds, auto-created SIEM incidents on failure, scheduled maintenances, and public Uptime-Kuma-style status pages per project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,16 +43,17 @@ We thank the following researchers for responsibly disclosing security issues:
 We provide security updates for the following versions:
 
 | Version | Supported          |
-|--------|--------------------|
-| 0.9.x  | :white_check_mark: |
-| 0.8.x  | :x:                |
-| 0.7.x  | :x:                |
-| 0.6.x  | :x:                |
-| 0.5.x  | :x:                |
-| 0.4.x  | :x:                |
-| 0.3.x  | :x:                |
-| 0.2.x  | :x:                |
-| 0.1.x  | :x:                |
+|---------|--------------------|
+| 1.0.x   | :white_check_mark: |
+| 0.9.x   | :x:                |
+| 0.8.x   | :x:                |
+| 0.7.x   | :x:                |
+| 0.6.x   | :x:                |
+| 0.5.x   | :x:                |
+| 0.4.x   | :x:                |
+| 0.3.x   | :x:                |
+| 0.2.x   | :x:                |
+| 0.1.x   | :x:                |
 
 ## Security Best Practices
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logtide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "LogTide - Self-hosted log management platform",
   "author": "LogTide Team",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logtide/backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "LogTide Backend API",
   "type": "module",

--- a/packages/backend/src/capabilities/resolver.ts
+++ b/packages/backend/src/capabilities/resolver.ts
@@ -110,8 +110,14 @@ export class DbCapabilityResolver implements CapabilityResolver {
   }
 
   async list(organizationId: string): Promise<Record<CapabilityName, EntitlementValue>> {
-    // Shallow copy: callers must not be able to mutate the cached map.
-    return { ...(await this.load(organizationId)) };
+    // Copy the map AND each value: a shallow map copy still shares the cached
+    // EntitlementValue objects, so a caller mutating one would corrupt the cache.
+    const loaded = await this.load(organizationId);
+    const out = {} as Record<CapabilityName, EntitlementValue>;
+    for (const key of Object.keys(loaded) as CapabilityName[]) {
+      out[key] = { ...loaded[key] };
+    }
+    return out;
   }
 
   invalidate(organizationId: string): void {

--- a/packages/backend/src/database/connection.ts
+++ b/packages/backend/src/database/connection.ts
@@ -137,10 +137,12 @@ pool.on('error', (err) => {
 
 // Pool status logging (development only)
 if (!isProduction && !isTest) {
-  setInterval(() => {
+  const poolStatusInterval = setInterval(() => {
     const { totalCount, idleCount, waitingCount } = pool;
     console.log(`[Database Pool] Total: ${totalCount}, Idle: ${idleCount}, Waiting: ${waitingCount}`);
   }, 60000); // Log every minute
+  // Don't let this dev-only timer keep the process alive (clean shutdown / reloads).
+  poolStatusInterval.unref();
 }
 
 const dialect = new PostgresDialect({ pool });

--- a/packages/backend/src/modules/admin/service.ts
+++ b/packages/backend/src/modules/admin/service.ts
@@ -1470,11 +1470,20 @@ export class AdminService {
             throw new Error('User not found');
         }
 
-        // Delete all active sessions to force re-login
+        // Delete all active sessions to force re-login, and invalidate the session
+        // cache so the old tokens cannot keep working until the cache TTL expires.
+        const sessions = await db
+            .selectFrom('sessions')
+            .select('token')
+            .where('user_id', '=', userId)
+            .execute();
+
         await db
             .deleteFrom('sessions')
             .where('user_id', '=', userId)
             .execute();
+
+        await Promise.all(sessions.map((sn) => CacheManager.invalidateSession(sn.token)));
 
         return user;
     }

--- a/packages/backend/src/modules/admin/service.ts
+++ b/packages/backend/src/modules/admin/service.ts
@@ -1377,12 +1377,25 @@ export class AdminService {
             throw new Error('User not found');
         }
 
-        // If disabling, delete all active sessions
+        // If disabling, revoke all active sessions. Deleting the DB rows is not
+        // enough: validateSession caches the UserProfile by token, so a disabled
+        // user would keep access until the cache TTL expires. Invalidate the cache
+        // for each token as well.
         if (disabled) {
+            const sessions = await db
+                .selectFrom('sessions')
+                .select('token')
+                .where('user_id', '=', userId)
+                .execute();
+
             await db
                 .deleteFrom('sessions')
                 .where('user_id', '=', userId)
                 .execute();
+
+            await Promise.all(
+                sessions.map((s) => CacheManager.invalidateSession(s.token))
+            );
         }
 
         return user;

--- a/packages/backend/src/modules/admin/service.ts
+++ b/packages/backend/src/modules/admin/service.ts
@@ -1494,21 +1494,24 @@ export class AdminService {
             ])
             .orderBy('organizations.created_at', 'desc');
 
+        let countQuery = db
+            .selectFrom('organizations')
+            .select(({ fn }) => [fn.count<number>('id').as('count')]);
+
         if (search) {
-            query = query.where((eb) =>
+            const applySearch = (eb: any) =>
                 eb.or([
                     eb('organizations.name', 'ilike', `%${search}%`),
                     eb('organizations.slug', 'ilike', `%${search}%`),
-                ])
-            );
+                ]);
+            query = query.where(applySearch);
+            // The count must apply the same filter, otherwise pagination is wrong.
+            countQuery = countQuery.where(applySearch);
         }
 
         const [organizations, countResult] = await Promise.all([
             query.limit(limit).offset(offset).execute(),
-            db
-                .selectFrom('organizations')
-                .select(({ fn }) => [fn.count<number>('id').as('count')])
-                .executeTakeFirst(),
+            countQuery.executeTakeFirst(),
         ]);
 
         const total = Number(countResult?.count || 0);
@@ -1642,21 +1645,25 @@ export class AdminService {
             ])
             .orderBy('projects.created_at', 'desc');
 
+        let countQuery = db
+            .selectFrom('projects')
+            .innerJoin('organizations', 'organizations.id', 'projects.organization_id')
+            .select(({ fn }) => [fn.count<number>('projects.id').as('count')]);
+
         if (search) {
-            query = query.where((eb) =>
+            const applySearch = (eb: any) =>
                 eb.or([
                     eb('projects.name', 'ilike', `%${search}%`),
                     eb('organizations.name', 'ilike', `%${search}%`),
-                ])
-            );
+                ]);
+            query = query.where(applySearch);
+            // The count must apply the same filter (and join), otherwise pagination is wrong.
+            countQuery = countQuery.where(applySearch);
         }
 
         const [projects, countResult] = await Promise.all([
             query.limit(limit).offset(offset).execute(),
-            db
-                .selectFrom('projects')
-                .select(({ fn }) => [fn.count<number>('id').as('count')])
-                .executeTakeFirst(),
+            countQuery.executeTakeFirst(),
         ]);
 
         const total = Number(countResult?.count || 0);

--- a/packages/backend/src/modules/admin/service.ts
+++ b/packages/backend/src/modules/admin/service.ts
@@ -1416,6 +1416,16 @@ export class AdminService {
             throw new Error('User not found');
         }
 
+        // The session cache stores is_admin, so a demotion/promotion would not take
+        // effect until the cache TTL expires. Invalidate the cached sessions so the
+        // new role is re-read on the next request (sessions themselves stay valid).
+        const sessions = await db
+            .selectFrom('sessions')
+            .select('token')
+            .where('user_id', '=', userId)
+            .execute();
+        await Promise.all(sessions.map((sn) => CacheManager.invalidateSession(sn.token)));
+
         return user;
     }
 

--- a/packages/backend/src/modules/alerts/baseline-calculator.ts
+++ b/packages/backend/src/modules/alerts/baseline-calculator.ts
@@ -20,21 +20,46 @@ export class BaselineCalculatorService {
     projectIds: string[],
     levels: LogLevel[],
     service: string | null,
+    metadataFilters?: MetadataFilter[],
   ): Promise<BaselineResult | null> {
     if (projectIds.length === 0) return null;
 
     switch (method) {
       case 'same_time_yesterday':
-        return this.sameTimeYesterday(projectIds, levels, service);
+        return this.sameTimeYesterday(projectIds, levels, service, metadataFilters);
       case 'same_day_last_week':
-        return this.sameDayLastWeek(projectIds, levels, service);
+        return this.sameDayLastWeek(projectIds, levels, service, metadataFilters);
       case 'rolling_7d_avg':
-        return this.rolling7dAvg(projectIds, levels, service);
+        return this.rolling7dAvg(projectIds, levels, service, metadataFilters);
       case 'percentile_p95':
-        return this.percentileP95(projectIds, levels, service);
+        return this.percentileP95(projectIds, levels, service, metadataFilters);
       default:
         return null;
     }
+  }
+
+  /**
+   * Count logs in a single hour bucket honoring metadata filters. Used by the
+   * metadata-aware baseline path (the continuous aggregate / rollup has no
+   * metadata columns, so it cannot be used when filters are present).
+   */
+  private async countBucket(
+    projectIds: string[],
+    levels: LogLevel[],
+    service: string | null,
+    from: Date,
+    to: Date,
+    metadataFilters: MetadataFilter[],
+  ): Promise<number> {
+    const result = await reservoir.count({
+      projectId: projectIds,
+      from,
+      to,
+      level: levels as ReservoirLogLevel[],
+      ...(service ? { service: [service, 'unknown'] } : {}),
+      metadataFilters,
+    });
+    return result.count;
   }
 
   /**
@@ -70,6 +95,7 @@ export class BaselineCalculatorService {
     projectIds: string[],
     levels: LogLevel[],
     service: string | null,
+    metadataFilters?: MetadataFilter[],
   ): Promise<BaselineResult | null> {
     const now = new Date();
     // Get the hour bucket for 24h ago
@@ -77,6 +103,11 @@ export class BaselineCalculatorService {
     const bucketStart = new Date(yesterday);
     bucketStart.setMinutes(0, 0, 0);
     const bucketEnd = new Date(bucketStart.getTime() + 60 * 60 * 1000);
+
+    if (metadataFilters && metadataFilters.length > 0) {
+      const count = await this.countBucket(projectIds, levels, service, bucketStart, bucketEnd, metadataFilters);
+      return count > 0 ? { value: count, samplesUsed: 1 } : null;
+    }
 
     const result = await this.queryAggregate(bucketStart, bucketEnd, projectIds, levels, service);
     if (!result || result.samplesUsed === 0) return null;
@@ -90,12 +121,18 @@ export class BaselineCalculatorService {
     projectIds: string[],
     levels: LogLevel[],
     service: string | null,
+    metadataFilters?: MetadataFilter[],
   ): Promise<BaselineResult | null> {
     const now = new Date();
     const lastWeek = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const bucketStart = new Date(lastWeek);
     bucketStart.setMinutes(0, 0, 0);
     const bucketEnd = new Date(bucketStart.getTime() + 60 * 60 * 1000);
+
+    if (metadataFilters && metadataFilters.length > 0) {
+      const count = await this.countBucket(projectIds, levels, service, bucketStart, bucketEnd, metadataFilters);
+      return count > 0 ? { value: count, samplesUsed: 1 } : null;
+    }
 
     const result = await this.queryAggregate(bucketStart, bucketEnd, projectIds, levels, service);
     if (!result || result.samplesUsed === 0) return null;
@@ -111,6 +148,7 @@ export class BaselineCalculatorService {
     projectIds: string[],
     levels: LogLevel[],
     service: string | null,
+    metadataFilters?: MetadataFilter[],
   ): Promise<BaselineResult | null> {
     const now = new Date();
     const currentHour = new Date(now);
@@ -120,6 +158,27 @@ export class BaselineCalculatorService {
     const bucketTimes: Date[] = [];
     for (let i = 1; i <= 7; i++) {
       bucketTimes.push(new Date(currentHour.getTime() - i * 24 * 60 * 60 * 1000));
+    }
+
+    if (metadataFilters && metadataFilters.length > 0) {
+      // Metadata-aware path: count each of the 7 hour buckets via the reservoir
+      // (the continuous aggregate has no metadata columns). Average non-zero buckets.
+      const counts = await Promise.all(
+        bucketTimes.map((bucketStart) =>
+          this.countBucket(
+            projectIds, levels, service,
+            bucketStart, new Date(bucketStart.getTime() + 60 * 60 * 1000),
+            metadataFilters,
+          ),
+        ),
+      );
+      let total = 0;
+      let bucketCount = 0;
+      for (const c of counts) {
+        if (c > 0) { total += c; bucketCount++; }
+      }
+      if (bucketCount === 0) return null;
+      return { value: Math.round(total / bucketCount), samplesUsed: bucketCount };
     }
 
     if (reservoir.getEngineType() === 'timescale') {
@@ -201,11 +260,39 @@ export class BaselineCalculatorService {
     projectIds: string[],
     levels: LogLevel[],
     service: string | null,
+    metadataFilters?: MetadataFilter[],
   ): Promise<BaselineResult | null> {
     const fromTime = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const now = new Date();
 
     let counts: number[];
+
+    if (metadataFilters && metadataFilters.length > 0) {
+      // Metadata-aware path: count each hourly bucket over the last 7 days via the
+      // reservoir (no metadata columns in the rollup). Bounded concurrency so we
+      // don't open ~168 connections at once.
+      const currentHour = new Date(now);
+      currentHour.setMinutes(0, 0, 0);
+      const buckets: Date[] = [];
+      for (let i = 1; i <= 168; i++) {
+        buckets.push(new Date(currentHour.getTime() - i * 60 * 60 * 1000));
+      }
+      const hourly: number[] = [];
+      const CONCURRENCY = 12;
+      for (let i = 0; i < buckets.length; i += CONCURRENCY) {
+        const chunk = buckets.slice(i, i + CONCURRENCY);
+        const chunkCounts = await Promise.all(
+          chunk.map((b) =>
+            this.countBucket(projectIds, levels, service, b, new Date(b.getTime() + 60 * 60 * 1000), metadataFilters),
+          ),
+        );
+        hourly.push(...chunkCounts);
+      }
+      const nonZero = hourly.filter((c) => c > 0).sort((a, b) => a - b);
+      if (nonZero.length === 0) return null;
+      const idx = Math.min(Math.ceil(nonZero.length * 0.95) - 1, nonZero.length - 1);
+      return { value: nonZero[idx], samplesUsed: nonZero.length };
+    }
 
     if (reservoir.getEngineType() === 'timescale') {
       // Fast path: continuous aggregate (TimescaleDB only)

--- a/packages/backend/src/modules/alerts/routes.ts
+++ b/packages/backend/src/modules/alerts/routes.ts
@@ -208,7 +208,7 @@ export async function alertsRoutes(fastify: FastifyInstance) {
 
       // Associate channels with the alert rule
       if (channelIds && channelIds.length > 0) {
-        await notificationChannelsService.setAlertRuleChannels(alertRule.id, channelIds);
+        await notificationChannelsService.setAlertRuleChannels(alertRule.id, channelIds, body.organizationId);
       }
 
       const enrichedRule = await enrichAlertRuleWithChannels(alertRule);
@@ -409,7 +409,7 @@ export async function alertsRoutes(fastify: FastifyInstance) {
 
       // Update channels if provided
       if (channelIds !== undefined) {
-        await notificationChannelsService.setAlertRuleChannels(id, channelIds);
+        await notificationChannelsService.setAlertRuleChannels(id, channelIds, organizationId);
       }
 
       const enrichedRule = await enrichAlertRuleWithChannels(alertRule);

--- a/packages/backend/src/modules/alerts/service.ts
+++ b/packages/backend/src/modules/alerts/service.ts
@@ -161,7 +161,7 @@ export class AlertsService {
         alert_type: input.alertType || 'threshold',
         baseline_type: input.baselineType || null,
         deviation_multiplier: input.deviationMultiplier || null,
-        min_baseline_value: input.minBaselineValue || null,
+        min_baseline_value: input.minBaselineValue ?? null,
         cooldown_minutes: input.cooldownMinutes || null,
         sustained_minutes: input.sustainedMinutes || null,
         email_recipients: input.emailRecipients,
@@ -456,7 +456,7 @@ export class AlertsService {
     if (!rule.baseline_type || !rule.deviation_multiplier) return null;
 
     const deviationMultiplier = Number(rule.deviation_multiplier);
-    const minBaseline = Number(rule.min_baseline_value || 10);
+    const minBaseline = rule.min_baseline_value != null ? Number(rule.min_baseline_value) : 10;
     const cooldownMin = Number(rule.cooldown_minutes || 60);
     const sustainedMin = Number(rule.sustained_minutes || 5);
 

--- a/packages/backend/src/modules/alerts/service.ts
+++ b/packages/backend/src/modules/alerts/service.ts
@@ -484,12 +484,15 @@ export class AlertsService {
       }
     }
 
-    // Calculate baseline
+    // Calculate baseline. Pass the rule's metadata filters so the baseline is
+    // computed over the same filtered population as the current rate; otherwise
+    // the deviation ratio is deflated when filters are present.
     const baseline = await baselineCalculator.calculate(
       rule.baseline_type,
       projectIds,
       rule.level,
       rule.service || null,
+      ruleMetadataFilters.length > 0 ? ruleMetadataFilters : undefined,
     );
 
     if (!baseline || baseline.value < minBaseline) {

--- a/packages/backend/src/modules/api-keys/service.ts
+++ b/packages/backend/src/modules/api-keys/service.ts
@@ -170,6 +170,16 @@ export class ApiKeysService {
       return;
     }
     this.lastUsedWrites.set(keyId, now);
+    // Bound the debounce map: entries older than the debounce window no longer
+    // affect the decision, so prune them once the map grows large (otherwise it
+    // leaks one entry per distinct API key ever seen).
+    if (this.lastUsedWrites.size > 10_000) {
+      for (const [k, t] of this.lastUsedWrites) {
+        if (now - t >= ApiKeysService.LAST_USED_DEBOUNCE_MS) {
+          this.lastUsedWrites.delete(k);
+        }
+      }
+    }
     await db
       .updateTable('api_keys')
       .set({ last_used: new Date() })

--- a/packages/backend/src/modules/audit-log/service.ts
+++ b/packages/backend/src/modules/audit-log/service.ts
@@ -178,7 +178,14 @@ export class AuditLogService {
         .execute();
     } catch (err) {
       console.error('[AuditLog] flush error:', err);
+      // Re-queue the failed rows, but never let the buffer grow without bound on a
+      // persistent DB failure: cap at BUFFER_MAX, dropping the oldest excess.
       this.buffer.unshift(...toInsert);
+      if (this.buffer.length > BUFFER_MAX) {
+        const dropped = this.buffer.length - BUFFER_MAX;
+        this.buffer.splice(0, dropped);
+        console.error(`[AuditLog] buffer overflow on flush failure, dropped ${dropped} oldest audit rows`);
+      }
     } finally {
       this.flushing = false;
     }

--- a/packages/backend/src/modules/auth/authentication-service.ts
+++ b/packages/backend/src/modules/auth/authentication-service.ts
@@ -294,6 +294,15 @@ export class AuthenticationService {
         throw new Error('This account has been disabled');
       }
 
+      // Only auto-link to a pre-existing account when the provider asserts the
+      // email is verified. Otherwise an attacker could register at the IdP with a
+      // victim's (unverified) email and take over their existing account.
+      if (result.emailVerified !== true) {
+        throw new Error(
+          'Cannot link this identity to an existing account: the email address is not verified by the identity provider'
+        );
+      }
+
       // Link this external identity to the existing user
       await db
         .insertInto('user_identities')

--- a/packages/backend/src/modules/auth/providers/ldap-provider.ts
+++ b/packages/backend/src/modules/auth/providers/ldap-provider.ts
@@ -163,6 +163,7 @@ export class LdapProvider implements AuthProvider {
         success: true,
         providerUserId: userDn, // Use DN as unique identifier
         email: email.toLowerCase().trim(),
+        emailVerified: true, // LDAP directory is authoritative for the user's email
         name: name || username,
         metadata: {
           dn: userDn,

--- a/packages/backend/src/modules/auth/providers/oidc-provider.ts
+++ b/packages/backend/src/modules/auth/providers/oidc-provider.ts
@@ -209,6 +209,10 @@ export class OidcProvider implements AuthProvider {
         success: true,
         providerUserId: sub, // Use OIDC 'sub' claim as unique identifier
         email: email.toLowerCase().trim(),
+        // Only treat the email as verified when the IdP explicitly asserts it.
+        // A missing claim is treated as unverified so it cannot auto-link to an
+        // existing local account (account-takeover guard).
+        emailVerified: claims.email_verified === true,
         name: name || 'Unknown',
         metadata: {
           sub,

--- a/packages/backend/src/modules/auth/providers/types.ts
+++ b/packages/backend/src/modules/auth/providers/types.ts
@@ -67,6 +67,7 @@ export interface AuthenticationResult {
   success: boolean;
   providerUserId?: string; // External user identifier (OIDC sub, LDAP DN, email for local)
   email?: string;
+  emailVerified?: boolean; // Whether the provider asserts the email is verified (gates account linking)
   name?: string;
   metadata?: Record<string, unknown>; // Provider-specific data (claims, attributes)
   error?: string;

--- a/packages/backend/src/modules/correlation/pattern-registry.ts
+++ b/packages/backend/src/modules/correlation/pattern-registry.ts
@@ -293,8 +293,11 @@ export class IdentifierPatternRegistry {
     const seen = new Set<string>();
 
     for (const { type, pattern } of patterns) {
-      // Create new regex instance to reset lastIndex
-      const regex = new RegExp(pattern.source, pattern.flags);
+      // Create new regex instance to reset lastIndex. Force the global flag so the
+      // exec loop advances; without it a non-global regex re-matches from index 0
+      // forever.
+      const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+      const regex = new RegExp(pattern.source, flags);
       let match;
 
       while ((match = regex.exec(text)) !== null) {
@@ -305,6 +308,13 @@ export class IdentifierPatternRegistry {
         if (!seen.has(key)) {
           matches.push({ type, value });
           seen.add(key);
+        }
+
+        // Guard against zero-width matches (patterns that can match the empty
+        // string, e.g. `\d*`, `x?`). On an empty match lastIndex does not advance,
+        // so exec would return the same match forever and hang the ingest worker.
+        if (match.index === regex.lastIndex) {
+          regex.lastIndex++;
         }
       }
     }

--- a/packages/backend/src/modules/correlation/routes.ts
+++ b/packages/backend/src/modules/correlation/routes.ts
@@ -331,10 +331,14 @@ export default async function correlationRoutes(fastify: FastifyInstance) {
       }
 
       try {
-        // Determine which projects to search for these logs
+        // Determine which projects to search for these logs. A caller-supplied
+        // projectId must be intersected with the projects the user/API key can
+        // actually access, otherwise any authenticated caller could read another
+        // tenant's log identifiers by passing a foreign projectId.
+        const accessibleProjectIds = await getUserProjectIds(request as any);
         const searchProjectIds = projectId
-          ? [projectId]
-          : await getUserProjectIds(request as any);
+          ? accessibleProjectIds.filter((id) => id === projectId)
+          : accessibleProjectIds;
 
         if (searchProjectIds.length === 0) {
           return reply.status(403).send({

--- a/packages/backend/src/modules/correlation/routes.ts
+++ b/packages/backend/src/modules/correlation/routes.ts
@@ -311,6 +311,9 @@ export default async function correlationRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       // Explicit auth check (authPlugin handles auth, this ensures static analysis sees it)
       if (!requireAuth(request, reply)) return;
+      // This reads log data, so require full (read) access like the sibling read
+      // endpoints; a write-only API key must not be able to read identifiers.
+      if (!await requireFullAccess(request, reply)) return;
 
       const { logIds } = request.body;
       const { projectId } = request.query;

--- a/packages/backend/src/modules/correlation/service.ts
+++ b/packages/backend/src/modules/correlation/service.ts
@@ -258,6 +258,18 @@ export class CorrelationService {
     const logIds = identifierRows.map((row) => row.log_id);
     const identifierType = identifierRows[0].identifier_type;
 
+    // The log fetch above is capped at `limit`; count all matches in the window so
+    // `total` reflects the true number, not just the returned page.
+    const countRow = await db
+      .selectFrom('log_identifiers')
+      .select((eb) => eb.fn.countAll().as('count'))
+      .where('identifier_value', '=', identifierValue)
+      .where('project_id', '=', projectId)
+      .where('log_time', '>=', from)
+      .where('log_time', '<=', to)
+      .executeTakeFirst();
+    const total = Number(countRow?.count ?? 0);
+
     // Fetch actual logs (reservoir: works with any engine)
     const logsResult = await reservoir.getByIds({ ids: logIds, projectId });
     // Sort chronologically (getByIds returns in unspecified order)
@@ -278,7 +290,7 @@ export class CorrelationService {
         traceId: log.traceId ?? null,
         projectId: log.projectId ?? null,
       })),
-      total: sortedLogs.length,
+      total,
       timeWindow: { from, to },
     };
   }

--- a/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
+++ b/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
@@ -503,12 +503,23 @@ const metricStatFetcher: PanelDataSource<MetricStatConfig, MetricStatData> = {
       serviceName: config.serviceName ?? undefined,
     });
 
-    // Pick the latest non-null bucket
-    const latest = [...result.timeseries].reverse().find((b) => b.value != null);
+    // The window can span more than one bucket (e.g. a 24h range crossing midnight
+    // at 1d interval). For additive aggregations (sum/count) the buckets must be
+    // summed, otherwise only the latest day is counted and the stat undercounts.
+    // For avg/min/max/last/percentiles the tile shows the most recent bucket.
+    const nonNull = result.timeseries.filter((b) => b.value != null);
+    let value: number | null = null;
+    if (nonNull.length > 0) {
+      if (config.aggregation === 'sum' || config.aggregation === 'count') {
+        value = nonNull.reduce((acc, b) => acc + Number(b.value), 0);
+      } else {
+        value = Number(nonNull[nonNull.length - 1].value);
+      }
+    }
 
     return {
       metricName: result.metricName,
-      value: latest ? Number(latest.value) : null,
+      value,
       unit: config.unit,
       aggregation: config.aggregation,
     };

--- a/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
+++ b/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
@@ -299,19 +299,26 @@ const topNTableFetcher: PanelDataSource<TopNTableConfig, TopNTableData> = {
     const intervalMs = intervalToMs(config.interval);
     const from = new Date(now.getTime() - intervalMs);
 
-    const top = await reservoir.topValues({
-      field: 'message',
-      projectId: projectIds,
-      from,
-      to: now,
-      level: ['error', 'critical'],
-      limit: config.limit,
-    });
+    const [top, totalResult] = await Promise.all([
+      reservoir.topValues({
+        field: 'message',
+        projectId: projectIds,
+        from,
+        to: now,
+        level: ['error', 'critical'],
+        limit: config.limit,
+      }),
+      // True total of all error/critical logs in the window, so percentages are a
+      // share of the whole, not of just the top-N rows that fit the limit.
+      reservoir.count({
+        projectId: projectIds,
+        from,
+        to: now,
+        level: ['error', 'critical'],
+      }),
+    ]);
 
-    const total = top.values.reduce(
-      (sum: number, v: { count: number }) => sum + v.count,
-      0
-    );
+    const total = totalResult.count;
 
     return {
       rows: top.values.map((v: { value: string; count: number }) => ({

--- a/packages/backend/src/modules/custom-dashboards/routes.ts
+++ b/packages/backend/src/modules/custom-dashboards/routes.ts
@@ -189,7 +189,8 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
 
     const dashboard = await customDashboardsService.getById(
       (request.params as { id: string }).id,
-      organizationId
+      organizationId,
+      request.user.id
     );
     if (!dashboard) {
       return reply.status(404).send({ error: 'Not found' });
@@ -211,6 +212,7 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
       const dashboard = await customDashboardsService.update(
         (request.params as { id: string }).id,
         organizationId,
+        request.user.id,
         body
       );
 
@@ -282,7 +284,7 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
     }
     try {
       const dashboardId = (request.params as { id: string }).id;
-      await customDashboardsService.delete(dashboardId, organizationId);
+      await customDashboardsService.delete(dashboardId, organizationId, request.user.id);
 
       await auditLogService.record({
         action: 'dashboard.deleted',
@@ -316,7 +318,8 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
     try {
       const yamlText = await customDashboardsService.exportYaml(
         (request.params as { id: string }).id,
-        organizationId
+        organizationId,
+        request.user.id
       );
       return reply
         .header('Content-Type', 'application/x-yaml')
@@ -344,7 +347,8 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
 
       const dashboard = await customDashboardsService.getById(
         (request.params as { id: string }).id,
-        body.organizationId
+        body.organizationId,
+        request.user.id
       );
       if (!dashboard) {
         return reply.status(404).send({ error: 'Dashboard not found' });

--- a/packages/backend/src/modules/custom-dashboards/service.ts
+++ b/packages/backend/src/modules/custom-dashboards/service.ts
@@ -133,12 +133,19 @@ export class CustomDashboardsService {
     return rows.map((r) => this.mapRow(r as unknown as DashboardRow));
   }
 
-  async getById(id: string, organizationId: string): Promise<CustomDashboard | null> {
+  async getById(
+    id: string,
+    organizationId: string,
+    userId: string
+  ): Promise<CustomDashboard | null> {
     const row = await db
       .selectFrom('custom_dashboards')
       .selectAll()
       .where('id', '=', id)
       .where('organization_id', '=', organizationId)
+      // Personal dashboards are visible only to their creator (shared ones to any
+      // org member), matching list().
+      .where((eb) => eb.or([eb('is_personal', '=', false), eb('created_by', '=', userId)]))
       .executeTakeFirst();
 
     return row ? this.mapRow(row as unknown as DashboardRow) : null;
@@ -168,6 +175,7 @@ export class CustomDashboardsService {
   async update(
     id: string,
     organizationId: string,
+    userId: string,
     input: UpdateDashboardInput
   ): Promise<CustomDashboard> {
     const updates: Record<string, unknown> = { updated_at: new Date() };
@@ -185,6 +193,8 @@ export class CustomDashboardsService {
       .set(updates)
       .where('id', '=', id)
       .where('organization_id', '=', organizationId)
+      // A personal dashboard can only be edited by its creator.
+      .where((eb) => eb.or([eb('is_personal', '=', false), eb('created_by', '=', userId)]))
       .returningAll()
       .executeTakeFirst();
 
@@ -244,13 +254,15 @@ export class CustomDashboardsService {
     return this.mapRow(updated as unknown as DashboardRow);
   }
 
-  async delete(id: string, organizationId: string): Promise<void> {
+  async delete(id: string, organizationId: string, userId: string): Promise<void> {
     // Refuse to delete the default dashboard - the UI would have nothing to fall back to.
+    // A personal dashboard can only be deleted by its creator.
     const existing = await db
       .selectFrom('custom_dashboards')
       .select(['is_default'])
       .where('id', '=', id)
       .where('organization_id', '=', organizationId)
+      .where((eb) => eb.or([eb('is_personal', '=', false), eb('created_by', '=', userId)]))
       .executeTakeFirst();
 
     if (!existing) {
@@ -264,6 +276,7 @@ export class CustomDashboardsService {
       .deleteFrom('custom_dashboards')
       .where('id', '=', id)
       .where('organization_id', '=', organizationId)
+      .where((eb) => eb.or([eb('is_personal', '=', false), eb('created_by', '=', userId)]))
       .execute();
   }
 
@@ -425,8 +438,8 @@ export class CustomDashboardsService {
 
   // ─── YAML import/export ─────────────────────────────────────────────────
 
-  async exportYaml(id: string, organizationId: string): Promise<string> {
-    const dashboard = await this.getById(id, organizationId);
+  async exportYaml(id: string, organizationId: string, userId: string): Promise<string> {
+    const dashboard = await this.getById(id, organizationId, userId);
     if (!dashboard) throw new Error('Dashboard not found');
 
     const exportable = {

--- a/packages/backend/src/modules/detection-packs/service.ts
+++ b/packages/backend/src/modules/detection-packs/service.ts
@@ -1,4 +1,6 @@
 import { db } from '../../database/connection.js';
+import { context } from '@logtide/shared/context';
+import { assertWithinLimit } from '../../capabilities/index.js';
 import { DETECTION_PACKS, getPackById } from './pack-definitions.js';
 import type {
   DetectionPackWithStatus,
@@ -154,6 +156,25 @@ export class DetectionPacksService {
 
     // Default email to empty array if not provided (user can add later)
     const recipients = emailRecipients ?? [];
+
+    // Enforce the active-rule cap for the whole batch this pack would create,
+    // so enabling a pack cannot bypass sigma.max_active_rules (parity with the
+    // single-import and SigmaHQ-sync paths).
+    await context.runAsSystem('detection-pack:enable-limit-check', async () => {
+      await context.with({ organizationId }, async () => {
+        const activeCountRow = await db
+          .selectFrom('sigma_rules')
+          .select((eb) => eb.fn.countAll().as('count'))
+          .where('organization_id', '=', organizationId)
+          .where('enabled', '=', true)
+          .executeTakeFirst();
+        await assertWithinLimit(
+          'sigma.max_active_rules',
+          Number(activeCountRow?.count ?? 0),
+          pack.rules.length
+        );
+      });
+    });
 
     // Start transaction
     await db.transaction().execute(async (trx) => {

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -238,7 +238,15 @@ export class DigestGeneratorService {
       hub.captureLog('info', `[DigestGenerator] Email sent to ${recipient.email}`);
     });
 
-    await Promise.all(emailPromises);
+    // One recipient failing must not abort the rest. Send all, then report.
+    const results = await Promise.allSettled(emailPromises);
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failures.length > 0) {
+      hub.captureLog(
+        'error',
+        `[DigestGenerator] ${failures.length}/${recipients.length} digest emails failed to send`
+      );
+    }
   }
 
   //email template

--- a/packages/backend/src/modules/exceptions/parsers/python-parser.ts
+++ b/packages/backend/src/modules/exceptions/parsers/python-parser.ts
@@ -81,7 +81,14 @@ export class PythonExceptionParser extends BaseExceptionParser {
 
     if (frames.length === 0) return null;
 
+    // Python tracebacks list the oldest call first; reverse so the most recent
+    // frame is first, then assign frameIndex to that order. Without assigning it,
+    // every frame would be stored with an undefined frame_index and the order
+    // (this reverse) would be lost on retrieval.
     frames.reverse();
+    frames.forEach((frame, index) => {
+      frame.frameIndex = index;
+    });
 
     return {
       exceptionType,

--- a/packages/backend/src/modules/exceptions/routes.ts
+++ b/packages/backend/src/modules/exceptions/routes.ts
@@ -544,6 +544,12 @@ export async function exceptionsRoutes(fastify: FastifyInstance) {
           request.user.id
         );
 
+        // The row can disappear between the existence check and the update under
+        // concurrency; don't return 200 with a null body.
+        if (!group) {
+          return reply.status(404).send({ error: 'Error group not found' });
+        }
+
         return reply.send(group);
       } catch (error: any) {
         if (error instanceof z.ZodError) {

--- a/packages/backend/src/modules/ingestion/routes.ts
+++ b/packages/backend/src/modules/ingestion/routes.ts
@@ -20,15 +20,13 @@ const parseNdjson = (body: string): object[] => {
   });
 };
 
-// Detect if this is a systemd-journald formatted log.
-// Only the journald-specific trusted fields (underscore-prefixed) and
-// SYSLOG_IDENTIFIER are reliable signals. `MESSAGE`/`PRIORITY` alone are NOT:
-// an ordinary structured log can legitimately carry an uppercase MESSAGE or
-// PRIORITY field and must not be misrouted to the journald parser.
+// Detect if this is a systemd-journald formatted log. Fluent Bit forwards
+// journald entries using the uppercase MESSAGE/PRIORITY field names (often with
+// no other identifiers), so those are treated as journald signals by design.
 const isJournaldFormat = (data: any): boolean => {
-  return Boolean(
-    data._SYSTEMD_UNIT || data._COMM || data._EXE || data._HOSTNAME || data.SYSLOG_IDENTIFIER
-  );
+  return data._SYSTEMD_UNIT || data._COMM || data._EXE ||
+         data.SYSLOG_IDENTIFIER || data.MESSAGE !== undefined ||
+         data.PRIORITY !== undefined || data._HOSTNAME;
 };
 
 // Extract service name from journald fields

--- a/packages/backend/src/modules/ingestion/routes.ts
+++ b/packages/backend/src/modules/ingestion/routes.ts
@@ -20,11 +20,15 @@ const parseNdjson = (body: string): object[] => {
   });
 };
 
-// Detect if this is a systemd-journald formatted log
+// Detect if this is a systemd-journald formatted log.
+// Only the journald-specific trusted fields (underscore-prefixed) and
+// SYSLOG_IDENTIFIER are reliable signals. `MESSAGE`/`PRIORITY` alone are NOT:
+// an ordinary structured log can legitimately carry an uppercase MESSAGE or
+// PRIORITY field and must not be misrouted to the journald parser.
 const isJournaldFormat = (data: any): boolean => {
-  return data._SYSTEMD_UNIT || data._COMM || data._EXE ||
-         data.SYSLOG_IDENTIFIER || data.MESSAGE !== undefined ||
-         data.PRIORITY !== undefined || data._HOSTNAME;
+  return Boolean(
+    data._SYSTEMD_UNIT || data._COMM || data._EXE || data._HOSTNAME || data.SYSLOG_IDENTIFIER
+  );
 };
 
 // Extract service name from journald fields

--- a/packages/backend/src/modules/ingestion/routes.ts
+++ b/packages/backend/src/modules/ingestion/routes.ts
@@ -117,7 +117,10 @@ const normalizeLevel = (level: any): string => {
   if (level === null || level === undefined || level === '' || typeof level === 'boolean') {
     return 'info';
   }
-  if (typeof level === 'number' || !isNaN(Number(level))) {
+  // Treat as numeric only for real numbers or clean numeric strings. A bare
+  // Number() coercion would turn whitespace into 0, and accept "1e3"/"0x10"/
+  // "Infinity", misclassifying odd strings as numeric severities.
+  if (typeof level === 'number' || (typeof level === 'string' && /^\s*\d+(\.\d+)?\s*$/.test(level))) {
     const numLevel = Number(level);
     if (numLevel >= 60) return 'critical';
     if (numLevel >= 50) return 'error';
@@ -461,19 +464,22 @@ const ingestionRoutes: FastifyPluginAsync = async (fastify) => {
           rawLogs = body;
         }
 
-        // Normalize and validate each log
+        // Normalize and validate each log. Track which submitted-batch index each
+        // valid log came from so rejection indices can be remapped back.
         const validLogs = [];
+        const validOriginalIndices: number[] = [];
         const errors = [];
 
-        for (const logData of rawLogs) {
-          const log = normalizeLogData(logData);
+        for (let i = 0; i < rawLogs.length; i++) {
+          const log = normalizeLogData(rawLogs[i]);
 
           const parseResult = logSchema.safeParse(log);
 
           if (parseResult.success) {
             validLogs.push(parseResult.data);
+            validOriginalIndices.push(i);
           } else {
-            errors.push({ log: logData, error: parseResult.error.format() });
+            errors.push({ log: rawLogs[i], error: parseResult.error.format() });
           }
         }
 
@@ -485,9 +491,15 @@ const ingestionRoutes: FastifyPluginAsync = async (fastify) => {
         }
 
         const result = await ingestionService.ingestLogs(validLogs, projectId);
+        // ingestLogs indexes rejections against validLogs; remap to the index in
+        // the batch the client actually submitted.
+        const rejected = result.rejected.map((r) => ({
+          ...r,
+          index: validOriginalIndices[r.index] ?? r.index,
+        }));
         return {
           received: result.received,
-          ...(result.rejected.length > 0 && { rejected: result.rejected }),
+          ...(rejected.length > 0 && { rejected }),
           timestamp: new Date().toISOString(),
         };
       }

--- a/packages/backend/src/modules/invitations/service.ts
+++ b/packages/backend/src/modules/invitations/service.ts
@@ -283,8 +283,9 @@ export class InvitationsService {
       ])
       .where('organization_invitations.token', '=', token)
       .where('organization_invitations.accepted_at', 'is', null)
-      // Do not surface expired invitations to the public preview endpoint.
-      .where('organization_invitations.expires_at', '>', new Date())
+      // Expired invitations are intentionally still returned here so the public
+      // preview page can show an "expired" message; acceptInvitation separately
+      // rejects expired tokens.
       .executeTakeFirst();
 
     if (!result) {

--- a/packages/backend/src/modules/invitations/service.ts
+++ b/packages/backend/src/modules/invitations/service.ts
@@ -283,6 +283,8 @@ export class InvitationsService {
       ])
       .where('organization_invitations.token', '=', token)
       .where('organization_invitations.accepted_at', 'is', null)
+      // Do not surface expired invitations to the public preview endpoint.
+      .where('organization_invitations.expires_at', '>', new Date())
       .executeTakeFirst();
 
     if (!result) {

--- a/packages/backend/src/modules/maintenances/routes.ts
+++ b/packages/backend/src/modules/maintenances/routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { maintenanceService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
 import { db } from '../../database/connection.js';
+import { projectsService } from '../projects/service.js';
 
 async function checkOrgAdmin(userId: string, organizationId: string): Promise<boolean> {
   const member = await db
@@ -82,6 +83,13 @@ export async function maintenanceRoutes(fastify: FastifyInstance) {
 
     if (!(await checkOrgAdmin(request.user.id, parse.data.organizationId))) {
       return reply.status(403).send({ error: 'Admin or owner role required' });
+    }
+
+    // The projectId is attacker-controlled in the body; ensure it belongs to the
+    // caller's organization, otherwise a maintenance with a victim project_id
+    // could be injected onto another tenant's public status page.
+    if (!(await projectsService.projectBelongsToOrg(parse.data.projectId, parse.data.organizationId))) {
+      return reply.status(400).send({ error: 'projectId does not belong to the organization' });
     }
 
     const maintenance = await maintenanceService.create({

--- a/packages/backend/src/modules/monitoring/routes.ts
+++ b/packages/backend/src/modules/monitoring/routes.ts
@@ -264,7 +264,7 @@ export async function monitoringRoutes(fastify: FastifyInstance) {
     const monitor = await monitorService.getMonitor(id, organizationId);
     if (!monitor) return reply.status(404).send({ error: 'Not found' });
 
-    await notificationChannelsService.setMonitorChannels(id, parse.data.channelIds);
+    await notificationChannelsService.setMonitorChannels(id, parse.data.channelIds, organizationId);
     return reply.status(204).send();
   });
 }
@@ -281,9 +281,9 @@ export async function heartbeatRoutes(fastify: FastifyInstance) {
   }, async (request: any, reply) => {
     const monitorId = request.params.id;
 
-    // API key path: global auth plugin set organizationId
+    // API key path: global auth plugin set organizationId and the key-bound projectId.
     if (request.organizationId) {
-      await monitorService.recordHeartbeat(monitorId, request.organizationId);
+      await monitorService.recordHeartbeat(monitorId, request.organizationId, request.projectId);
       return reply.status(204).send();
     }
 

--- a/packages/backend/src/modules/monitoring/service.ts
+++ b/packages/backend/src/modules/monitoring/service.ts
@@ -270,7 +270,9 @@ export class MonitorService {
   // ============================================================================
 
   async getProjectByOrgAndSlug(orgSlug: string, projectSlug: string) {
-    return this.db
+    // `?? null` must apply to the resolved row, not the Promise (which is never
+    // nullish), so await first.
+    const row = await this.db
       .selectFrom('projects')
       .innerJoin('organizations', 'organizations.id', 'projects.organization_id')
       .select([
@@ -283,7 +285,8 @@ export class MonitorService {
       ])
       .where('organizations.slug', '=', orgSlug)
       .where('projects.slug', '=', projectSlug)
-      .executeTakeFirst() ?? null;
+      .executeTakeFirst();
+    return row ?? null;
   }
 
   async getPublicStatus(projectSlug: string, verifiedProjectId?: string): Promise<PublicStatusPage | null> {

--- a/packages/backend/src/modules/monitoring/service.ts
+++ b/packages/backend/src/modules/monitoring/service.ts
@@ -185,15 +185,21 @@ export class MonitorService {
   // HEARTBEAT
   // ============================================================================
 
-  async recordHeartbeat(monitorId: string, organizationId: string): Promise<void> {
-    const monitor = await this.db
+  async recordHeartbeat(monitorId: string, organizationId: string, projectId?: string): Promise<void> {
+    let query = this.db
       .selectFrom('monitors')
       .select(['id', 'type', 'project_id'])
       .where('id', '=', monitorId)
       .where('organization_id', '=', organizationId)
       .where('type', '=', 'heartbeat')
-      .where('enabled', '=', true)
-      .executeTakeFirst();
+      .where('enabled', '=', true);
+
+    // A project-scoped API key may only ping monitors of its own project.
+    if (projectId) {
+      query = query.where('project_id', '=', projectId);
+    }
+
+    const monitor = await query.executeTakeFirst();
 
     if (!monitor) {
       throw new Error('Heartbeat monitor not found or not enabled');

--- a/packages/backend/src/modules/notification-channels/routes.ts
+++ b/packages/backend/src/modules/notification-channels/routes.ts
@@ -408,6 +408,14 @@ export async function notificationChannelsRoutes(fastify: FastifyInstance) {
         return reply.status(403).send({ error: 'Only admins can update default channels' });
       }
 
+      // Channels must belong to this org: prevent setting defaults to another
+      // tenant's channels.
+      if (!(await notificationChannelsService.channelsBelongToOrg(channelIds, organizationId))) {
+        return reply
+          .status(400)
+          .send({ error: 'One or more channels do not belong to this organization' });
+      }
+
       await notificationChannelsService.setOrganizationDefaults(
         organizationId,
         eventType as NotificationEventType,

--- a/packages/backend/src/modules/notification-channels/routes.ts
+++ b/packages/backend/src/modules/notification-channels/routes.ts
@@ -436,7 +436,23 @@ export async function notificationChannelsRoutes(fastify: FastifyInstance) {
         return reply.status(400).send({ error: 'alertRuleId is required' });
       }
 
-      const channels = await notificationChannelsService.getAlertRuleChannels(alertRuleId);
+      // Resolve the rule's organization and require the caller to be a member,
+      // then scope the channel read to that org. Without this any authenticated
+      // user could read another tenant's channels (incl. webhook secrets).
+      const organizationId =
+        await notificationChannelsService.getAlertRuleOrganizationId(alertRuleId);
+      if (!organizationId) {
+        return reply.status(404).send({ error: 'Alert rule not found' });
+      }
+      const isMember = await checkOrganizationMembership(request.user.id, organizationId);
+      if (!isMember) {
+        return reply.status(403).send({ error: 'Access denied' });
+      }
+
+      const channels = await notificationChannelsService.getAlertRuleChannels(
+        alertRuleId,
+        organizationId
+      );
       return reply.send({ channels });
     } catch (error) {
       console.error(error, 'Failed to get alert rule channels');
@@ -456,7 +472,22 @@ export async function notificationChannelsRoutes(fastify: FastifyInstance) {
         return reply.status(400).send({ error: 'sigmaRuleId is required' });
       }
 
-      const channels = await notificationChannelsService.getSigmaRuleChannels(sigmaRuleId);
+      // Resolve the rule's organization and require the caller to be a member,
+      // then scope the channel read to that org (see alert-rules above).
+      const organizationId =
+        await notificationChannelsService.getSigmaRuleOrganizationId(sigmaRuleId);
+      if (!organizationId) {
+        return reply.status(404).send({ error: 'Sigma rule not found' });
+      }
+      const isMember = await checkOrganizationMembership(request.user.id, organizationId);
+      if (!isMember) {
+        return reply.status(403).send({ error: 'Access denied' });
+      }
+
+      const channels = await notificationChannelsService.getSigmaRuleChannels(
+        sigmaRuleId,
+        organizationId
+      );
       return reply.send({ channels });
     } catch (error) {
       console.error(error, 'Failed to get sigma rule channels');

--- a/packages/backend/src/modules/notification-channels/service.ts
+++ b/packages/backend/src/modules/notification-channels/service.ts
@@ -192,7 +192,14 @@ export class NotificationChannelsService {
   /**
    * Set channels for an alert rule (replaces existing)
    */
-  async setAlertRuleChannels(alertRuleId: string, channelIds: string[]): Promise<void> {
+  async setAlertRuleChannels(
+    alertRuleId: string,
+    channelIds: string[],
+    organizationId: string
+  ): Promise<void> {
+    if (channelIds.length > 0 && !(await this.channelsBelongToOrg(channelIds, organizationId))) {
+      throw new Error('One or more channels do not belong to this organization');
+    }
     await db.transaction().execute(async (trx) => {
       // Delete existing associations
       await trx
@@ -260,7 +267,14 @@ export class NotificationChannelsService {
   /**
    * Set channels for a sigma rule (replaces existing)
    */
-  async setSigmaRuleChannels(sigmaRuleId: string, channelIds: string[]): Promise<void> {
+  async setSigmaRuleChannels(
+    sigmaRuleId: string,
+    channelIds: string[],
+    organizationId: string
+  ): Promise<void> {
+    if (channelIds.length > 0 && !(await this.channelsBelongToOrg(channelIds, organizationId))) {
+      throw new Error('One or more channels do not belong to this organization');
+    }
     await db.transaction().execute(async (trx) => {
       await trx
         .deleteFrom('sigma_rule_channels')
@@ -326,7 +340,14 @@ export class NotificationChannelsService {
   /**
    * Set channels for a monitor (replaces existing)
    */
-  async setMonitorChannels(monitorId: string, channelIds: string[]): Promise<void> {
+  async setMonitorChannels(
+    monitorId: string,
+    channelIds: string[],
+    organizationId: string
+  ): Promise<void> {
+    if (channelIds.length > 0 && !(await this.channelsBelongToOrg(channelIds, organizationId))) {
+      throw new Error('One or more channels do not belong to this organization');
+    }
     await db.transaction().execute(async (trx) => {
       await trx
         .deleteFrom('monitor_channels')

--- a/packages/backend/src/modules/notification-channels/service.ts
+++ b/packages/backend/src/modules/notification-channels/service.ts
@@ -467,6 +467,19 @@ export class NotificationChannelsService {
   /**
    * Set default channels for an event type in an organization
    */
+  /** True if every channel id belongs to the given organization. */
+  async channelsBelongToOrg(channelIds: string[], organizationId: string): Promise<boolean> {
+    const unique = [...new Set(channelIds)];
+    if (unique.length === 0) return true;
+    const rows = await db
+      .selectFrom('notification_channels')
+      .select('id')
+      .where('id', 'in', unique)
+      .where('organization_id', '=', organizationId)
+      .execute();
+    return rows.length === unique.length;
+  }
+
   async setOrganizationDefaults(
     organizationId: string,
     eventType: NotificationEventType,

--- a/packages/backend/src/modules/notification-channels/service.ts
+++ b/packages/backend/src/modules/notification-channels/service.ts
@@ -218,8 +218,11 @@ export class NotificationChannelsService {
   /**
    * Get channels for an alert rule
    */
-  async getAlertRuleChannels(alertRuleId: string): Promise<NotificationChannel[]> {
-    const rows = await db
+  async getAlertRuleChannels(
+    alertRuleId: string,
+    organizationId?: string
+  ): Promise<NotificationChannel[]> {
+    let query = db
       .selectFrom('alert_rule_channels')
       .innerJoin(
         'notification_channels',
@@ -228,10 +231,26 @@ export class NotificationChannelsService {
       )
       .selectAll('notification_channels')
       .where('alert_rule_channels.alert_rule_id', '=', alertRuleId)
-      .where('notification_channels.enabled', '=', true)
-      .execute();
+      .where('notification_channels.enabled', '=', true);
+
+    // Optional org scoping: defense in depth for tenant-facing callers.
+    if (organizationId) {
+      query = query.where('notification_channels.organization_id', '=', organizationId);
+    }
+
+    const rows = await query.execute();
 
     return rows.map((r) => this.mapChannel(r));
+  }
+
+  /** Organization that owns an alert rule, or null if the rule does not exist. */
+  async getAlertRuleOrganizationId(alertRuleId: string): Promise<string | null> {
+    const row = await db
+      .selectFrom('alert_rules')
+      .select('organization_id')
+      .where('id', '=', alertRuleId)
+      .executeTakeFirst();
+    return row?.organization_id ?? null;
   }
 
   // ============================================================================
@@ -265,8 +284,11 @@ export class NotificationChannelsService {
   /**
    * Get channels for a sigma rule
    */
-  async getSigmaRuleChannels(sigmaRuleId: string): Promise<NotificationChannel[]> {
-    const rows = await db
+  async getSigmaRuleChannels(
+    sigmaRuleId: string,
+    organizationId?: string
+  ): Promise<NotificationChannel[]> {
+    let query = db
       .selectFrom('sigma_rule_channels')
       .innerJoin(
         'notification_channels',
@@ -275,10 +297,26 @@ export class NotificationChannelsService {
       )
       .selectAll('notification_channels')
       .where('sigma_rule_channels.sigma_rule_id', '=', sigmaRuleId)
-      .where('notification_channels.enabled', '=', true)
-      .execute();
+      .where('notification_channels.enabled', '=', true);
+
+    // Optional org scoping: defense in depth for tenant-facing callers.
+    if (organizationId) {
+      query = query.where('notification_channels.organization_id', '=', organizationId);
+    }
+
+    const rows = await query.execute();
 
     return rows.map((r) => this.mapChannel(r));
+  }
+
+  /** Organization that owns a sigma rule, or null if the rule does not exist. */
+  async getSigmaRuleOrganizationId(sigmaRuleId: string): Promise<string | null> {
+    const row = await db
+      .selectFrom('sigma_rules')
+      .select('organization_id')
+      .where('id', '=', sigmaRuleId)
+      .executeTakeFirst();
+    return row?.organization_id ?? null;
   }
 
   // ============================================================================

--- a/packages/backend/src/modules/organizations/service.ts
+++ b/packages/backend/src/modules/organizations/service.ts
@@ -470,6 +470,12 @@ export class OrganizationsService {
       throw new Error('Cannot demote yourself from owner. Transfer ownership first.');
     }
 
+    // Admins may only manage plain members and may not grant the admin role
+    // (creating peer admins is owner-only), consistent with removeMember.
+    if (currentUserMember.role === 'admin' && (targetMember.role !== 'member' || newRole !== 'member')) {
+      throw new Error('Admins can only manage member-level roles');
+    }
+
     await db
       .updateTable('organization_members')
       .set({ role: newRole })

--- a/packages/backend/src/modules/otlp/parser.ts
+++ b/packages/backend/src/modules/otlp/parser.ts
@@ -396,10 +396,15 @@ function normalizeTraceSpanId(id: unknown): string | undefined {
         const buffer = Buffer.from(id, 'base64');
         return buffer.toString('hex');
       } catch {
-        return id; // Return as-is if conversion fails
+        return undefined; // malformed
       }
     }
-    return id;
+    // Hex string: only the canonical span (16) and trace (32) hex lengths are
+    // valid per OTLP. Drop other lengths instead of propagating a malformed id.
+    if (id.length === 16 || id.length === 32) {
+      return id.toLowerCase();
+    }
+    return undefined;
   }
 
   // If Uint8Array, convert to hex

--- a/packages/backend/src/modules/otlp/severity-mapper.ts
+++ b/packages/backend/src/modules/otlp/severity-mapper.ts
@@ -31,16 +31,18 @@ export function mapSeverityToLevel(
   severityNumber?: number,
   severityText?: string
 ): LogTideLevel {
-  // Try severityText first if provided (allows custom SDK severity names)
+  // Try severityText first if provided (allows custom SDK severity names).
+  // Match on a word-start boundary rather than a bare substring so an unrelated
+  // text like "unwarranted" does not match "warn" and override the number.
   if (severityText) {
     const normalized = severityText.toLowerCase();
 
-    if (normalized.includes('trace')) return 'debug';
-    if (normalized.includes('debug')) return 'debug';
-    if (normalized.includes('info')) return 'info';
-    if (normalized.includes('warn')) return 'warn';
-    if (normalized.includes('error')) return 'error';
-    if (normalized.includes('fatal') || normalized.includes('critical')) return 'critical';
+    if (/\btrace/.test(normalized)) return 'debug';
+    if (/\bdebug/.test(normalized)) return 'debug';
+    if (/\binfo/.test(normalized)) return 'info';
+    if (/\bwarn/.test(normalized)) return 'warn';
+    if (/\berror/.test(normalized)) return 'error';
+    if (/\bfatal/.test(normalized) || /\bcritical/.test(normalized)) return 'critical';
   }
 
   // Map by severity number

--- a/packages/backend/src/modules/pii-masking/service.ts
+++ b/packages/backend/src/modules/pii-masking/service.ts
@@ -594,8 +594,10 @@ export class PiiMaskingService {
   // -------------------------------------------------------------------------
 
   private maskText(text: string, ruleSet: CompiledRuleSet): string {
-    // Early exit: very short strings or pure alphanumeric won't contain PII
-    if (text.length < 6 || /^[a-zA-Z0-9 _]+$/.test(text)) {
+    // Early exit only for strings too short to contain any supported PII. Do NOT
+    // skip pure-alphanumeric strings: credit card numbers, account numbers, phone
+    // numbers and similar are all-digit and must still run through the rules.
+    if (text.length < 6) {
       return text;
     }
 

--- a/packages/backend/src/modules/query/routes.ts
+++ b/packages/backend/src/modules/query/routes.ts
@@ -722,7 +722,12 @@ const queryRoutes: FastifyPluginAsync = async (fastify) => {
       reply.raw.write(`data: ${JSON.stringify({ type: 'connected', timestamp: new Date() })}\n\n`);
 
       // Poll for new logs every second
+      let polling = false;
       const intervalId = setInterval(async () => {
+        // Re-entrancy guard: skip this tick if the previous poll is still running
+        // (a slow query must not overlap and corrupt lastTimestamp/sentIds).
+        if (polling) return;
+        polling = true;
         try {
           const newLogs = await queryService.queryLogs({
             projectId,
@@ -732,6 +737,8 @@ const queryRoutes: FastifyPluginAsync = async (fastify) => {
             to: new Date(),
             limit: 100,
             offset: 0,
+            // Live tail must see fresh data; the 60s query cache would stall it.
+            skipCache: true,
           });
 
           if (newLogs.logs.length > 0) {
@@ -770,6 +777,8 @@ const queryRoutes: FastifyPluginAsync = async (fastify) => {
           console.error('Error in SSE stream:', error);
           clearInterval(intervalId);
           reply.raw.end();
+        } finally {
+          polling = false;
         }
       }, 1000);
 

--- a/packages/backend/src/modules/query/service.ts
+++ b/packages/backend/src/modules/query/service.ts
@@ -24,6 +24,7 @@ export interface LogQueryParams {
   limit?: number;
   offset?: number;
   cursor?: string;
+  skipCache?: boolean; // Bypass the query cache (e.g. for per-second live tail polling)
 }
 
 export class QueryService {
@@ -61,6 +62,7 @@ export class QueryService {
       limit = 100,
       offset = 0,
       cursor,
+      skipCache = false,
     } = params;
 
     // PERFORMANCE: Default to last 24h if no time filter provided
@@ -83,7 +85,7 @@ export class QueryService {
       cursor: cursor || null,
     };
     const cacheKey = CacheManager.queryKey(projectId, cacheParams);
-    const cached = await CacheManager.get<any>(cacheKey);
+    const cached = skipCache ? null : await CacheManager.get<any>(cacheKey);
 
     if (cached && cached.total !== -1) {
       return {
@@ -144,7 +146,9 @@ export class QueryService {
       nextCursor: queryResult.nextCursor,
     };
 
-    await CacheManager.set(cacheKey, result, CACHE_TTL.QUERY);
+    if (!skipCache) {
+      await CacheManager.set(cacheKey, result, CACHE_TTL.QUERY);
+    }
 
     return result;
   }

--- a/packages/backend/src/modules/query/service.ts
+++ b/packages/backend/src/modules/query/service.ts
@@ -329,26 +329,39 @@ export class QueryService {
     try {
       if (reservoir.getEngineType() !== 'timescale') throw new Error('skip aggregate');
 
-      // Fast path: use continuous aggregate (TimescaleDB only)
+      // Fast path: use continuous aggregate (TimescaleDB only). Split the window
+      // at oneDayAgo: the historical part comes from logs_daily_stats, the recent
+      // part from raw data. Both halves must honor the requested [from, to] bounds.
       const { sql } = await import('kysely');
       const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const toDate = to ?? new Date();
+
+      // Historical upper bound is min(oneDayAgo, to); recent lower bound is
+      // max(oneDayAgo, from). Either half may be empty for a fully-recent or
+      // fully-historical window.
+      const historicalUpper = toDate < oneDayAgo ? toDate : oneDayAgo;
+      const recentFrom = effectiveFrom > oneDayAgo ? effectiveFrom : oneDayAgo;
+
+      const historicalPromise =
+        effectiveFrom < historicalUpper
+          ? db
+              .selectFrom('logs_daily_stats')
+              .select(['service', sql<string>`SUM(log_count)`.as('count')])
+              .where('project_id', '=', projectId)
+              .where('bucket', '>=', effectiveFrom)
+              .where('bucket', '<', historicalUpper)
+              .groupBy('service')
+              .execute()
+          : Promise.resolve([] as Array<{ service: string; count: string }>);
+
+      const recentPromise =
+        toDate > recentFrom
+          ? reservoir.topValues({ field: 'service', projectId, from: recentFrom, to: toDate, limit: 100 })
+          : Promise.resolve({ values: [] as Array<{ value: string; count: number }> });
 
       const [historicalServices, recentServices] = await Promise.all([
-        db
-          .selectFrom('logs_daily_stats')
-          .select(['service', sql<string>`SUM(log_count)`.as('count')])
-          .where('project_id', '=', projectId)
-          .where('bucket', '>=', effectiveFrom)
-          .where('bucket', '<', oneDayAgo)
-          .groupBy('service')
-          .execute(),
-        reservoir.topValues({
-          field: 'service',
-          projectId,
-          from: oneDayAgo,
-          to: to ?? new Date(),
-          limit: 100,
-        }),
+        historicalPromise,
+        recentPromise,
       ]);
 
       const serviceMap = new Map<string, number>();

--- a/packages/backend/src/modules/query/websocket.ts
+++ b/packages/backend/src/modules/query/websocket.ts
@@ -21,7 +21,12 @@ import { verifyProjectAccess } from '../auth/verify-project-access.js';
  * Connection rate is implicitly limited by authentication requirements.
  */
 const websocketRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get('/api/v1/logs/ws', { websocket: true }, async (socket, req: any) => {
+  fastify.get('/api/v1/logs/ws', {
+    websocket: true,
+    // Rate-limit the connection upgrade: the handler does a session lookup and a
+    // project-membership check (DB), so cap the connection attempt rate per client.
+    config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+  }, async (socket, req: any) => {
     const { projectId, service, level, hostname, token } = req.query as {
       projectId: string;
       service?: string | string[];

--- a/packages/backend/src/modules/query/websocket.ts
+++ b/packages/backend/src/modules/query/websocket.ts
@@ -8,6 +8,7 @@ import {
   type LogSubscriber,
 } from '../streaming/index.js';
 import { randomUUID } from 'crypto';
+import { verifyProjectAccess } from '../auth/verify-project-access.js';
 
 /**
  * WebSocket routes for real-time log streaming.
@@ -35,13 +36,21 @@ const websocketRoutes: FastifyPluginAsync = async (fastify) => {
       return;
     }
 
-    // Verify session token (reuse session validation logic)
+    if (!projectId) {
+      socket.close(1008, 'ProjectId required');
+      return;
+    }
+
+    // Verify session token (reuse session validation logic) and that the
+    // authenticated user actually has access to the requested project. The REST
+    // log/trace/metric routes all gate on verifyProjectAccess; without the same
+    // check here, any authenticated user could live-tail any project's logs by
+    // passing a foreign projectId (cross-tenant leak).
     try {
       const session = await db
         .selectFrom('sessions')
         .innerJoin('users', 'users.id', 'sessions.user_id')
-        .selectAll('users')
-        .select('sessions.expires_at')
+        .select(['users.id as userId', 'sessions.expires_at'])
         .where('sessions.token', '=', token)
         .executeTakeFirst();
 
@@ -49,14 +58,15 @@ const websocketRoutes: FastifyPluginAsync = async (fastify) => {
         socket.close(1008, 'Invalid or expired authentication token');
         return;
       }
+
+      const hasAccess = await verifyProjectAccess(projectId, session.userId);
+      if (!hasAccess) {
+        socket.close(1008, 'Access denied for the requested project');
+        return;
+      }
     } catch (error) {
       console.error('[WebSocket] Authentication error:', error);
       socket.close(1011, 'Internal Server Error');
-      return;
-    }
-
-    if (!projectId) {
-      socket.close(1008, 'ProjectId required');
       return;
     }
 

--- a/packages/backend/src/modules/settings/service.ts
+++ b/packages/backend/src/modules/settings/service.ts
@@ -58,9 +58,12 @@ export class SettingsService {
   ): Promise<SystemSettings[K]> {
     // Try cache first
     const cacheKey = CacheManager.settingsKey(key);
-    const cached = await CacheManager.get<SystemSettings[K]>(cacheKey);
+    // Wrap in an envelope so a legitimately-null setting value (e.g.
+    // auth.default_user_id) is distinguishable from a cache miss (both would
+    // otherwise be `null` from CacheManager.get).
+    const cached = await CacheManager.get<{ v: SystemSettings[K] }>(cacheKey);
     if (cached !== null) {
-      return cached;
+      return cached.v;
     }
 
     // Fallback to DB
@@ -72,8 +75,8 @@ export class SettingsService {
 
     const value = (result?.value ?? defaultValue ?? DEFAULT_VALUES[key]) as SystemSettings[K];
 
-    // Cache the result
-    await CacheManager.set(cacheKey, value, CACHE_TTL.SETTINGS);
+    // Cache the result (enveloped, see the get above)
+    await CacheManager.set(cacheKey, { v: value }, CACHE_TTL.SETTINGS);
 
     return value;
   }

--- a/packages/backend/src/modules/siem/enrichment-service.ts
+++ b/packages/backend/src/modules/siem/enrichment-service.ts
@@ -71,7 +71,7 @@ export class EnrichmentService {
     return {
       ip: result.ip,
       reputation: result.reputation,
-      abuseConfidenceScore: result.score * 10, // Convert to 0-100 scale (approx)
+      abuseConfidenceScore: Math.min(100, result.score * 10), // Convert to 0-100 scale (approx), clamped
       source: 'IPsum',
       lastChecked: result.lastChecked,
     };

--- a/packages/backend/src/modules/siem/service.ts
+++ b/packages/backend/src/modules/siem/service.ts
@@ -311,11 +311,23 @@ export class SiemService {
   ): Promise<void> {
     if (detectionEventIds.length === 0) return;
 
+    // Only link detection events that actually belong to this organization.
+    // Otherwise the incident_alerts insert would link cross-tenant events and the
+    // detection_count would be inflated by events that were never updated.
+    const owned = await this.db
+      .selectFrom('detection_events')
+      .select('id')
+      .where('id', 'in', detectionEventIds)
+      .where('organization_id', '=', organizationId)
+      .execute();
+    const ownedIds = owned.map((r) => r.id);
+    if (ownedIds.length === 0) return;
+
     // Insert incident_alerts entries
     await this.db
       .insertInto('incident_alerts')
       .values(
-        detectionEventIds.map((eventId) => ({
+        ownedIds.map((eventId) => ({
           incident_id: incidentId,
           detection_event_id: eventId,
           alert_history_id: null,
@@ -327,7 +339,7 @@ export class SiemService {
     await this.db
       .updateTable('detection_events')
       .set({ incident_id: incidentId })
-      .where('id', 'in', detectionEventIds)
+      .where('id', 'in', ownedIds)
       .where('organization_id', '=', organizationId)
       .execute();
 
@@ -335,7 +347,7 @@ export class SiemService {
     await this.db
       .updateTable('incidents')
       .set({
-        detection_count: sql`detection_count + ${detectionEventIds.length}`,
+        detection_count: sql`detection_count + ${ownedIds.length}`,
       })
       .where('id', '=', incidentId)
       .where('organization_id', '=', organizationId)

--- a/packages/backend/src/modules/sigma/condition-evaluator.ts
+++ b/packages/backend/src/modules/sigma/condition-evaluator.ts
@@ -85,7 +85,12 @@ export class SigmaConditionEvaluator {
   }
 
   /**
-   * Parse and evaluate expression (recursive descent parser)
+   * Parse and evaluate an OR expression (lowest precedence).
+   *
+   * Sigma follows standard boolean precedence: NOT binds tighter than AND, which
+   * binds tighter than OR. So `a or b and c` is `a or (b and c)`, not `(a or b)
+   * and c`. This is implemented as parseExpression(OR) -> parseAndExpression(AND)
+   * -> parseTerm(NOT/group/quantifier/identifier).
    */
   private static parseExpression(
     tokens: string[],
@@ -94,35 +99,51 @@ export class SigmaConditionEvaluator {
     detectionBlock: Record<string, any>,
     caseSensitive: boolean
   ): { result: boolean; nextIndex: number } {
-    let result = false;
-    let i = startIndex;
+    const first = this.parseAndExpression(tokens, startIndex, logData, detectionBlock, caseSensitive);
+    let result = first.result;
+    let i = first.nextIndex;
 
-    // Parse first term
-    const first = this.parseTerm(tokens, i, logData, detectionBlock, caseSensitive);
-    result = first.result;
-    i = first.nextIndex;
-
-    // Handle operators (AND, OR)
     while (i < tokens.length) {
       const operator = tokens[i];
-
-      if (operator === ')') {
-        // End of grouped expression
+      if (operator === ')') break; // end of a grouped expression
+      if (operator === 'OR') {
+        i++;
+        const next = this.parseAndExpression(tokens, i, logData, detectionBlock, caseSensitive);
+        result = result || next.result;
+        i = next.nextIndex;
+      } else {
+        // Anything else (e.g. a dangling token) ends this expression.
         break;
       }
+    }
 
+    return { result, nextIndex: i };
+  }
+
+  /**
+   * Parse and evaluate an AND expression (higher precedence than OR). Stops at OR,
+   * a closing parenthesis, or the end of input so the OR level can take over.
+   */
+  private static parseAndExpression(
+    tokens: string[],
+    startIndex: number,
+    logData: Record<string, any>,
+    detectionBlock: Record<string, any>,
+    caseSensitive: boolean
+  ): { result: boolean; nextIndex: number } {
+    const first = this.parseTerm(tokens, startIndex, logData, detectionBlock, caseSensitive);
+    let result = first.result;
+    let i = first.nextIndex;
+
+    while (i < tokens.length) {
+      const operator = tokens[i];
       if (operator === 'AND') {
         i++;
         const next = this.parseTerm(tokens, i, logData, detectionBlock, caseSensitive);
         result = result && next.result;
         i = next.nextIndex;
-      } else if (operator === 'OR') {
-        i++;
-        const next = this.parseTerm(tokens, i, logData, detectionBlock, caseSensitive);
-        result = result || next.result;
-        i = next.nextIndex;
       } else {
-        // Unknown operator or end of expression
+        // OR, ')', or unknown: hand back to the OR level.
         break;
       }
     }

--- a/packages/backend/src/modules/sigma/github-client.ts
+++ b/packages/backend/src/modules/sigma/github-client.ts
@@ -276,7 +276,9 @@ export class SigmaHQClient {
       // Filter for .yml/.yaml files in the category
       if (
         item.type === 'blob' &&
-        item.path.startsWith(categoryPath) &&
+        // Require a path boundary so e.g. "rules/windows" does not also match the
+        // sibling "rules/windows_extra/...". Match the dir itself or its descendants.
+        (item.path === categoryPath || item.path.startsWith(`${categoryPath}/`)) &&
         (item.path.endsWith('.yml') || item.path.endsWith('.yaml'))
       ) {
         const fileName = item.path.split('/').pop() || item.path;

--- a/packages/backend/src/modules/sigma/routes.ts
+++ b/packages/backend/src/modules/sigma/routes.ts
@@ -105,7 +105,7 @@ export async function sigmaRoutes(fastify: FastifyInstance) {
 
         // Associate channels with the sigma rule if import was successful
         if (result.sigmaRule && channelIds && channelIds.length > 0) {
-          await notificationChannelsService.setSigmaRuleChannels(result.sigmaRule.id, channelIds);
+          await notificationChannelsService.setSigmaRuleChannels(result.sigmaRule.id, channelIds, body.organizationId);
         }
 
         if (result.errors.length > 0) {
@@ -352,7 +352,7 @@ export async function sigmaRoutes(fastify: FastifyInstance) {
             return reply.code(404).send({ error: 'Sigma rule not found' });
           }
         }
-        await notificationChannelsService.setSigmaRuleChannels(params.id, body.channelIds);
+        await notificationChannelsService.setSigmaRuleChannels(params.id, body.channelIds, body.organizationId);
       }
 
       if (body.enabled === undefined && body.channelIds === undefined) {

--- a/packages/backend/src/modules/status-incidents/routes.ts
+++ b/packages/backend/src/modules/status-incidents/routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { statusIncidentService } from './service.js';
 import { authenticate } from '../auth/middleware.js';
 import { db } from '../../database/connection.js';
+import { projectsService } from '../projects/service.js';
 
 const STATUS_VALUES = ['investigating', 'identified', 'monitoring', 'resolved'] as const;
 const SEVERITY_VALUES = ['minor', 'major', 'critical'] as const;
@@ -91,6 +92,12 @@ export async function statusIncidentRoutes(fastify: FastifyInstance) {
 
     if (!(await checkOrgAdmin(request.user.id, parse.data.organizationId))) {
       return reply.status(403).send({ error: 'Admin or owner role required' });
+    }
+
+    // The projectId is attacker-controlled in the body; ensure it belongs to the
+    // caller's organization to prevent cross-tenant status-page injection.
+    if (!(await projectsService.projectBelongsToOrg(parse.data.projectId, parse.data.organizationId))) {
+      return reply.status(400).send({ error: 'projectId does not belong to the organization' });
     }
 
     const incident = await statusIncidentService.create({

--- a/packages/backend/src/modules/traces/service.ts
+++ b/packages/backend/src/modules/traces/service.ts
@@ -203,7 +203,10 @@ export class TracesService {
       return result.map((r) => r.service_name);
     }
 
-    // ClickHouse: query via reservoir
+    // ClickHouse: derive distinct services from traces. KNOWN LIMITATION: this
+    // pages at most 10000 traces, so a service that only appears in traces beyond
+    // that cap is not listed. A dedicated SELECT DISTINCT service_name query in the
+    // ClickHouse engine would remove the cap (tracked for the reservoir API).
     const result = await reservoir.queryTraces({
       projectId,
       from: effectiveFrom,
@@ -338,6 +341,10 @@ export class TracesService {
         sql<number>`CASE WHEN SUM(span_count) > 0
           THEN SUM(COALESCE(duration_avg_ms, 0) * span_count) / SUM(span_count)
           ELSE 0 END`.as('avg_latency_ms'),
+        // APPROXIMATION: this is the max of the per-bucket p95s, not a true window
+        // p95 (the hourly/daily aggregate stores only a per-bucket p95, which is
+        // not mergeable). It is an upper-bound estimate; a true p95 would require a
+        // mergeable quantile sketch (t-digest) in the continuous aggregate.
         db.fn.max<number>('duration_p95_ms').as('p95_latency_ms'),
       ])
       .where('project_id', '=', projectId)

--- a/packages/backend/src/modules/traces/service.ts
+++ b/packages/backend/src/modules/traces/service.ts
@@ -462,7 +462,10 @@ export class TracesService {
       avg_duration_ms: Math.round(avgDuration),
       max_duration_ms: maxDuration,
       error_count: errorCount,
-      error_rate: totalTraces > 0 ? errorCount / totalTraces : 0,
+      // errorCount/avg/spans are computed over the analyzed page, so the rate must
+      // use the same denominator (traces.length), not the full total_traces, which
+      // would deflate the rate whenever the result set exceeds the query cap.
+      error_rate: traces.length > 0 ? errorCount / traces.length : 0,
     };
   }
 }

--- a/packages/backend/src/modules/traces/service.ts
+++ b/packages/backend/src/modules/traces/service.ts
@@ -189,32 +189,10 @@ export class TracesService {
   async getServices(projectId: string, from?: Date): Promise<string[]> {
     const effectiveFrom = from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
-    // Query traces for distinct services - stays in Kysely for timescale,
-    // uses reservoir queryTraces for clickhouse
-    if (reservoir.getEngineType() === 'timescale') {
-      const result = await db
-        .selectFrom('traces')
-        .select('service_name')
-        .where('project_id', '=', projectId)
-        .where('start_time', '>=', effectiveFrom)
-        .groupBy('service_name')
-        .orderBy('service_name', 'asc')
-        .execute();
-      return result.map((r) => r.service_name);
-    }
-
-    // ClickHouse: derive distinct services from traces. KNOWN LIMITATION: this
-    // pages at most 10000 traces, so a service that only appears in traces beyond
-    // that cap is not listed. A dedicated SELECT DISTINCT service_name query in the
-    // ClickHouse engine would remove the cap (tracked for the reservoir API).
-    const result = await reservoir.queryTraces({
-      projectId,
-      from: effectiveFrom,
-      to: new Date(),
-      limit: 10000,
-    });
-    const serviceSet = new Set(result.traces.map((t: { serviceName: string }) => t.serviceName));
-    return Array.from(serviceSet).sort() as string[];
+    // Distinct service names straight from the storage engine (SELECT DISTINCT /
+    // collection.distinct), so no result cap can drop services - works on all engines.
+    const services = await reservoir.getTraceServices(projectId, effectiveFrom, new Date());
+    return [...services].sort();
   }
 
   async getServiceDependencies(projectId: string, from?: Date, to?: Date) {

--- a/packages/backend/src/modules/users/service.ts
+++ b/packages/backend/src/modules/users/service.ts
@@ -83,11 +83,15 @@ export class UsersService {
    * so the instance always has at least one user able to access admin settings.
    */
   async createUser(input: CreateUserInput): Promise<UserProfile> {
+    // Normalize email so registration/login are case-insensitive and consistent
+    // with the OIDC/invitation paths, preventing duplicate accounts.
+    const email = input.email.toLowerCase().trim();
+
     // Check if user already exists
     const existingUser = await db
       .selectFrom('users')
       .select('id')
-      .where('email', '=', input.email)
+      .where('email', '=', email)
       .executeTakeFirst();
 
     if (existingUser) {
@@ -100,14 +104,14 @@ export class UsersService {
     // Promote first user to admin if no admin exists yet
     const shouldBeAdmin = !(await this.hasAnyAdmin());
     if (shouldBeAdmin) {
-      console.log(`[Users] No admin exists yet. Promoting ${input.email} to admin on registration.`);
+      console.log(`[Users] No admin exists yet. Promoting ${email} to admin on registration.`);
     }
 
     // Insert the user
     const user = await db
       .insertInto('users')
       .values({
-        email: input.email,
+        email,
         password_hash: passwordHash,
         name: input.name,
         is_admin: shouldBeAdmin,
@@ -130,11 +134,11 @@ export class UsersService {
    * Authenticate a user and create a session
    */
   async login(input: LoginInput): Promise<SessionInfo> {
-    // Find user by email
+    // Find user by email (case-insensitive, matching how emails are stored)
     const user = await db
       .selectFrom('users')
       .select(['id', 'email', 'password_hash', 'disabled'])
-      .where('email', '=', input.email)
+      .where('email', '=', input.email.toLowerCase().trim())
       .executeTakeFirst();
 
     if (!user) {
@@ -327,12 +331,15 @@ export class UsersService {
       throw new Error('User not found');
     }
 
+    // Normalize a new email the same way as registration/login.
+    const normalizedEmail = input.email ? input.email.toLowerCase().trim() : undefined;
+
     // If changing email, check if new email already exists
-    if (input.email && input.email !== user.email) {
+    if (normalizedEmail && normalizedEmail !== user.email) {
       const existingUser = await db
         .selectFrom('users')
         .select('id')
-        .where('email', '=', input.email)
+        .where('email', '=', normalizedEmail)
         .executeTakeFirst();
 
       if (existingUser) {
@@ -373,7 +380,7 @@ export class UsersService {
     // Build update object
     const updateData: any = {};
     if (input.name) updateData.name = input.name;
-    if (input.email) updateData.email = input.email;
+    if (normalizedEmail) updateData.email = normalizedEmail;
     if (input.newPassword) {
       updateData.password_hash = await this.hashPassword(input.newPassword);
     }

--- a/packages/backend/src/modules/webhooks/routes.ts
+++ b/packages/backend/src/modules/webhooks/routes.ts
@@ -84,7 +84,7 @@ export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
 
   /**
    * POST /api/v1/webhooks/deliveries/:id/replay
-   * Re-enqueue a failed or dead delivery. Admin only.
+   * Re-enqueue a dead-letter delivery. Admin only.
    */
   fastify.post('/deliveries/:id/replay', async (request: any, reply) => {
     const { id } = request.params as { id: string };
@@ -97,8 +97,11 @@ export async function webhookDeliveriesRoutes(fastify: FastifyInstance) {
       return reply.status(403).send({ error: 'Only admins can replay deliveries' });
     }
 
-    if (delivery.status !== 'dead' && delivery.status !== 'failed') {
-      return reply.status(409).send({ error: 'Only failed or dead deliveries can be replayed' });
+    // Only terminal 'dead' (dead-letter) deliveries may be replayed. A 'failed'
+    // delivery still has a delayed retry job enqueued, so replaying it would
+    // double-deliver and race attempt_count with the in-flight retry.
+    if (delivery.status !== 'dead') {
+      return reply.status(409).send({ error: 'Only dead-letter deliveries can be replayed' });
     }
 
     const reset = await webhookDeliveryService.resetForReplay(id);

--- a/packages/backend/src/queue/adapters/bullmq-adapter.ts
+++ b/packages/backend/src/queue/adapters/bullmq-adapter.ts
@@ -64,7 +64,10 @@ export class BullMQQueueAdapter<T = unknown> implements IQueueAdapter<T>, ICronR
     const payload = attachContextToPayload(data);
     const bullJob = await (this.queue as any).add(jobName, payload, {
       delay: options?.delay,
-      attempts: options?.maxAttempts,
+      // Default to 3 attempts to match the graphile adapter. Without this BullMQ
+      // would default to 1 (no retries), so the same job retried differently
+      // depending on the configured queue backend.
+      attempts: options?.maxAttempts ?? 3,
       priority: options?.priority,
       jobId: options?.jobKey,
       repeat: options?.repeat,

--- a/packages/backend/src/queue/jobs/log-pipeline.ts
+++ b/packages/backend/src/queue/jobs/log-pipeline.ts
@@ -53,6 +53,8 @@ export async function processLogPipeline(job: IJob<LogPipelineJobData>): Promise
           metadata: sql`COALESCE(metadata, '{}'::jsonb) || ${JSON.stringify(update.fields)}::jsonb`,
         })
         .where('id', '=', update.id)
+        // Defense in depth: scope the tenant-table update to the job's project.
+        .where('project_id', '=', projectId)
         .execute();
     } catch (err) {
       console.error(`[Pipeline] Failed to update metadata for log ${update.id}:`, err);

--- a/packages/backend/src/tests/modules/alerts/baseline-calculator.test.ts
+++ b/packages/backend/src/tests/modules/alerts/baseline-calculator.test.ts
@@ -3,6 +3,7 @@ import { sql } from 'kysely';
 import { db } from '../../../database/index.js';
 import { createTestContext, createTestLog } from '../../helpers/factories.js';
 import { BaselineCalculatorService } from '../../../modules/alerts/baseline-calculator.js';
+import type { MetadataFilter } from '@logtide/shared';
 
 describe('BaselineCalculatorService', () => {
     let service: BaselineCalculatorService;
@@ -92,6 +93,22 @@ describe('BaselineCalculatorService', () => {
         it('should dispatch to percentileP95', async () => {
             const result = await service.calculate('percentile_p95', [testProject.id], ['error'], null);
             expect(result).toBeNull();
+        });
+
+        it('applies metadata filters to the baseline (counts only matching logs)', async () => {
+            const anchor = midCurrentHour();
+            const yesterday = new Date(anchor.getTime() - 24 * 60 * 60 * 1000);
+            // 3 prod + 2 dev error logs in the same-time-yesterday bucket.
+            for (let i = 0; i < 3; i++) {
+                await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `p${i}`, time: yesterday, metadata: { env: 'prod' } });
+            }
+            for (let i = 0; i < 2; i++) {
+                await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `d${i}`, time: yesterday, metadata: { env: 'dev' } });
+            }
+
+            const filter: MetadataFilter[] = [{ key: 'env', op: 'equals', value: 'prod' }];
+            const filtered = await service.calculate('same_time_yesterday', [testProject.id], ['error'], null, filter);
+            expect(filtered?.value).toBe(3);
         });
 
         it('should return null for unknown method', async () => {

--- a/packages/backend/src/tests/modules/alerts/baseline-calculator.test.ts
+++ b/packages/backend/src/tests/modules/alerts/baseline-calculator.test.ts
@@ -111,6 +111,39 @@ describe('BaselineCalculatorService', () => {
             expect(filtered?.value).toBe(3);
         });
 
+        it('applies metadata filters to the rolling_7d_avg baseline', async () => {
+            const anchor = midCurrentHour();
+            const day1 = new Date(anchor.getTime() - 24 * 60 * 60 * 1000);
+            const day2 = new Date(anchor.getTime() - 48 * 60 * 60 * 1000);
+            for (let i = 0; i < 3; i++) await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `p1-${i}`, time: day1, metadata: { env: 'prod' } });
+            for (let i = 0; i < 5; i++) await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `p2-${i}`, time: day2, metadata: { env: 'prod' } });
+            for (let i = 0; i < 4; i++) await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `d1-${i}`, time: day1, metadata: { env: 'dev' } });
+
+            const filter: MetadataFilter[] = [{ key: 'env', op: 'equals', value: 'prod' }];
+            const result = await service.calculate('rolling_7d_avg', [testProject.id], ['error'], null, filter);
+            expect(result?.value).toBe(4); // average of [3, 5] prod buckets
+            expect(result?.samplesUsed).toBe(2);
+        });
+
+        it('applies metadata filters to the percentile_p95 baseline', async () => {
+            const anchor = midCurrentHour();
+            const hoursAgo = (n: number) => new Date(anchor.getTime() - n * 60 * 60 * 1000);
+            const seed = async (when: Date, count: number) => {
+                for (let i = 0; i < count; i++) {
+                    await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: `pp-${when.getTime()}-${i}`, time: when, metadata: { env: 'prod' } });
+                }
+            };
+            // prod counts 2/4/6 across three distinct hourly buckets, plus dev noise
+            await seed(hoursAgo(2), 2);
+            await seed(hoursAgo(5), 4);
+            await seed(hoursAgo(10), 6);
+            await createTestLog({ projectId: testProject.id, level: 'error', service: 'svc', message: 'noise', time: hoursAgo(2), metadata: { env: 'dev' } });
+
+            const filter: MetadataFilter[] = [{ key: 'env', op: 'equals', value: 'prod' }];
+            const result = await service.calculate('percentile_p95', [testProject.id], ['error'], null, filter);
+            expect(result?.value).toBe(6); // p95 of [2, 4, 6]
+        });
+
         it('should return null for unknown method', async () => {
             const result = await service.calculate(
                 'nonexistent' as any,

--- a/packages/backend/src/tests/modules/auth/authentication-service.test.ts
+++ b/packages/backend/src/tests/modules/auth/authentication-service.test.ts
@@ -821,6 +821,7 @@ describe('AuthenticationService', () => {
                     success: true,
                     providerUserId: 'oidc-external-user-id',
                     email: 'link-by-email@example.com', // Same email as existing user
+                    emailVerified: true,
                     name: 'Linked User',
                     metadata: {},
                 }),
@@ -851,6 +852,53 @@ describe('AuthenticationService', () => {
             getProviderSpy.mockRestore();
         });
 
+        it('should refuse to link to an existing account when the email is unverified', async () => {
+            const existingUser = await createTestUser({ email: 'unverified-link@example.com' });
+            const linkProviderId = crypto.randomUUID();
+
+            await db.insertInto('auth_providers').values({
+                id: linkProviderId,
+                type: 'oidc',
+                name: 'OIDC Provider',
+                slug: 'oidc-unverified-link',
+                enabled: true,
+                config: { allowAutoRegister: true },
+            }).execute();
+
+            const mockProvider = {
+                config: {
+                    id: linkProviderId, type: 'oidc', name: 'OIDC Provider',
+                    slug: 'oidc-unverified-link', enabled: true, config: { allowAutoRegister: true },
+                },
+                authenticate: vi.fn().mockResolvedValue({
+                    success: true,
+                    providerUserId: 'attacker-external-id',
+                    email: 'unverified-link@example.com', // victim's email, but NOT verified
+                    emailVerified: false,
+                    name: 'Attacker',
+                    metadata: {},
+                }),
+                supportsRedirect: () => true,
+            };
+
+            const getProviderSpy = vi.spyOn(providerRegistryModule.providerRegistry, 'getProvider')
+                .mockResolvedValue(mockProvider as any);
+
+            await expect(
+                authService.authenticateWithProvider('oidc-unverified-link', {})
+            ).rejects.toThrow(/not verified/i);
+
+            // No identity should have been linked to the victim.
+            const identities = await db
+                .selectFrom('user_identities')
+                .selectAll()
+                .where('user_id', '=', existingUser.id)
+                .execute();
+            expect(identities).toHaveLength(0);
+
+            getProviderSpy.mockRestore();
+        });
+
         it('should update last login when linking identity by email', async () => {
             const existingUser = await createTestUser({ email: 'last-login-update@example.com' });
             const linkProviderId = crypto.randomUUID();
@@ -876,6 +924,7 @@ describe('AuthenticationService', () => {
                     success: true,
                     providerUserId: 'oidc-user-123',
                     email: 'last-login-update@example.com',
+                    emailVerified: true,
                 }),
                 supportsRedirect: () => true,
             };

--- a/packages/backend/src/tests/modules/custom-dashboards/panel-data-service.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/panel-data-service.test.ts
@@ -730,6 +730,37 @@ describe('metric_stat panel', () => {
     expect(r.unit).toBe('%');
   });
 
+  it('sums across all buckets for sum aggregation (no undercount)', async () => {
+    const now = new Date();
+    const spy = vi.spyOn(reservoir, 'aggregateMetrics').mockResolvedValueOnce({
+      metricName: 'requests',
+      metricType: 'counter',
+      timeseries: [
+        { bucket: new Date(now.getTime() - 3600_000), value: 100, labels: {} },
+        { bucket: new Date(now.getTime() - 1800_000), value: 40, labels: {} },
+      ],
+      executionTimeMs: 1,
+    } as Awaited<ReturnType<typeof reservoir.aggregateMetrics>>);
+
+    const r = (await fetchPanelData(
+      {
+        type: 'metric_stat',
+        title: 'Requests',
+        source: 'metrics',
+        projectId,
+        metricName: 'requests',
+        aggregation: 'sum',
+        timeRange: '24h',
+        serviceName: null,
+        unit: null,
+      },
+      ctx(),
+    )) as { value: number | null };
+
+    spy.mockRestore();
+    expect(r.value).toBe(140); // 100 + 40, not just the latest bucket
+  });
+
   it('tenancy: foreign projectId throws', async () => {
     await expect(
       fetchPanelData(

--- a/packages/backend/src/tests/modules/custom-dashboards/service.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/service.test.ts
@@ -135,11 +135,31 @@ describe('CustomDashboardsService.getById', () => {
   });
 });
 
+describe('CustomDashboardsService personal dashboard isolation', () => {
+  const otherUser = '00000000-0000-0000-0000-000000000999';
+
+  it('hides a personal dashboard from other users and blocks edit/delete', async () => {
+    const d = await service.create(
+      { organizationId: ctx.organization.id, name: 'Private', isPersonal: true },
+      ctx.user.id
+    );
+
+    // Creator can read it; another user in the org cannot.
+    expect(await service.getById(d.id, ctx.organization.id, ctx.user.id)).not.toBeNull();
+    expect(await service.getById(d.id, ctx.organization.id, otherUser)).toBeNull();
+
+    await expect(
+      service.update(d.id, ctx.organization.id, otherUser, { name: 'hijacked' })
+    ).rejects.toThrow();
+    await expect(service.delete(d.id, ctx.organization.id, otherUser)).rejects.toThrow();
+  });
+});
+
 describe('CustomDashboardsService.update', () => {
   it('updates dashboard name', async () => {
     const d = await service.create({ organizationId: ctx.organization.id, name: 'Old' }, ctx.user.id);
 
-    const updated = await service.update(d.id, ctx.organization.id, { name: 'New' });
+    const updated = await service.update(d.id, ctx.organization.id, ctx.user.id, { name: 'New' });
     expect(updated.name).toBe('New');
   });
 
@@ -147,7 +167,7 @@ describe('CustomDashboardsService.update', () => {
     const d = await service.create({ organizationId: ctx.organization.id, name: 'Panels' }, ctx.user.id);
 
     const panel = makePanel('p-new');
-    const updated = await service.update(d.id, ctx.organization.id, { panels: [panel] });
+    const updated = await service.update(d.id, ctx.organization.id, ctx.user.id, { panels: [panel] });
     expect(updated.panels).toHaveLength(1);
     expect(updated.panels[0].id).toBe('p-new');
   });
@@ -158,7 +178,7 @@ describe('CustomDashboardsService.update', () => {
       ctx.user.id
     );
 
-    const updated = await service.update(d.id, ctx.organization.id, { description: null });
+    const updated = await service.update(d.id, ctx.organization.id, ctx.user.id, { description: null });
     expect(updated.description).toBeNull();
   });
 });

--- a/packages/backend/src/tests/modules/notification-channels/routes.test.ts
+++ b/packages/backend/src/tests/modules/notification-channels/routes.test.ts
@@ -617,6 +617,34 @@ describe('Notification Channels Routes', () => {
       const body = JSON.parse(response.payload);
       expect(body.channels).toHaveLength(1);
     });
+
+    it('should not leak channels of an alert rule in another organization', async () => {
+      const otherOrg = await createTestOrganization();
+      const alertRule = await createTestAlertRule({ organizationId: otherOrg.id });
+      const [channel] = await db
+        .insertInto('notification_channels')
+        .values({
+          organization_id: otherOrg.id,
+          name: 'Other Org Channel',
+          type: 'webhook',
+          config: { url: 'https://evil.example.com/hook', auth: { token: 'secret' } },
+        })
+        .returningAll()
+        .execute();
+      await db
+        .insertInto('alert_rule_channels')
+        .values({ alert_rule_id: alertRule.id, channel_id: channel.id })
+        .execute();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/notification-channels/alert-rules/${alertRule.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.payload).not.toContain('secret');
+    });
   });
 
   describe('GET /api/v1/notification-channels/sigma-rules/:sigmaRuleId', () => {
@@ -650,6 +678,34 @@ describe('Notification Channels Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.payload);
       expect(body.channels).toHaveLength(1);
+    });
+
+    it('should not leak channels of a sigma rule in another organization', async () => {
+      const otherOrg = await createTestOrganization();
+      const sigmaRule = await createTestSigmaRule({ organizationId: otherOrg.id });
+      const [channel] = await db
+        .insertInto('notification_channels')
+        .values({
+          organization_id: otherOrg.id,
+          name: 'Other Org Sigma Channel',
+          type: 'webhook',
+          config: { url: 'https://evil.example.com/hook', auth: { token: 'secret' } },
+        })
+        .returningAll()
+        .execute();
+      await db
+        .insertInto('sigma_rule_channels')
+        .values({ sigma_rule_id: sigmaRule.id, channel_id: channel.id })
+        .execute();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/notification-channels/sigma-rules/${sigmaRule.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.payload).not.toContain('secret');
     });
   });
 

--- a/packages/backend/src/tests/modules/notification-channels/service.test.ts
+++ b/packages/backend/src/tests/modules/notification-channels/service.test.ts
@@ -344,7 +344,7 @@ describe('NotificationChannelsService', () => {
         config: { url: 'https://example.com/hook' },
       });
 
-      await service.setAlertRuleChannels(alertRule.id, [channel1.id, channel2.id]);
+      await service.setAlertRuleChannels(alertRule.id, [channel1.id, channel2.id], testOrganization.id);
 
       const channels = await service.getAlertRuleChannels(alertRule.id);
 
@@ -364,11 +364,11 @@ describe('NotificationChannelsService', () => {
         config: { recipients: ['test2@example.com'] },
       });
 
-      await service.setAlertRuleChannels(alertRule.id, [channel1.id]);
+      await service.setAlertRuleChannels(alertRule.id, [channel1.id], testOrganization.id);
       let channels = await service.getAlertRuleChannels(alertRule.id);
       expect(channels).toHaveLength(1);
 
-      await service.setAlertRuleChannels(alertRule.id, [channel2.id]);
+      await service.setAlertRuleChannels(alertRule.id, [channel2.id], testOrganization.id);
       channels = await service.getAlertRuleChannels(alertRule.id);
       expect(channels).toHaveLength(1);
       expect(channels[0].id).toBe(channel2.id);
@@ -388,7 +388,7 @@ describe('NotificationChannelsService', () => {
       });
 
       await service.updateChannel(channel2.id, testOrganization.id, { enabled: false });
-      await service.setAlertRuleChannels(alertRule.id, [channel1.id, channel2.id]);
+      await service.setAlertRuleChannels(alertRule.id, [channel1.id, channel2.id], testOrganization.id);
 
       const channels = await service.getAlertRuleChannels(alertRule.id);
       expect(channels).toHaveLength(1);
@@ -405,7 +405,7 @@ describe('NotificationChannelsService', () => {
         config: { recipients: ['test@example.com'] },
       });
 
-      await service.setSigmaRuleChannels(sigmaRule.id, [channel.id]);
+      await service.setSigmaRuleChannels(sigmaRule.id, [channel.id], testOrganization.id);
 
       const channels = await service.getSigmaRuleChannels(sigmaRule.id);
 
@@ -421,8 +421,8 @@ describe('NotificationChannelsService', () => {
         config: { recipients: ['test@example.com'] },
       });
 
-      await service.setSigmaRuleChannels(sigmaRule.id, [channel.id]);
-      await service.setSigmaRuleChannels(sigmaRule.id, []);
+      await service.setSigmaRuleChannels(sigmaRule.id, [channel.id], testOrganization.id);
+      await service.setSigmaRuleChannels(sigmaRule.id, [], testOrganization.id);
 
       const channels = await service.getSigmaRuleChannels(sigmaRule.id);
       expect(channels).toHaveLength(0);

--- a/packages/backend/src/tests/modules/pii-masking/service.test.ts
+++ b/packages/backend/src/tests/modules/pii-masking/service.test.ts
@@ -402,6 +402,26 @@ describe('PiiMaskingService', () => {
             expect(logs[0].message).toContain('[REDACTED_CC]');
         });
 
+        it('should mask a credit card in an otherwise pure-alphanumeric string', async () => {
+            // Regression: maskText used to early-exit on /^[a-zA-Z0-9 _]+$/ strings,
+            // leaving separator-less card numbers unmasked.
+            await service.createRule(organizationId, {
+                name: 'credit_card',
+                displayName: 'Credit Card',
+                patternType: 'builtin',
+                action: 'redact',
+                enabled: true,
+            });
+
+            const logs = [
+                { message: 'card 4111111111111111', service: 'svc', level: 'info' as const },
+            ];
+
+            await service.maskLogBatch(logs, organizationId, projectId);
+            expect(logs[0].message).not.toContain('4111111111111111');
+            expect(logs[0].message).toContain('[REDACTED_CC]');
+        });
+
         it('should mask SSN patterns', async () => {
             await service.createRule(organizationId, {
                 name: 'ssn',

--- a/packages/backend/src/tests/modules/query/websocket.test.ts
+++ b/packages/backend/src/tests/modules/query/websocket.test.ts
@@ -143,6 +143,33 @@ describe('WebSocket route /api/v1/logs/ws', () => {
     });
 
     // -------------------------------------------------------------------------
+    // tenant isolation: project access
+    // -------------------------------------------------------------------------
+
+    describe('tenant isolation', () => {
+        it('closes with 1008 when the user is not a member of the project\'s organization', async () => {
+            // testUser/authToken belong to the org created in beforeEach. Create a
+            // separate org+project and try to live-tail it with the first user's token.
+            const otherCtx = await createTestContext();
+
+            const ws = await (app as any).injectWS(
+                `/api/v1/logs/ws?projectId=${otherCtx.project.id}&token=${authToken}`,
+            );
+            const { code } = await waitForClose(ws);
+            expect(code).toBe(1008);
+        });
+
+        it('allows a user to subscribe to a project in their own organization', async () => {
+            const ws = await (app as any).injectWS(
+                `/api/v1/logs/ws?projectId=${testProject.id}&token=${authToken}`,
+            );
+            const msg = await waitForMessage(ws) as any;
+            expect(msg.type).toBe('connected');
+            ws.terminate();
+        });
+    });
+
+    // -------------------------------------------------------------------------
     // valid session: connection established
     // -------------------------------------------------------------------------
 

--- a/packages/backend/src/tests/modules/sigma/condition-evaluator.test.ts
+++ b/packages/backend/src/tests/modules/sigma/condition-evaluator.test.ts
@@ -484,6 +484,36 @@ describe('Sigma Condition Evaluator', () => {
         });
     });
 
+    describe('Operator Precedence', () => {
+        // t=true, f1=false, f2=false against logData below.
+        const detectionBlock = {
+            t: { service: 'sshd' },
+            f1: { service: 'nope' },
+            f2: { service: 'nah' },
+        };
+        const logData = { service: 'sshd' };
+
+        it('binds AND tighter than OR: "t or f1 and f2" is true', () => {
+            // t or (f1 and f2) = true. Left-to-right (t or f1) and f2 would be false.
+            expect(
+                SigmaConditionEvaluator.evaluateDetection({ ...detectionBlock, condition: 't or f1 and f2' }, logData)
+            ).toBe(true);
+        });
+
+        it('respects explicit grouping: "(t or f1) and f2" is false', () => {
+            expect(
+                SigmaConditionEvaluator.evaluateDetection({ ...detectionBlock, condition: '(t or f1) and f2' }, logData)
+            ).toBe(false);
+        });
+
+        it('handles "f1 and t or f2" as (f1 and t) or f2', () => {
+            // (false and true) or false = false
+            expect(
+                SigmaConditionEvaluator.evaluateDetection({ ...detectionBlock, condition: 'f1 and t or f2' }, logData)
+            ).toBe(false);
+        });
+    });
+
     describe('Case Sensitivity', () => {
         it('should respect case-sensitive flag', () => {
             const detectionBlock = {

--- a/packages/backend/src/tests/modules/webhooks/routes.test.ts
+++ b/packages/backend/src/tests/modules/webhooks/routes.test.ts
@@ -244,7 +244,9 @@ describe('Webhook Deliveries Routes', () => {
       expect(body.delivery.status).toBe('pending');
     });
 
-    it('should replay a failed delivery', async () => {
+    it('should return 409 when replaying a still-retrying (failed) delivery', async () => {
+      // A 'failed'/retrying delivery still has a delayed retry job enqueued, so
+      // replaying it would double-deliver. Only terminal 'dead' deliveries replay.
       const delivery = await webhookDeliveryService.createDelivery({
         organizationId: testOrganization.id,
         eventType: 'alert',
@@ -260,9 +262,7 @@ describe('Webhook Deliveries Routes', () => {
         headers: { Authorization: `Bearer ${authToken}` },
       });
 
-      expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.payload);
-      expect(body.delivery.status).toBe('pending');
+      expect(response.statusCode).toBe(409);
     });
 
     it('should return 409 when delivery is already delivered', async () => {

--- a/packages/backend/src/tests/utils/cache-custom-ttl.test.ts
+++ b/packages/backend/src/tests/utils/cache-custom-ttl.test.ts
@@ -27,8 +27,16 @@ describe('Cache Utilities (Custom TTL)', () => {
     });
 
     describe('getCacheTTL', () => {
-        it('should return config TTL when it differs from default', () => {
-            expect(getCacheTTL(300)).toBe(120);
+        it('applies the global override to the query cache TTL', () => {
+            // CACHE_TTL.QUERY is 60; the override (120) tunes the query cache.
+            expect(getCacheTTL(60)).toBe(120);
+        });
+
+        it('does not clamp semantic TTLs (sessions, settings, etc.)', () => {
+            // A 5-minute semantic TTL must be preserved, not clamped to the override.
+            expect(getCacheTTL(300)).toBe(300);
+            // A 30-minute session TTL must be preserved.
+            expect(getCacheTTL(1800)).toBe(1800);
         });
     });
 });

--- a/packages/backend/src/utils/cache.ts
+++ b/packages/backend/src/utils/cache.ts
@@ -65,8 +65,11 @@ export function isCacheEnabled(): boolean {
  * Get custom TTL from config or use default
  */
 export function getCacheTTL(defaultTTL: number): number {
-  // If a global TTL override is set and different from default, use it
-  if (config.CACHE_TTL && config.CACHE_TTL !== 60) {
+  // A global CACHE_TTL override only tunes the generic query cache. It must NOT
+  // clamp semantic TTLs (sessions, OIDC state, settings, provider config, etc.),
+  // which would otherwise shorten session lifetimes or stretch security-sensitive
+  // caches whenever an operator tunes the query cache.
+  if (config.CACHE_TTL && config.CACHE_TTL !== 60 && defaultTTL === CACHE_TTL.QUERY) {
     return config.CACHE_TTL;
   }
   return defaultTTL;

--- a/packages/backend/src/utils/internal-logger.ts
+++ b/packages/backend/src/utils/internal-logger.ts
@@ -58,7 +58,7 @@ export async function initializeInternalLogging(): Promise<string | null> {
       dsn,
       service: process.env.SERVICE_NAME || 'logtide-backend',
       environment: process.env.NODE_ENV || 'development',
-      release: process.env.npm_package_version || '1.0.0',
+      release: process.env.npm_package_version || '1.0.1',
       batchSize: 5, // Smaller batch for internal logs to see them faster
       flushInterval: 5000,
       maxBufferSize: 1000,

--- a/packages/backend/src/worker.ts
+++ b/packages/backend/src/worker.ts
@@ -375,7 +375,11 @@ async function checkAlerts() {
         const notificationQueue = createQueue('alert-notifications');
 
         for (const alert of triggeredAlerts) {
-          await notificationQueue.add('send-notification', alert);
+          // Dedup by the alert_history id so an overlapping evaluation that
+          // re-enqueues the same trigger does not send duplicate notifications.
+          await notificationQueue.add('send-notification', alert, {
+            jobKey: `alert-notif-${alert.historyId}`,
+          });
 
           if (isInternalLoggingEnabled()) {
             hub.captureLog('info', `Alert notification queued`, {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logtide/frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "LogTide Frontend Dashboard",
   "type": "module",

--- a/packages/frontend/src/hooks.client.ts
+++ b/packages/frontend/src/hooks.client.ts
@@ -9,7 +9,7 @@ if (dsn) {
     dsn,
     service: 'logtide-frontend-client',
     environment: env.PUBLIC_NODE_ENV || 'production',
-    release: env.PUBLIC_APP_VERSION || '1.0.0',
+    release: env.PUBLIC_APP_VERSION || '1.0.1',
     debug: env.PUBLIC_NODE_ENV === 'development',
     browser: {
       // Core Web Vitals (LCP, INP, CLS, TTFB)

--- a/packages/frontend/src/hooks.server.ts
+++ b/packages/frontend/src/hooks.server.ts
@@ -82,7 +82,7 @@ export const handle = dsn
         dsn,
         service: 'logtide-frontend',
         environment: privateEnv?.NODE_ENV || 'production',
-        release: process.env.npm_package_version || '1.0.0',      }) as unknown as Handle,
+        release: process.env.npm_package_version || '1.0.1',      }) as unknown as Handle,
       requestLogHandle,
       configHandle
     )

--- a/packages/frontend/src/lib/api/logs.ts
+++ b/packages/frontend/src/lib/api/logs.ts
@@ -178,8 +178,12 @@ export class LogsAPI {
     }
 
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const apiUrl = new URL(getApiUrl());
-    const wsUrl = `${wsProtocol}//${apiUrl.host}/api/v1/logs/ws?${params.toString()}`;
+    // getApiUrl() may be empty (same-origin reverse proxy) or a relative path, in
+    // which case `new URL(...)` would throw "Invalid URL". Resolve against the
+    // current location and fall back to the page host for the same-origin case.
+    const apiBase = getApiUrl();
+    const apiHost = apiBase ? new URL(apiBase, window.location.href).host : window.location.host;
+    const wsUrl = `${wsProtocol}//${apiHost}/api/v1/logs/ws?${params.toString()}`;
 
     return new WebSocket(wsUrl);
   }

--- a/packages/frontend/src/lib/components/AppLayout.svelte
+++ b/packages/frontend/src/lib/components/AppLayout.svelte
@@ -4,6 +4,7 @@
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
   import { authStore } from "$lib/stores/auth";
+  import { authAPI } from "$lib/api/auth";
   import { currentOrganization, organizationStore } from "$lib/stores/organization";
   import { toastStore } from "$lib/stores/toast";
   import { shortcutsStore } from "$lib/stores/shortcuts";
@@ -277,6 +278,15 @@
   }
 
   async function handleLogout() {
+    // Revoke the server-side session so the token cannot be reused. Best-effort:
+    // still clear local state and redirect even if the request fails.
+    if (token) {
+      try {
+        await authAPI.logout(token);
+      } catch (e) {
+        console.error("Logout request failed", e);
+      }
+    }
     authStore.clearAuth();
     goto("/login");
   }

--- a/packages/frontend/src/lib/components/Footer.svelte
+++ b/packages/frontend/src/lib/components/Footer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Github from "@lucide/svelte/icons/github";
 
-  const version = "Beta v1.0.0";
+  const version = "Beta v1.0.1";
   const currentYear = new Date().getFullYear();
   const githubUrl = "https://github.com/logtide-dev/logtide";
 </script>

--- a/packages/frontend/src/routes/dashboard/search/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/search/+page.svelte
@@ -707,7 +707,18 @@
             }
 
             if (newLogs.length > 0) {
+              const shift = newLogs.length;
               logs = [...newLogs, ...logs].slice(0, liveTailLimit);
+              // Prepending shifts every existing row's index by `shift`; remap the
+              // index-keyed UI state so expansion/selection stays on the same logs
+              // instead of jumping to whatever now sits at the old index.
+              expandedRows = new Set(
+                [...expandedRows].map((i) => i + shift).filter((i) => i < logs.length)
+              );
+              if (selectedLogIndex >= 0) {
+                const next = selectedLogIndex + shift;
+                selectedLogIndex = next < logs.length ? next : -1;
+              }
             }
           }
         } catch (e) {

--- a/packages/frontend/src/routes/dashboard/settings/usage/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/usage/+page.svelte
@@ -172,9 +172,12 @@
     return CAP_META[c.capability]?.unit === 'bytes' ? formatBytes(n) : formatCount(n);
   }
 
-  // null limit = unlimited, so no percentage. Capped at 999 to avoid runaway labels.
+  // Only a null limit means unlimited (no percentage). A limit of 0 is the
+  // opposite (fully restricted), so it must render as at/over limit, not unlimited.
+  // Capped at 999 to avoid runaway labels.
   function capPercent(c: CapabilityUsage): number | null {
-    if (c.limit === null || c.limit <= 0) return null;
+    if (c.limit === null) return null;
+    if (c.limit <= 0) return c.current > 0 ? 999 : 100;
     return Math.min(999, Math.round((c.current / c.limit) * 100));
   }
 

--- a/packages/frontend/src/routes/dashboard/traces/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/traces/+page.svelte
@@ -423,13 +423,18 @@
           const data = JSON.parse(event.data);
           if (data.type === 'trace') {
             const incoming = data.data as TraceRecord;
-            // Prepend and dedupe by trace_id; cap at liveTailLimit.
+            // Prepend and dedupe by trace_id; cap the displayed list at liveTailLimit.
             const existing = traces.findIndex((t) => t.trace_id === incoming.trace_id);
             const next = existing >= 0
               ? [incoming, ...traces.filter((_, i) => i !== existing)]
               : [incoming, ...traces];
             traces = next.slice(0, liveTailLimit);
-            totalTraces = traces.length;
+            // Only the rendered list is capped at liveTailLimit; do NOT overwrite
+            // totalTraces with the capped length (that corrupts pagination). Bump
+            // the running total when a genuinely new trace arrives.
+            if (existing < 0) {
+              totalTraces += 1;
+            }
           }
         } catch (e) {
           console.error('[TracesLiveTail] parse error', e);

--- a/packages/frontend/src/routes/dashboard/traces/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/traces/+page.svelte
@@ -362,12 +362,17 @@
       traces = response.traces;
       totalTraces = response.total;
 
-      const statsResponse = await tracesAPI.getStats(
-        selectedProject,
-        timeRange.from.toISOString(),
-        timeRange.to.toISOString()
-      );
-      stats = statsResponse;
+      // Stats are auxiliary: a stats failure must not discard the loaded traces,
+      // so fetch them in their own try/catch rather than the outer one.
+      try {
+        stats = await tracesAPI.getStats(
+          selectedProject,
+          timeRange.from.toISOString(),
+          timeRange.to.toISOString()
+        );
+      } catch (e) {
+        console.error("Failed to load trace stats:", e);
+      }
     } catch (e) {
       console.error("Failed to load traces:", e);
       toastStore.error('Failed to load traces');

--- a/packages/reservoir/package.json
+++ b/packages/reservoir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logtide/reservoir",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pluggable storage abstraction for Logtide log management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/reservoir/src/buffered/reservoir-buffered.ts
+++ b/packages/reservoir/src/buffered/reservoir-buffered.ts
@@ -120,6 +120,7 @@ export class ReservoirBuffered implements IReservoir {
   queryTraces(...args: Parameters<Reservoir['queryTraces']>): ReturnType<Reservoir['queryTraces']> { return this.inner.queryTraces(...args); }
   getTraceById(...args: Parameters<Reservoir['getTraceById']>): ReturnType<Reservoir['getTraceById']> { return this.inner.getTraceById(...args); }
   getServiceDependencies(...args: Parameters<Reservoir['getServiceDependencies']>): ReturnType<Reservoir['getServiceDependencies']> { return this.inner.getServiceDependencies(...args); }
+  getTraceServices(...args: Parameters<Reservoir['getTraceServices']>): ReturnType<Reservoir['getTraceServices']> { return this.inner.getTraceServices(...args); }
   deleteSpansByTimeRange(...args: Parameters<Reservoir['deleteSpansByTimeRange']>): ReturnType<Reservoir['deleteSpansByTimeRange']> { return this.inner.deleteSpansByTimeRange(...args); }
   queryMetrics(...args: Parameters<Reservoir['queryMetrics']>): ReturnType<Reservoir['queryMetrics']> { return this.inner.queryMetrics(...args); }
   aggregateMetrics(...args: Parameters<Reservoir['aggregateMetrics']>): ReturnType<Reservoir['aggregateMetrics']> { return this.inner.aggregateMetrics(...args); }

--- a/packages/reservoir/src/client.ts
+++ b/packages/reservoir/src/client.ts
@@ -206,6 +206,11 @@ export class Reservoir implements IReservoir {
     return this.engine.getServiceDependencies(projectId, from, to);
   }
 
+  async getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]> {
+    this.ensureInitialized();
+    return this.engine.getTraceServices(projectId, from, to);
+  }
+
   async deleteSpansByTimeRange(params: DeleteSpansByTimeRangeParams): Promise<DeleteResult> {
     this.ensureInitialized();
     return this.engine.deleteSpansByTimeRange(params);

--- a/packages/reservoir/src/core/reservoir-interface.ts
+++ b/packages/reservoir/src/core/reservoir-interface.ts
@@ -83,6 +83,8 @@ export interface IReservoir {
     from?: Date,
     to?: Date,
   ): Promise<ServiceDependencyResult>;
+  /** Distinct service names that appear in traces within the time range. */
+  getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]>;
   deleteSpansByTimeRange(params: DeleteSpansByTimeRangeParams): Promise<DeleteResult>;
 
   // Metrics

--- a/packages/reservoir/src/core/storage-engine.ts
+++ b/packages/reservoir/src/core/storage-engine.ts
@@ -141,6 +141,9 @@ export abstract class StorageEngine {
     to?: Date,
   ): Promise<ServiceDependencyResult>;
 
+  /** Distinct service names appearing in traces within the time range */
+  abstract getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]>;
+
   /** Delete spans by time range */
   abstract deleteSpansByTimeRange(params: DeleteSpansByTimeRangeParams): Promise<DeleteResult>;
 

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine-metrics.test.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine-metrics.test.ts
@@ -1045,6 +1045,14 @@ describe('ClickHouseEngine metric operations (unit)', () => {
   // ===========================================================================
 
   describe('getMetricsOverview', () => {
+    // getMetricsOverview now issues a second query (latest value from raw metrics)
+    // alongside the rollup query. Default any un-queued call to an empty result so
+    // the per-test mockResolvedValueOnce drives the first (rollup) query and the
+    // latest query falls through to empty.
+    beforeEach(() => {
+      mockQuery.mockResolvedValue(mockQueryResult([]));
+    });
+
     it('should return metrics grouped by service', async () => {
       mockQuery.mockResolvedValueOnce(
         mockQueryResult([

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.test.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.test.ts
@@ -686,7 +686,14 @@ describe('ClickHouseEngine (integration)', () => {
       expect(trace!.error).toBe(false);
     });
 
-    it('merges times and span count on update', async () => {
+    it('merges times and span count from spans on update', async () => {
+      // The trace summary is recomputed from the spans table (race-free), so spans
+      // are ingested across two batches and each batch re-upserts the trace. The
+      // final summary must reflect ALL spans (count and the widest time range).
+      await engine.ingestSpans([
+        makeSpan({ spanId: 'm1', traceId: 'trace-merge', startTime: new Date('2025-01-15T12:00:01Z'), endTime: new Date('2025-01-15T12:00:03Z') }),
+        makeSpan({ spanId: 'm2', traceId: 'trace-merge', startTime: new Date('2025-01-15T12:00:02Z'), endTime: new Date('2025-01-15T12:00:04Z') }),
+      ]);
       await engine.upsertTrace(makeTrace({
         traceId: 'trace-merge',
         startTime: new Date('2025-01-15T12:00:01Z'),
@@ -694,7 +701,9 @@ describe('ClickHouseEngine (integration)', () => {
         spanCount: 2,
       }));
 
-
+      await engine.ingestSpans([
+        makeSpan({ spanId: 'm3', traceId: 'trace-merge', startTime: new Date('2025-01-15T12:00:00Z'), endTime: new Date('2025-01-15T12:00:05Z') }),
+      ]);
       await engine.upsertTrace(makeTrace({
         traceId: 'trace-merge',
         startTime: new Date('2025-01-15T12:00:00Z'),
@@ -702,11 +711,10 @@ describe('ClickHouseEngine (integration)', () => {
         spanCount: 1,
       }));
 
-
       const trace = await engine.getTraceById('trace-merge', 'proj-1');
       expect(trace).not.toBeNull();
       expect(trace!.spanCount).toBe(3);
-      // Duration should cover the wider range
+      // Duration should cover the wider range (00 -> 05 = 5s)
       expect(trace!.durationMs).toBeGreaterThanOrEqual(4000);
     });
   });

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.test.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.test.ts
@@ -902,6 +902,25 @@ describe('ClickHouseEngine (integration)', () => {
     });
   });
 
+  describe('getTraceServices', () => {
+    beforeEach(async () => {
+      await client.command({ query: 'TRUNCATE TABLE IF EXISTS traces' });
+      await engine.upsertTrace(makeTrace({ traceId: 't-svc-1', serviceName: 'api' }));
+      await engine.upsertTrace(makeTrace({ traceId: 't-svc-2', serviceName: 'worker' }));
+      await engine.upsertTrace(makeTrace({ traceId: 't-svc-3', serviceName: 'api' }));
+    });
+
+    it('returns distinct service names across all traces', async () => {
+      const services = await engine.getTraceServices('proj-1');
+      expect(services.sort()).toEqual(['api', 'worker']);
+    });
+
+    it('scopes by project', async () => {
+      const services = await engine.getTraceServices('other-project');
+      expect(services).toEqual([]);
+    });
+  });
+
   describe('getServiceDependencies', () => {
     beforeEach(async () => {
       await client.command({ query: 'TRUNCATE TABLE IF EXISTS spans' });

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
@@ -841,36 +841,35 @@ export class ClickHouseEngine extends StorageEngine {
   }
 
   async upsertTrace(trace: TraceRecord): Promise<void> {
-    // ReplacingMergeTree handles dedup by (project_id, trace_id) using updated_at
-    // We read the existing row, merge, and insert the merged version
+    // Recompute the trace summary directly from the spans table (the source of
+    // truth) instead of read-modify-writing the existing traces row. The old
+    // approach (SELECT existing -> existing.span_count + delta -> INSERT) lost
+    // concurrent increments under a race. Aggregating from spans is idempotent and
+    // race-free: spans are always inserted before the upsert, so whichever upsert
+    // runs last writes the correct totals. The ReplacingMergeTree then keeps that
+    // latest (correct) row. Falls back to the payload when no spans are present.
     const resultSet = await this.runQuery({
-      query: `SELECT trace_id, start_time, end_time, span_count, error
-              FROM traces FINAL
+      query: `SELECT count() AS span_count,
+                     min(start_time) AS start_time,
+                     max(end_time) AS end_time,
+                     max(status_code = 'ERROR') AS error
+              FROM spans
               WHERE trace_id = {traceId:String} AND project_id = {projectId:String}`,
       query_params: { traceId: trace.traceId, projectId: trace.projectId },
       format: 'JSONEachRow',
     });
-    const existing = (await resultSet.json<{
-      trace_id: string;
+    const agg = (await resultSet.json<{
+      span_count: number;
       start_time: string;
       end_time: string;
-      span_count: number;
       error: number;
     }>())[0];
 
-    let startTime = trace.startTime;
-    let endTime = trace.endTime;
-    let spanCount = trace.spanCount;
-    let error = trace.error;
-
-    if (existing) {
-      const existingStart = parseClickHouseTime(existing.start_time);
-      const existingEnd = parseClickHouseTime(existing.end_time);
-      startTime = trace.startTime < existingStart ? trace.startTime : existingStart;
-      endTime = trace.endTime > existingEnd ? trace.endTime : existingEnd;
-      spanCount = existing.span_count + trace.spanCount;
-      error = !!existing.error || trace.error;
-    }
+    const haveSpans = agg && Number(agg.span_count) > 0;
+    const startTime = haveSpans ? parseClickHouseTime(agg.start_time) : trace.startTime;
+    const endTime = haveSpans ? parseClickHouseTime(agg.end_time) : trace.endTime;
+    const spanCount = haveSpans ? Number(agg.span_count) : trace.spanCount;
+    const error = haveSpans ? !!agg.error : trace.error;
 
     const durationMs = endTime.getTime() - startTime.getTime();
 

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
@@ -1745,6 +1745,10 @@ export class ClickHouseEngine extends StorageEngine {
       serviceFilter = ' AND service_name = {p_service:String}';
     }
 
+    // Aggregates come from the hourly rollup. The rollup has no last-value column,
+    // so the true latest value is computed separately from the raw metrics table
+    // via argMax(value, time) instead of mislabeling the average as the latest.
+    // DateTime64(3) params match the fractional-second values from toDateTime64.
     const sql = `
       SELECT
         metric_name,
@@ -1756,28 +1760,44 @@ export class ClickHouseEngine extends StorageEngine {
         max(max_value) AS mx
       FROM metrics_hourly_rollup
       WHERE project_id IN {p_pids:Array(String)}
-        AND bucket >= {p_from:DateTime}
-        AND bucket <= {p_to:DateTime}
+        AND bucket >= {p_from:DateTime64(3)}
+        AND bucket <= {p_to:DateTime64(3)}
         ${serviceFilter}
       GROUP BY metric_name, service_name
       ORDER BY service_name, metric_name
     `;
 
-    const result = await this.runQuery({
-      query: sql,
-      query_params: queryParams,
-      format: 'JSONEachRow',
-    });
+    const latestSql = `
+      SELECT metric_name, service_name, argMax(value, time) AS latest_val
+      FROM metrics
+      WHERE project_id IN {p_pids:Array(String)}
+        AND time >= {p_from:DateTime64(3)}
+        AND time <= {p_to:DateTime64(3)}
+        ${serviceFilter}
+      GROUP BY metric_name, service_name
+    `;
+
+    const [result, latestResult] = await Promise.all([
+      this.runQuery({ query: sql, query_params: queryParams, format: 'JSONEachRow' }),
+      this.runQuery({ query: latestSql, query_params: queryParams, format: 'JSONEachRow' }),
+    ]);
     const rows = await result.json<Record<string, unknown>>();
+    const latestRows = await latestResult.json<Record<string, unknown>>();
+
+    const latestMap = new Map<string, number>();
+    for (const lr of latestRows) {
+      latestMap.set(`${lr.metric_name as string}|${lr.service_name as string}`, Number(lr.latest_val));
+    }
 
     const serviceMap = new Map<string, MetricOverviewItem[]>();
     for (const row of rows) {
       const serviceName = row.service_name as string;
+      const latestKey = `${row.metric_name as string}|${serviceName}`;
       const item: MetricOverviewItem = {
         metricName: row.metric_name as string,
         metricType: (row.mt as MetricType) || 'gauge',
         serviceName,
-        latestValue: Number(row.avg_val) ?? 0,
+        latestValue: latestMap.has(latestKey) ? latestMap.get(latestKey)! : Number(row.avg_val) ?? 0,
         avgValue: Number(row.avg_val) ?? 0,
         minValue: Number(row.mn) ?? 0,
         maxValue: Number(row.mx) ?? 0,

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
@@ -195,6 +195,7 @@ export class ClickHouseEngine extends StorageEngine {
           metadata String DEFAULT '{}',
           trace_id Nullable(String) DEFAULT NULL,
           span_id Nullable(String) DEFAULT NULL,
+          session_id Nullable(String) DEFAULT NULL,
           created_at DateTime DEFAULT now()
         )
         ENGINE = MergeTree()
@@ -239,6 +240,19 @@ export class ClickHouseEngine extends StorageEngine {
       });
     } catch {
       // index may already exist
+    }
+
+    // session_id: the engine writes and filters on it, so existing installs that
+    // predate this column need it added. New tables already have it from CREATE.
+    try {
+      await this.runCommand({
+        query: `ALTER TABLE ${t} ADD COLUMN IF NOT EXISTS session_id Nullable(String) DEFAULT NULL`,
+      });
+      await this.runCommand({
+        query: `ALTER TABLE ${t} ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 1`,
+      });
+    } catch {
+      // column/index may already exist
     }
 
     // Projection for fast service+level filtered queries
@@ -1788,9 +1802,15 @@ function parseClickHouseTime(value: unknown): Date {
   const str = String(value);
   // ClickHouse DateTime64(3) can return as epoch seconds (number) or ISO string
   const num = Number(str);
-  if (!isNaN(num)) {
+  if (!isNaN(num) && str.trim() !== '') {
     // If it looks like epoch seconds (< year 10000), convert
     return num < 1e12 ? new Date(num * 1000) : new Date(num);
+  }
+  // A space-separated ClickHouse datetime like "2025-01-15 12:00:00.000" carries
+  // no timezone and would be parsed as LOCAL time by Date. Treat the zone-less
+  // form as UTC by normalizing it to an ISO string with a 'Z' suffix.
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(str)) {
+    return new Date(`${str.replace(' ', 'T')}Z`);
   }
   return new Date(str);
 }

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
@@ -1790,6 +1790,13 @@ export class ClickHouseEngine extends StorageEngine {
     }
 
     const serviceMap = new Map<string, MetricOverviewItem[]>();
+    // `Number(x) ?? 0` does not catch NaN (Number() returns NaN, not nullish), so
+    // coerce explicitly and fall back to 0 for non-finite values.
+    const safeNum = (v: unknown): number => {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : 0;
+    };
+
     for (const row of rows) {
       const serviceName = row.service_name as string;
       const latestKey = `${row.metric_name as string}|${serviceName}`;
@@ -1797,11 +1804,11 @@ export class ClickHouseEngine extends StorageEngine {
         metricName: row.metric_name as string,
         metricType: (row.mt as MetricType) || 'gauge',
         serviceName,
-        latestValue: latestMap.has(latestKey) ? latestMap.get(latestKey)! : Number(row.avg_val) ?? 0,
-        avgValue: Number(row.avg_val) ?? 0,
-        minValue: Number(row.mn) ?? 0,
-        maxValue: Number(row.mx) ?? 0,
-        pointCount: Number(row.total_points) ?? 0,
+        latestValue: latestMap.has(latestKey) ? safeNum(latestMap.get(latestKey)) : safeNum(row.avg_val),
+        avgValue: safeNum(row.avg_val),
+        minValue: safeNum(row.mn),
+        maxValue: safeNum(row.mx),
+        pointCount: safeNum(row.total_points),
       };
       if (!serviceMap.has(serviceName)) serviceMap.set(serviceName, []);
       serviceMap.get(serviceName)!.push(item);

--- a/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
+++ b/packages/reservoir/src/engines/clickhouse/clickhouse-engine.ts
@@ -1047,6 +1047,21 @@ export class ClickHouseEngine extends StorageEngine {
     return rows.length > 0 ? mapClickHouseRowToTraceRecord(rows[0]) : null;
   }
 
+  async getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]> {
+    const conditions = ['project_id = {p_pid:String}'];
+    const queryParams: Record<string, unknown> = { p_pid: projectId };
+    if (from) { conditions.push('start_time >= {p_from:DateTime64(3)}'); queryParams.p_from = toDateTime64(from); }
+    if (to) { conditions.push('start_time <= {p_to:DateTime64(3)}'); queryParams.p_to = toDateTime64(to); }
+
+    const resultSet = await this.runQuery({
+      query: `SELECT DISTINCT service_name FROM traces WHERE ${conditions.join(' AND ')} ORDER BY service_name`,
+      query_params: queryParams,
+      format: 'JSONEachRow',
+    });
+    const rows = await resultSet.json<{ service_name: string }>();
+    return rows.map((r) => r.service_name).filter((s) => s != null && s !== '');
+  }
+
   async getServiceDependencies(
     projectId: string,
     from?: Date,

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine-integration.test.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine-integration.test.ts
@@ -916,6 +916,24 @@ describe('MongoDBEngine (integration)', () => {
     });
   });
 
+  describe('getTraceServices', () => {
+    beforeEach(async () => {
+      await engine.upsertTrace(makeTrace({ traceId: 'ts-1', projectId: 'proj-svc', serviceName: 'api' }));
+      await engine.upsertTrace(makeTrace({ traceId: 'ts-2', projectId: 'proj-svc', serviceName: 'worker' }));
+      await engine.upsertTrace(makeTrace({ traceId: 'ts-3', projectId: 'proj-svc', serviceName: 'api' }));
+    });
+
+    it('returns distinct service names across all traces', async () => {
+      const services = await engine.getTraceServices('proj-svc');
+      expect(services.sort()).toEqual(['api', 'worker']);
+    });
+
+    it('scopes by project', async () => {
+      const services = await engine.getTraceServices('proj-svc-empty');
+      expect(services).toEqual([]);
+    });
+  });
+
   describe('getServiceDependencies', () => {
     beforeEach(async () => {
       await engine.ingestSpans([

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
@@ -323,34 +323,43 @@ export class MongoDBEngine extends StorageEngine {
     const col = this.logsCol();
     const logsWithIds = logs.map((log) => ({ ...log, id: log.id ?? randomUUID() }));
 
+    const toRow = (log: (typeof logsWithIds)[number]): StoredLogRecord => ({
+      id: log.id,
+      time: log.time,
+      projectId: log.projectId,
+      organizationId: log.organizationId,
+      service: log.service,
+      level: log.level,
+      message: log.message,
+      metadata: log.metadata,
+      traceId: log.traceId,
+      spanId: log.spanId,
+      hostname: log.hostname,
+    });
+
     try {
       const docs = logsWithIds.map((log) => toMongoLogDoc(log, log.id));
       await col.insertMany(docs, { ...ctxOpts(), ordered: false });
 
-      const rows: StoredLogRecord[] = logsWithIds.map((log) => ({
-        id: log.id,
-        time: log.time,
-        projectId: log.projectId,
-        organizationId: log.organizationId,
-        service: log.service,
-        level: log.level,
-        message: log.message,
-        metadata: log.metadata,
-        traceId: log.traceId,
-        spanId: log.spanId,
-        hostname: log.hostname,
-      }));
+      const rows: StoredLogRecord[] = logsWithIds.map(toRow);
 
       return { ingested: logs.length, failed: 0, durationMs: Date.now() - start, rows };
     } catch (err) {
       if (err instanceof MongoBulkWriteError) {
         const inserted = err.result?.insertedCount ?? 0;
+        // With ordered:false every doc is attempted; the failed ones are reported
+        // with their indices. The inserted rows are therefore all inputs except
+        // those indices. Return them so downstream SIEM/pipeline processing still
+        // runs for the records that actually landed.
+        const writeErrors = extractWriteErrors(err);
+        const failedIdx = new Set(writeErrors.map((e) => e.index));
+        const rows = logsWithIds.filter((_, i) => !failedIdx.has(i)).map(toRow);
         return {
           ingested: inserted,
           failed: logs.length - inserted,
           durationMs: Date.now() - start,
-          rows: [], // cannot reliably determine which rows were inserted with ordered:false
-          errors: extractWriteErrors(err),
+          rows,
+          errors: writeErrors,
         };
       }
       return {

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
@@ -712,6 +712,19 @@ export class MongoDBEngine extends StorageEngine {
     return doc ? mapDocToTraceRecord(doc) : null;
   }
 
+  async getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]> {
+    const col = this.tracesCol();
+    const filter: Document = { project_id: projectId };
+    if (from || to) {
+      const timeFilter: Document = {};
+      if (from) timeFilter.$gte = from;
+      if (to) timeFilter.$lte = to;
+      filter.start_time = timeFilter;
+    }
+    const values = await col.distinct('service_name', filter, { ...ctxOpts() });
+    return (values as string[]).filter((v) => v != null && v !== '').sort();
+  }
+
   async getServiceDependencies(
     projectId: string,
     from?: Date,

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
@@ -504,8 +504,10 @@ export class MongoDBEngine extends StorageEngine {
     const pipeline: Document[] = [
       { $match: filter },
       // Pre-filter before $group to reduce the number of docs aggregated.
-      // Avoids grouping null/empty values that would be discarded afterwards.
-      { $match: { [mongoField]: { $exists: true, $ne: null, $gt: '' } } },
+      // Exclude only null and empty string. NOTE: `$gt: ''` would wrongly drop all
+      // numeric/boolean values too, since in BSON sort order those types compare
+      // below strings; use $nin so non-string metadata values survive.
+      { $match: { [mongoField]: { $exists: true, $nin: [null, ''] } } },
       { $group: { _id: `$${mongoField}` } },
       { $sort: { _id: 1 } },
       { $limit: limit },
@@ -1119,14 +1121,32 @@ export class MongoDBEngine extends StorageEngine {
       filter.service_name = { $in: svc };
     }
 
+    // When filtering by metric/service, only the matching metrics' exemplars must
+    // be removed. Exemplars carry no metric_name/service_name, only metric_id, so
+    // collect the matching metric ids before deleting the metrics.
+    const filtered = params.metricName !== undefined || params.serviceName !== undefined;
+    let exemplarFilter: Document;
+    if (filtered) {
+      const matched = await db
+        .collection('metrics')
+        .find(filter, { projection: { id: 1 }, ...ctxOpts() })
+        .toArray();
+      const ids = matched.map((m) => m.id);
+      exemplarFilter = { metric_id: { $in: ids } };
+    } else {
+      exemplarFilter = {
+        project_id: { $in: pids },
+        time: { $gte: params.from, $lte: params.to },
+      };
+    }
+
     // Delete metrics
     const result = await db.collection('metrics').deleteMany(filter, { ...ctxOpts() });
 
-    // Delete exemplars for same time range + project
-    await db.collection('metric_exemplars').deleteMany({
-      project_id: { $in: pids },
-      time: { $gte: params.from, $lte: params.to },
-    }, { ...ctxOpts() });
+    // Delete the corresponding exemplars (scoped to the matching metrics when filtered).
+    if (!filtered || (exemplarFilter.metric_id as { $in: unknown[] }).$in.length > 0) {
+      await db.collection('metric_exemplars').deleteMany(exemplarFilter, { ...ctxOpts() });
+    }
 
     return { deleted: result.deletedCount, executionTimeMs: Date.now() - start };
   }
@@ -1144,6 +1164,9 @@ export class MongoDBEngine extends StorageEngine {
 
     const pipeline = [
       { $match: match },
+      // $last is order-dependent, so sort by time first to make latest_value the
+      // value at the most recent timestamp (otherwise it is arbitrary).
+      { $sort: { time: 1 as const } },
       {
         $group: {
           _id: {

--- a/packages/reservoir/src/engines/timescale/timescale-engine.test.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.test.ts
@@ -590,36 +590,20 @@ describe('TimescaleEngine', () => {
       ...overrides,
     });
 
-    it('inserts a new trace when none exists', async () => {
-      // First query: SELECT existing → empty
-      mockQuery.mockResolvedValueOnce({ rows: [] });
-      // Second query: INSERT
+    it('upserts a trace with a single atomic ON CONFLICT statement', async () => {
       mockQuery.mockResolvedValueOnce({ rows: [] });
       await engine.connect();
 
       await engine.upsertTrace(makeTrace());
 
-      expect(mockQuery).toHaveBeenCalledTimes(2);
-      const selectSql = mockQuery.mock.calls[0][0] as string;
-      expect(selectSql).toContain('SELECT trace_id');
-      expect(selectSql).toContain('FROM public.traces');
-
-      const insertSql = mockQuery.mock.calls[1][0] as string;
-      expect(insertSql).toContain('INSERT INTO public.traces');
+      // A single statement now does the whole upsert (no read-modify-write).
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain('INSERT INTO public.traces');
+      expect(sql).toContain('ON CONFLICT (trace_id, project_id) DO UPDATE');
     });
 
-    it('updates an existing trace merging times and span count', async () => {
-      // First query: SELECT existing
-      mockQuery.mockResolvedValueOnce({
-        rows: [{
-          trace_id: 'trace-1',
-          start_time: new Date('2024-01-01T00:00:01Z'),
-          end_time: new Date('2024-01-01T00:00:04Z'),
-          span_count: 2,
-          error: false,
-        }],
-      });
-      // Second query: UPDATE
+    it('merges times and span count in SQL, not via a prior read', async () => {
       mockQuery.mockResolvedValueOnce({ rows: [] });
       await engine.connect();
 
@@ -629,16 +613,19 @@ describe('TimescaleEngine', () => {
         spanCount: 1,
       }));
 
-      const updateSql = mockQuery.mock.calls[1][0] as string;
-      expect(updateSql).toContain('UPDATE public.traces');
+      // Only one query: no SELECT of the existing row.
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const sql = mockQuery.mock.calls[0][0] as string;
+      // Time window widened and span_count accumulated atomically in SQL.
+      expect(sql).toContain('LEAST(public.traces.start_time, EXCLUDED.start_time)');
+      expect(sql).toContain('GREATEST(public.traces.end_time, EXCLUDED.end_time)');
+      expect(sql).toContain('public.traces.span_count + EXCLUDED.span_count');
 
-      const updateParams = mockQuery.mock.calls[1][1] as unknown[];
-      // start_time should be min (00:00:00)
-      expect((updateParams[0] as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z');
-      // end_time should be max (00:00:05)
-      expect((updateParams[1] as Date).toISOString()).toBe('2024-01-01T00:00:05.000Z');
-      // span_count increment
-      expect(updateParams[3]).toBe(1);
+      // Params carry the raw new values; the merge is done by the DB.
+      const params = mockQuery.mock.calls[0][1] as unknown[];
+      expect((params[6] as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z'); // start_time
+      expect((params[7] as Date).toISOString()).toBe('2024-01-01T00:00:05.000Z'); // end_time
+      expect(params[9]).toBe(1); // span_count
     });
   });
 

--- a/packages/reservoir/src/engines/timescale/timescale-engine.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.ts
@@ -622,42 +622,30 @@ export class TimescaleEngine extends StorageEngine {
   async upsertTrace(trace: TraceRecord): Promise<void> {
     const s = this.schema;
 
-    const existing = await this.runQuery(
-      `SELECT trace_id, start_time, end_time, span_count, error FROM ${s}.traces
-       WHERE trace_id = $1 AND project_id = $2`,
-      [trace.traceId, trace.projectId],
+    // Single atomic upsert on the (trace_id, project_id) primary key. Spans for one
+    // trace routinely arrive in concurrent ingest batches; a read-modify-write would
+    // race and lose span counts or insert duplicates. ON CONFLICT lets Postgres
+    // serialize the per-row merge, accumulating span_count and widening the time
+    // window with LEAST/GREATEST.
+    await this.runQuery(
+      `INSERT INTO ${s}.traces (
+        trace_id, organization_id, project_id, service_name, root_service_name, root_operation_name,
+        start_time, end_time, duration_ms, span_count, error
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      ON CONFLICT (trace_id, project_id) DO UPDATE SET
+        start_time = LEAST(${s}.traces.start_time, EXCLUDED.start_time),
+        end_time = GREATEST(${s}.traces.end_time, EXCLUDED.end_time),
+        duration_ms = (EXTRACT(EPOCH FROM (
+          GREATEST(${s}.traces.end_time, EXCLUDED.end_time) - LEAST(${s}.traces.start_time, EXCLUDED.start_time)
+        )) * 1000)::integer,
+        span_count = ${s}.traces.span_count + EXCLUDED.span_count,
+        error = ${s}.traces.error OR EXCLUDED.error,
+        root_service_name = COALESCE(EXCLUDED.root_service_name, ${s}.traces.root_service_name),
+        root_operation_name = COALESCE(EXCLUDED.root_operation_name, ${s}.traces.root_operation_name)`,
+      [trace.traceId, trace.organizationId ?? null, trace.projectId, trace.serviceName,
+       trace.rootServiceName ?? null, trace.rootOperationName ?? null,
+       trace.startTime, trace.endTime, trace.durationMs, trace.spanCount, trace.error],
     );
-
-    if (existing.rows.length === 0) {
-      await this.runQuery(
-        `INSERT INTO ${s}.traces (
-          trace_id, organization_id, project_id, service_name, root_service_name, root_operation_name,
-          start_time, end_time, duration_ms, span_count, error
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-        [trace.traceId, trace.organizationId ?? null, trace.projectId, trace.serviceName,
-         trace.rootServiceName ?? null, trace.rootOperationName ?? null,
-         trace.startTime, trace.endTime, trace.durationMs, trace.spanCount, trace.error],
-      );
-    } else {
-      const row = existing.rows[0];
-      const existingStart = new Date(row.start_time);
-      const existingEnd = new Date(row.end_time);
-      const newStart = trace.startTime < existingStart ? trace.startTime : existingStart;
-      const newEnd = trace.endTime > existingEnd ? trace.endTime : existingEnd;
-      const newDuration = newEnd.getTime() - newStart.getTime();
-
-      await this.runQuery(
-        `UPDATE ${s}.traces SET
-          start_time = $1, end_time = $2, duration_ms = $3,
-          span_count = span_count + $4, error = error OR $5,
-          root_service_name = COALESCE($6, root_service_name),
-          root_operation_name = COALESCE($7, root_operation_name)
-        WHERE trace_id = $8 AND project_id = $9`,
-        [newStart, newEnd, newDuration, trace.spanCount, trace.error,
-         trace.rootServiceName ?? null, trace.rootOperationName ?? null,
-         trace.traceId, trace.projectId],
-      );
-    }
   }
 
   async querySpans(params: SpanQueryParams): Promise<SpanQueryResult> {

--- a/packages/reservoir/src/engines/timescale/timescale-engine.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.ts
@@ -812,6 +812,23 @@ export class TimescaleEngine extends StorageEngine {
     return result.rows.length > 0 ? mapRowToTraceRecord(result.rows[0]) : null;
   }
 
+  async getTraceServices(projectId: string, from?: Date, to?: Date): Promise<string[]> {
+    const s = this.schema;
+    const conditions = ['project_id = $1'];
+    const values: unknown[] = [projectId];
+    let idx = 2;
+    if (from) { conditions.push(`start_time >= $${idx++}`); values.push(from); }
+    if (to) { conditions.push(`start_time <= $${idx++}`); values.push(to); }
+
+    const result = await this.runQuery(
+      `SELECT DISTINCT service_name FROM ${s}.traces WHERE ${conditions.join(' AND ')} ORDER BY service_name ASC`,
+      values,
+    );
+    return result.rows
+      .map((r) => r.service_name as string)
+      .filter((v) => v != null && v !== '');
+  }
+
   async getServiceDependencies(
     projectId: string,
     from?: Date,

--- a/packages/reservoir/src/engines/timescale/timescale-engine.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.ts
@@ -831,6 +831,7 @@ export class TimescaleEngine extends StorageEngine {
       INNER JOIN ${s}.spans parent
         ON child.parent_span_id = parent.span_id
         AND child.trace_id = parent.trace_id
+        AND parent.project_id = child.project_id
       WHERE child.project_id = $1
         AND child.service_name <> parent.service_name
         ${timeFilter}

--- a/packages/reservoir/src/engines/timescale/timescale-engine.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.ts
@@ -1,4 +1,5 @@
 import pg from 'pg';
+import { randomUUID } from 'crypto';
 import { currentOrNull } from '@logtide/shared/context';
 import { StorageEngine } from '../../core/storage-engine.js';
 import type {
@@ -497,7 +498,10 @@ export class TimescaleEngine extends StorageEngine {
   private buildInsertQuery(logs: LogRecord[], returning = false): { query: string; values: unknown[] } {
     const s = this.schema;
     const t = this.tableName;
-    const hasIds = logs.length > 0 && logs[0].id != null;
+    // Use the id-path if ANY log carries an id (not just the first): a mixed batch
+    // must not push `undefined` into the id array. Missing ids are generated so the
+    // UNNEST arrays stay aligned and provided ids are preserved.
+    const hasIds = logs.length > 0 && logs.some((l) => l.id != null);
 
     const ids: string[] = [];
     const times: Date[] = [];
@@ -511,7 +515,7 @@ export class TimescaleEngine extends StorageEngine {
     const sessionIds: (string | null)[] = [];
 
     for (const log of logs) {
-      if (hasIds) ids.push(log.id!);
+      if (hasIds) ids.push(log.id ?? randomUUID());
       times.push(log.time);
       projectIds.push(sanitizeNull(log.projectId));
       services.push(sanitizeNull(log.service));

--- a/packages/reservoir/src/engines/timescale/timescale-engine.ts
+++ b/packages/reservoir/src/engines/timescale/timescale-engine.ts
@@ -402,16 +402,21 @@ export class TimescaleEngine extends StorageEngine {
         const fieldName = params.field; // safe, validated above
         const projectIds = Array.isArray(params.projectId) ? params.projectId : [params.projectId];
 
+        // Honor the exclusive-bound flags so this fast path matches the standard
+        // distinct path (operators are not user input).
+        const fromOp = params.fromExclusive ? '>' : '>=';
+        const toOp = params.toExclusive ? '<' : '<=';
+
         // Use a recursive CTE to jump through the b-tree index
         // ORDER BY field only (not project_id) so we get the globally smallest value first
         const query = `
           WITH RECURSIVE t AS (
              (SELECT ${fieldName} AS value FROM ${this.schema}.${this.tableName}
-              WHERE project_id = ANY($1) AND time >= $2 AND time <= $3
+              WHERE project_id = ANY($1) AND time ${fromOp} $2 AND time ${toOp} $3
               ORDER BY ${fieldName}, time DESC LIMIT 1)
              UNION ALL
              SELECT (SELECT ${fieldName} AS value FROM ${this.schema}.${this.tableName}
-                     WHERE project_id = ANY($1) AND time >= $2 AND time <= $3 AND ${fieldName} > t.value
+                     WHERE project_id = ANY($1) AND time ${fromOp} $2 AND time ${toOp} $3 AND ${fieldName} > t.value
                      ORDER BY ${fieldName}, time DESC LIMIT 1)
              FROM t
              WHERE t.value IS NOT NULL

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logtide/shared",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Shared types, schemas and utilities for LogTide",
   "type": "module",

--- a/packages/shared/src/schemas/webhook-events.ts
+++ b/packages/shared/src/schemas/webhook-events.ts
@@ -59,7 +59,7 @@ export const monitorStatusChangedDataSchema = z
     title: z.string(),
     message: z.string(),
     organization: organizationRefSchema,
-    target: z.string().optional(),
+    target: z.string().nullable().optional(),
     error_code: z.string().nullable().optional(),
     response_time_ms: z.number().nullable().optional(),
     consecutive_failures: z.number().optional(),

--- a/packages/shared/src/schemas/webhook-events.ts
+++ b/packages/shared/src/schemas/webhook-events.ts
@@ -92,7 +92,7 @@ export const channelNotificationDataSchema = z
   .passthrough();
 
 export const webhookEnvelopeSchema = z.object({
-  id: z.string().regex(/^evt_[0-9a-f-]{36}$/),
+  id: z.string().regex(/^evt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/),
   type: webhookEventTypeSchema,
   version: z.literal(1),
   occurredAt: z.string().datetime(),


### PR DESCRIPTION
Patch release: security + correctness fixes from a comprehensive multi-engine bug audit of the 1.0 line. No database migrations; drop-in upgrade. Full record in `CHANGELOG.md` under `[1.0.1]`.

## Headline (security, were live in 1.0.0)
- **Cross-tenant log exposure** via the WebSocket live-tail (`/api/v1/logs/ws`) - now enforces project membership like the REST routes.
- **Cross-tenant leak of notification-channel secrets** via the alert-rule/sigma-rule channel endpoints - now membership + org-scoped.

## Also in this release
- **Security**: PII masking fail-open on all-digit strings, OIDC account-takeover (verified-email required), several `?projectId`/association cross-tenant gaps, session invalidation on disable/reset/role-change, logout revokes the server session, plus hardening (case-insensitive email, cache-TTL scoping, UUID envelope id, OTLP id validation).
- **Correctness**: Sigma AND/OR precedence, infinite-loop ingestion guard, race-free `upsertTrace` (Timescale `ON CONFLICT` + ClickHouse recompute-from-spans), ClickHouse `session_id`/UTC datetime/metrics, MongoDB exemplar/sort/distinct fixes, metadata-aware rate-of-change baselines, dashboard/pagination/live-tail fixes, queue retry parity, dead-letter-only webhook replay, bounded audit buffer.
- **Changed**: new `getTraceServices` (no distinct-services cap, all engines); CI now runs the MongoDB reservoir integration suite.

## Verification
- Full backend suite green (4564), shared + frontend unit green, reservoir CH+Mongo integration validated against real engines.
- PR #256 (the bug-hunt) merged into develop with all CI green incl. codecov/patch 83.5%.

Deferred follow-ups tracked in #255 (Sigma compound modifiers; true service-map p95).

After merge: tag `v1.0.1` and publish the GitHub release.