### PR TITLE
Digest expansion: ten new toggleable email report sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Top-N metadata dimension**: `top_n_table` panels can rank any flat metadata key (e.g. GeoIP `geo_place`) with limit up to 50, optional level/service filters and a Last seen column; reservoir `topValues` learned `includeLastSeen` on TimescaleDB, ClickHouse and MongoDB (#299).
 - **Digest sections**: daily/weekly digest emails can now report on every vertical, with ten new toggleable sections (log level breakdown, top error messages, traces, metrics, alerts, security activity, monitor performance, usage and quota warnings, webhook deliveries, team activity); new sections are off by default and configurable per organization in Settings > Email Digests.
 
+### Fixed
+
+- **MongoDB span sorting**: MongoDB span queries now accept the same sort fields as TimescaleDB and ClickHouse (`duration_ms`, `end_time`, `service_name`, `operation_name`); previously any sort other than `start_time`/`time` was silently ignored.
+
 
 ## [1.3.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Time series labels**: `time_series` panels accept optional per-level `seriesLabels` (e.g. info -> "Heartbeat"); legend and tooltip use them, falling back to Debug/Info/Warn/Error/Critical (#300).
 - **Display preferences**: new Settings > Display card with 12h/24h clock and explicit IANA timezone; all custom-dashboard panel timestamps honor it (browser timezone and 24h remain the defaults) (#297).
 - **Top-N metadata dimension**: `top_n_table` panels can rank any flat metadata key (e.g. GeoIP `geo_place`) with limit up to 50, optional level/service filters and a Last seen column; reservoir `topValues` learned `includeLastSeen` on TimescaleDB, ClickHouse and MongoDB (#299).
+- **Digest sections**: daily/weekly digest emails can now report on every vertical, with ten new toggleable sections (log level breakdown, top error messages, traces, metrics, alerts, security activity, monitor performance, usage and quota warnings, webhook deliveries, team activity); new sections are off by default and configurable per organization in Settings > Email Digests.
 
 
 ## [1.3.0] - 2026-08-11

--- a/packages/backend/migrations/057_digest_sections.sql
+++ b/packages/backend/migrations/057_digest_sections.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- Migration 057: Digest section toggles
+-- Adds sections JSONB to digest_configs: a partial map of section key to
+-- boolean, merged over code-side defaults. NULL means all defaults (the five
+-- original sections enabled, the ten new ones disabled).
+-- ============================================================================
+
+ALTER TABLE digest_configs ADD COLUMN IF NOT EXISTS sections JSONB;

--- a/packages/backend/src/database/types.ts
+++ b/packages/backend/src/database/types.ts
@@ -18,6 +18,7 @@ import type {
   ApiKeyType,
   PanelInstance,
   MetadataFilter,
+  DigestSections,
 } from '@logtide/shared';
 
 // Re-export types for backward compatibility (modules importing from database/types)
@@ -1142,6 +1143,12 @@ export interface DigestConfigsTable {
   delivery_day_of_week: number | null; 
   enabled: Generated<boolean>;
   last_sent_at: Timestamp | null;
+  // JSONB partial map of section key to boolean; NULL means all defaults
+  sections: ColumnType<
+    Partial<DigestSections> | null,
+    Partial<DigestSections> | null,
+    Partial<DigestSections> | null
+  >;
   created_at: Generated<Timestamp>;
   updated_at: Generated<Timestamp>;
 }

--- a/packages/backend/src/lib/email-templates.ts
+++ b/packages/backend/src/lib/email-templates.ts
@@ -939,15 +939,22 @@ function formatPct(value: number): string {
 }
 
 /**
- * Inbox preview line. The logs + detections pair is the original wording and
- * stays byte-identical when no expanded section is present; alerts and
- * incidents are appended only when their sections carry data.
+ * Inbox preview line. Every part is conditional on its section being present,
+ * so a disabled section never shows up as a zero. The logs + detections pair is
+ * the original wording and stays byte-identical with the default sections on
+ * and no expanded section present; alerts and incidents are appended only when
+ * their sections carry data.
  */
 function buildPreheader(data: DigestEmailData): string {
-  const parts = [
-    `${data.logVolume.current.toLocaleString('en-US')} logs`,
-    `${data.security.totalDetections.toLocaleString('en-US')} detections`,
-  ];
+  const parts: string[] = [];
+
+  if (data.logVolume) {
+    parts.push(`${data.logVolume.current.toLocaleString('en-US')} logs`);
+  }
+
+  if (data.security) {
+    parts.push(`${data.security.totalDetections.toLocaleString('en-US')} detections`);
+  }
 
   if (data.alerts) {
     parts.push(`${data.alerts.total.toLocaleString('en-US')} alerts`);
@@ -958,6 +965,11 @@ function buildPreheader(data: DigestEmailData): string {
     parts.push(`${opened.toLocaleString('en-US')} incidents`);
   }
 
+  // Every counted section is off: there is no number worth previewing.
+  if (parts.length === 0) {
+    return `Digest for ${data.organizationName}`;
+  }
+
   return `${parts.join(', ')} for ${data.organizationName}`;
 }
 
@@ -965,57 +977,77 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
   const frequencyLabel = data.frequency === 'daily' ? 'Daily' : 'Weekly';
   const title = `${frequencyLabel} Digest`;
   // A period is only quiet when nothing arrived at all: an org that ships no
-  // logs but does ship traces is not quiet, so spans veto the message.
+  // logs but does ship traces is not quiet, so spans veto the message. With the
+  // log volume section disabled there is no volume to call quiet at all.
   const quiet =
+    !!data.logVolume &&
     data.logVolume.current === 0 &&
     data.logVolume.previous === 0 &&
     (!data.traces || data.traces.spanCount + data.traces.previousSpanCount === 0);
 
-  const logVolumeSection = quiet
-    ? alertBox('No activity during this period. Your systems have been quiet.', 'info')
-    : infoBox([
-        { label: 'Total Logs', value: data.logVolume.current.toLocaleString('en-US') },
-        { label: 'Trend', value: data.logVolume.trend },
-        { label: 'Previous Period', value: data.logVolume.previous.toLocaleString('en-US') },
-      ]);
+  // --------------------------------------------------------------------------
+  // The five original sections. Each carries its own title so a disabled one
+  // (undefined) leaves nothing behind; enabled but empty still renders with the
+  // zeros and empty-state lines it has always shown.
+  // --------------------------------------------------------------------------
 
-  const topServicesSection =
-    data.topErrorServices.length > 0
-      ? digestTable(
-          ['Service', 'Errors', 'Previous', 'Delta'],
-          data.topErrorServices.map((s) => [
-            s.service,
-            s.errorCount.toLocaleString('en-US'),
-            s.previousCount.toLocaleString('en-US'),
-            formatDelta(s.delta),
-          ])
-        )
-      : digestEmptyLine('No errors recorded in this period.');
+  const logVolumeSection = data.logVolume
+    ? digestSectionTitle('Log Volume') +
+      (quiet
+        ? alertBox('No activity during this period. Your systems have been quiet.', 'info')
+        : infoBox([
+            { label: 'Total Logs', value: data.logVolume.current.toLocaleString('en-US') },
+            { label: 'Trend', value: data.logVolume.trend },
+            { label: 'Previous Period', value: data.logVolume.previous.toLocaleString('en-US') },
+          ]))
+    : '';
 
-  const errorGroupsSection =
-    data.newErrorGroups.length > 0
-      ? digestTable(
-          ['Error', 'Language', 'Occurrences'],
-          data.newErrorGroups.map((g) => [
-            `${g.exceptionType}${g.exceptionMessage ? ': ' + truncate(g.exceptionMessage, 60) : ''}`,
-            g.language,
-            g.occurrenceCount.toLocaleString('en-US'),
-          ])
-        )
-      : digestEmptyLine('No new error groups appeared in this period.');
+  const topServicesSection = data.topErrorServices
+    ? digestSectionTitle('Top Services by Errors') +
+      (data.topErrorServices.length > 0
+        ? digestTable(
+            ['Service', 'Errors', 'Previous', 'Delta'],
+            data.topErrorServices.map((s) => [
+              s.service,
+              s.errorCount.toLocaleString('en-US'),
+              s.previousCount.toLocaleString('en-US'),
+              formatDelta(s.delta),
+            ])
+          )
+        : digestEmptyLine('No errors recorded in this period.'))
+    : '';
 
-  const securityRows = [
-    { label: 'Detections', value: data.security.totalDetections.toLocaleString('en-US') },
-    { label: 'Open Incidents', value: data.security.openIncidents.toLocaleString('en-US') },
-  ];
-  const securitySection =
-    data.security.topRules.length > 0
-      ? infoBox(securityRows) +
-        digestTable(
-          ['Rule', 'Severity', 'Detections'],
-          data.security.topRules.map((r) => [r.ruleTitle, r.severity, r.count.toLocaleString('en-US')])
-        )
-      : infoBox(securityRows);
+  const errorGroupsSection = data.newErrorGroups
+    ? digestSectionTitle('New Error Groups') +
+      (data.newErrorGroups.length > 0
+        ? digestTable(
+            ['Error', 'Language', 'Occurrences'],
+            data.newErrorGroups.map((g) => [
+              `${g.exceptionType}${g.exceptionMessage ? ': ' + truncate(g.exceptionMessage, 60) : ''}`,
+              g.language,
+              g.occurrenceCount.toLocaleString('en-US'),
+            ])
+          )
+        : digestEmptyLine('No new error groups appeared in this period.'))
+    : '';
+
+  const securitySection = data.security
+    ? digestSectionTitle('Security') +
+      infoBox([
+        { label: 'Detections', value: data.security.totalDetections.toLocaleString('en-US') },
+        { label: 'Open Incidents', value: data.security.openIncidents.toLocaleString('en-US') },
+      ]) +
+      (data.security.topRules.length > 0
+        ? digestTable(
+            ['Rule', 'Severity', 'Detections'],
+            data.security.topRules.map((r) => [
+              r.ruleTitle,
+              r.severity,
+              r.count.toLocaleString('en-US'),
+            ])
+          )
+        : '')
+    : '';
 
   const uptimeSection = data.uptime
     ? digestSectionTitle('Uptime') +
@@ -1239,18 +1271,14 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
       ${divider()}
       ${subtitle(`${data.organizationName} - ${data.periodLabel}`)}
       ${timestamp()}
-      ${digestSectionTitle('Log Volume')}
       ${logVolumeSection}
       ${logBreakdownSection}
-      ${digestSectionTitle('Top Services by Errors')}
       ${topServicesSection}
       ${topErrorMessagesSection}
-      ${digestSectionTitle('New Error Groups')}
       ${errorGroupsSection}
       ${tracesSection}
       ${metricsSection}
       ${alertsSection}
-      ${digestSectionTitle('Security')}
       ${securitySection}
       ${securityActivitySection}
       ${uptimeSection}
@@ -1279,14 +1307,16 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
   lines.push(`Period: ${data.periodLabel}`);
   lines.push('');
   lines.push('='.repeat(50));
-  heading('LOG VOLUME');
-  if (quiet) {
-    lines.push('No activity during this period.');
-    lines.push('Your systems have been quiet.');
-  } else {
-    lines.push(`Total logs: ${data.logVolume.current.toLocaleString('en-US')}`);
-    lines.push(`Trend: ${data.logVolume.trend}`);
-    lines.push(`Previous period: ${data.logVolume.previous.toLocaleString('en-US')}`);
+  if (data.logVolume) {
+    heading('LOG VOLUME');
+    if (quiet) {
+      lines.push('No activity during this period.');
+      lines.push('Your systems have been quiet.');
+    } else {
+      lines.push(`Total logs: ${data.logVolume.current.toLocaleString('en-US')}`);
+      lines.push(`Trend: ${data.logVolume.trend}`);
+      lines.push(`Previous period: ${data.logVolume.previous.toLocaleString('en-US')}`);
+    }
   }
   if (data.logBreakdown) {
     heading('LOG BREAKDOWN');
@@ -1305,15 +1335,17 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
       }
     }
   }
-  heading('TOP SERVICES BY ERRORS');
-  if (data.topErrorServices.length > 0) {
-    for (const s of data.topErrorServices) {
-      lines.push(
-        `${s.service}: ${s.errorCount.toLocaleString('en-US')} errors (previous: ${s.previousCount.toLocaleString('en-US')}, delta: ${formatDelta(s.delta)})`
-      );
+  if (data.topErrorServices) {
+    heading('TOP SERVICES BY ERRORS');
+    if (data.topErrorServices.length > 0) {
+      for (const s of data.topErrorServices) {
+        lines.push(
+          `${s.service}: ${s.errorCount.toLocaleString('en-US')} errors (previous: ${s.previousCount.toLocaleString('en-US')}, delta: ${formatDelta(s.delta)})`
+        );
+      }
+    } else {
+      lines.push('No errors recorded in this period.');
     }
-  } else {
-    lines.push('No errors recorded in this period.');
   }
   if (data.topErrorMessages) {
     heading('TOP ERROR MESSAGES');
@@ -1321,14 +1353,16 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
       lines.push(`${truncate(m.message, 120)}: ${m.count.toLocaleString('en-US')}`);
     }
   }
-  heading('NEW ERROR GROUPS');
-  if (data.newErrorGroups.length > 0) {
-    for (const g of data.newErrorGroups) {
-      const message = g.exceptionMessage ? `: ${truncate(g.exceptionMessage, 80)}` : '';
-      lines.push(`${g.exceptionType}${message} (${g.language}, ${g.occurrenceCount.toLocaleString('en-US')} occurrences)`);
+  if (data.newErrorGroups) {
+    heading('NEW ERROR GROUPS');
+    if (data.newErrorGroups.length > 0) {
+      for (const g of data.newErrorGroups) {
+        const message = g.exceptionMessage ? `: ${truncate(g.exceptionMessage, 80)}` : '';
+        lines.push(`${g.exceptionType}${message} (${g.language}, ${g.occurrenceCount.toLocaleString('en-US')} occurrences)`);
+      }
+    } else {
+      lines.push('No new error groups appeared in this period.');
     }
-  } else {
-    lines.push('No new error groups appeared in this period.');
   }
   if (data.traces) {
     heading('TRACES');
@@ -1366,11 +1400,13 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
       lines.push(`${r.name}: ${r.count.toLocaleString('en-US')} triggers`);
     }
   }
-  heading('SECURITY');
-  lines.push(`Detections: ${data.security.totalDetections.toLocaleString('en-US')}`);
-  lines.push(`Open incidents: ${data.security.openIncidents.toLocaleString('en-US')}`);
-  for (const r of data.security.topRules) {
-    lines.push(`${r.ruleTitle} [${r.severity}]: ${r.count.toLocaleString('en-US')} detections`);
+  if (data.security) {
+    heading('SECURITY');
+    lines.push(`Detections: ${data.security.totalDetections.toLocaleString('en-US')}`);
+    lines.push(`Open incidents: ${data.security.openIncidents.toLocaleString('en-US')}`);
+    for (const r of data.security.topRules) {
+      lines.push(`${r.ruleTitle} [${r.severity}]: ${r.count.toLocaleString('en-US')} detections`);
+    }
   }
   if (data.securityActivity) {
     heading('SECURITY ACTIVITY');

--- a/packages/backend/src/lib/email-templates.ts
+++ b/packages/backend/src/lib/email-templates.ts
@@ -7,6 +7,7 @@
 
 import { config } from '../config/index.js';
 import { getLogoUrl } from './logo.js';
+import type { DigestReportData } from '../modules/digests/generator.js';
 
 // ============================================================================
 // HELPERS
@@ -843,40 +844,16 @@ Manage notifications: ${frontendUrl}/dashboard/settings/channels
 // DIGEST REPORT EMAIL (#154)
 // ============================================================================
 
-export interface DigestEmailData {
-  organizationName: string;
-  frequency: 'daily' | 'weekly';
-  periodLabel: string;
-  logVolume: {
-    current: number;
-    previous: number;
-    trend: string;
-  };
-  topErrorServices: Array<{
-    service: string;
-    errorCount: number;
-    previousCount: number;
-    delta: number;
-  }>;
-  newErrorGroups: Array<{
-    exceptionType: string;
-    exceptionMessage: string;
-    occurrenceCount: number;
-    language: string;
-  }>;
-  security: {
-    totalDetections: number;
-    topRules: Array<{ ruleTitle: string; severity: string; count: number }>;
-    openIncidents: number;
-  };
-  uptime: {
-    monitorCount: number;
-    overallUptimePct: number;
-    worstMonitors: Array<{ name: string; uptimePct: number }>;
-  } | null;
+/**
+ * The email is a pure projection of the generator's report: the section shapes
+ * live there and are imported as TYPES ONLY, so nothing of the generator (db,
+ * reservoir, nodemailer) is pulled into this module at runtime and the
+ * generator -> template import stays a one-way edge.
+ */
+export type DigestEmailData = DigestReportData & {
   unsubscribeUrl: string;
   dashboardUrl: string;
-}
+};
 
 function digestSectionTitle(title: string): string {
   return `<tr>
@@ -930,10 +907,69 @@ function formatDelta(delta: number): string {
   return delta.toLocaleString('en-US');
 }
 
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+/** Human-readable byte size: whole bytes, one decimal from KB up (1.5 GB). */
+function formatBytes(bytes: number): string {
+  let value = Math.max(0, bytes);
+  let unit = 0;
+
+  while (value >= 1024 && unit < BYTE_UNITS.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  const rendered = unit === 0 ? Math.round(value).toLocaleString('en-US') : value.toFixed(1);
+  return `${rendered} ${BYTE_UNITS[unit]}`;
+}
+
+/**
+ * Durations in ms, or a dash when there is nothing to show. Heartbeat monitors
+ * record no response time and surface as 0, which means "not timed" and must
+ * never be printed as an instant 0ms response.
+ */
+function formatMs(ms: number | null): string {
+  if (ms === null || ms <= 0) return '-';
+  return `${ms.toLocaleString('en-US')}ms`;
+}
+
+/** Percentages carry at most one decimal and are never fixed-width. */
+function formatPct(value: number): string {
+  return `${value.toLocaleString('en-US')}%`;
+}
+
+/**
+ * Inbox preview line. The logs + detections pair is the original wording and
+ * stays byte-identical when no expanded section is present; alerts and
+ * incidents are appended only when their sections carry data.
+ */
+function buildPreheader(data: DigestEmailData): string {
+  const parts = [
+    `${data.logVolume.current.toLocaleString('en-US')} logs`,
+    `${data.security.totalDetections.toLocaleString('en-US')} detections`,
+  ];
+
+  if (data.alerts) {
+    parts.push(`${data.alerts.total.toLocaleString('en-US')} alerts`);
+  }
+
+  if (data.securityActivity) {
+    const opened = data.securityActivity.openedBySeverity.reduce((sum, s) => sum + s.count, 0);
+    parts.push(`${opened.toLocaleString('en-US')} incidents`);
+  }
+
+  return `${parts.join(', ')} for ${data.organizationName}`;
+}
+
 export function generateDigestEmail(data: DigestEmailData): { html: string; text: string } {
   const frequencyLabel = data.frequency === 'daily' ? 'Daily' : 'Weekly';
   const title = `${frequencyLabel} Digest`;
-  const quiet = data.logVolume.current === 0 && data.logVolume.previous === 0;
+  // A period is only quiet when nothing arrived at all: an org that ships no
+  // logs but does ship traces is not quiet, so spans veto the message.
+  const quiet =
+    data.logVolume.current === 0 &&
+    data.logVolume.previous === 0 &&
+    (!data.traces || data.traces.spanCount + data.traces.previousSpanCount === 0);
 
   const logVolumeSection = quiet
     ? alertBox('No activity during this period. Your systems have been quiet.', 'info')
@@ -995,6 +1031,208 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
         : '')
     : '';
 
+  // --------------------------------------------------------------------------
+  // Expanded sections. Each one is undefined when disabled OR empty, and then
+  // renders nothing at all: no title, no empty-state line.
+  // (digestEmptyLine doubles as the muted one-liner for short section notes.)
+  // --------------------------------------------------------------------------
+
+  const logBreakdownSection = data.logBreakdown
+    ? digestSectionTitle('Log Breakdown') +
+      digestTable(
+        ['Level', 'Logs', 'Previous'],
+        data.logBreakdown.levels.map((l) => [
+          l.level,
+          l.current.toLocaleString('en-US'),
+          l.previous.toLocaleString('en-US'),
+        ])
+      ) +
+      infoBox([
+        { label: 'Error Rate', value: formatPct(data.logBreakdown.errorRatePct) },
+        { label: 'Previous Error Rate', value: formatPct(data.logBreakdown.previousErrorRatePct) },
+      ]) +
+      (data.logBreakdown.daily?.length
+        ? digestTable(
+            ['Day', 'Logs'],
+            data.logBreakdown.daily.map((d) => [d.date, d.count.toLocaleString('en-US')])
+          )
+        : '')
+    : '';
+
+  const topErrorMessagesSection = data.topErrorMessages
+    ? digestSectionTitle('Top Error Messages') +
+      digestTable(
+        ['Message', 'Count'],
+        data.topErrorMessages.map((m) => [
+          truncate(m.message, 120),
+          m.count.toLocaleString('en-US'),
+        ])
+      )
+    : '';
+
+  const tracesSection = data.traces
+    ? digestSectionTitle('Traces') +
+      infoBox([
+        { label: 'Spans', value: data.traces.spanCount.toLocaleString('en-US') },
+        { label: 'Span Trend', value: data.traces.trend },
+        { label: 'Previous Period', value: data.traces.previousSpanCount.toLocaleString('en-US') },
+        { label: 'Error Spans', value: data.traces.errorSpanCount.toLocaleString('en-US') },
+      ]) +
+      (data.traces.services.length > 0
+        ? digestEmptyLine(
+            'Top services by calls. p95 is the worst project value, not a merged percentile.'
+          ) +
+          digestTable(
+            ['Service', 'Calls', 'Error Rate', 'p95 (worst)'],
+            data.traces.services.map((s) => [
+              s.service,
+              s.calls.toLocaleString('en-US'),
+              formatPct(s.errorRatePct),
+              formatMs(s.p95Ms),
+            ])
+          )
+        : '') +
+      (data.traces.slowestSpans.length > 0
+        ? digestEmptyLine('Slowest spans in the period.') +
+          digestTable(
+            ['Operation', 'Service', 'Duration'],
+            data.traces.slowestSpans.map((s) => [
+              s.operation,
+              s.service,
+              formatMs(s.durationMs),
+            ])
+          )
+        : '')
+    : '';
+
+  const metricsSection = data.metrics
+    ? digestSectionTitle('Metrics') +
+      infoBox([
+        { label: 'Datapoints', value: data.metrics.datapoints.toLocaleString('en-US') },
+        { label: 'Datapoint Trend', value: data.metrics.trend },
+        {
+          label: 'Previous Period',
+          value: data.metrics.previousDatapoints.toLocaleString('en-US'),
+        },
+      ])
+    : '';
+
+  const alertsSection = data.alerts
+    ? digestSectionTitle('Alerts') +
+      infoBox([
+        { label: 'Triggers', value: data.alerts.total.toLocaleString('en-US') },
+        { label: 'Alert Trend', value: data.alerts.trend },
+        { label: 'Previous Period', value: data.alerts.previousTotal.toLocaleString('en-US') },
+      ]) +
+      // Nothing fired this period but something fired in the previous one: the
+      // totals still matter, the (empty) ranking does not.
+      (data.alerts.topRules.length > 0
+        ? digestTable(
+            ['Rule', 'Triggers'],
+            data.alerts.topRules.map((r) => [r.name, r.count.toLocaleString('en-US')])
+          )
+        : '')
+    : '';
+
+  const incidentsOpened = data.securityActivity
+    ? data.securityActivity.openedBySeverity.reduce((sum, s) => sum + s.count, 0)
+    : 0;
+
+  const securityActivitySection = data.securityActivity
+    ? digestSectionTitle('Security Activity') +
+      infoBox([
+        { label: 'Incidents Opened', value: incidentsOpened.toLocaleString('en-US') },
+        {
+          label: 'Incidents Resolved',
+          value: data.securityActivity.resolvedCount.toLocaleString('en-US'),
+        },
+      ]) +
+      (data.securityActivity.openedBySeverity.length > 0
+        ? digestTable(
+            ['Severity', 'Opened'],
+            data.securityActivity.openedBySeverity.map((s) => [
+              s.severity,
+              s.count.toLocaleString('en-US'),
+            ])
+          )
+        : '') +
+      (data.securityActivity.topTechniques.length > 0
+        ? digestTable(
+            ['MITRE Technique', 'Detections'],
+            data.securityActivity.topTechniques.map((t) => [
+              t.technique,
+              t.count.toLocaleString('en-US'),
+            ])
+          )
+        : '')
+    : '';
+
+  const monitorPerformanceSection = data.monitorPerformance
+    ? digestSectionTitle('Monitor Performance') +
+      digestEmptyLine('Monitors without response timing (heartbeats) show a dash.') +
+      digestTable(
+        ['Monitor', 'Avg', 'p95', 'Failed'],
+        data.monitorPerformance.map((m) => [
+          m.name,
+          formatMs(m.avgMs),
+          formatMs(m.p95Ms),
+          m.failedChecks.toLocaleString('en-US'),
+        ])
+      )
+    : '';
+
+  const usageSection = data.usage
+    ? digestSectionTitle('Usage') +
+      infoBox([
+        { label: 'Log Events', value: data.usage.logEvents.toLocaleString('en-US') },
+        { label: 'Log Volume', value: formatBytes(data.usage.logBytes) },
+        { label: 'Spans', value: data.usage.spans.toLocaleString('en-US') },
+      ]) +
+      (data.usage.topProjects.length > 0
+        ? digestTable(
+            ['Project', 'Events'],
+            data.usage.topProjects.map((p) => [p.name, p.events.toLocaleString('en-US')])
+          )
+        : '') +
+      // Quota windows are month-to-date, not period-scoped: say so.
+      (data.usage.quotaWarnings.length > 0
+        ? alertBox(
+            `Month-to-date usage above 80% of limit: ${data.usage.quotaWarnings
+              .map((w) => `<strong>${escapeHtml(w.capability)}</strong> ${w.usedPct}%`)
+              .join(', ')}`,
+            'warning'
+          )
+        : '')
+    : '';
+
+  const webhooksSection = data.webhooks
+    ? digestSectionTitle('Webhooks') +
+      infoBox([
+        { label: 'Delivered', value: data.webhooks.delivered.toLocaleString('en-US') },
+        { label: 'Failed', value: data.webhooks.failed.toLocaleString('en-US') },
+        { label: 'Dead', value: data.webhooks.dead.toLocaleString('en-US') },
+      ]) +
+      (data.webhooks.dead > 0
+        ? alertBox(
+            `<strong>${data.webhooks.dead.toLocaleString('en-US')}</strong> deliver${data.webhooks.dead === 1 ? 'y' : 'ies'} reached the dead-letter queue and need attention.`,
+            'warning'
+          )
+        : '')
+    : '';
+
+  const teamActivitySection = data.teamActivity
+    ? digestSectionTitle('Team Activity') +
+      infoBox([
+        { label: 'Members Added', value: data.teamActivity.membersAdded.toLocaleString('en-US') },
+        {
+          label: 'Members Removed',
+          value: data.teamActivity.membersRemoved.toLocaleString('en-US'),
+        },
+        { label: 'Config Changes', value: data.teamActivity.configChanges.toLocaleString('en-US') },
+        { label: 'Failed Logins', value: data.teamActivity.failedLogins.toLocaleString('en-US') },
+      ])
+    : '';
+
   const html = baseTemplate(
     card(`
       ${header(title, { text: data.frequency, color: colors.info })}
@@ -1003,32 +1241,45 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
       ${timestamp()}
       ${digestSectionTitle('Log Volume')}
       ${logVolumeSection}
+      ${logBreakdownSection}
       ${digestSectionTitle('Top Services by Errors')}
       ${topServicesSection}
+      ${topErrorMessagesSection}
       ${digestSectionTitle('New Error Groups')}
       ${errorGroupsSection}
+      ${tracesSection}
+      ${metricsSection}
+      ${alertsSection}
       ${digestSectionTitle('Security')}
       ${securitySection}
+      ${securityActivitySection}
       ${uptimeSection}
+      ${monitorPerformanceSection}
+      ${usageSection}
+      ${webhooksSection}
+      ${teamActivitySection}
       ${cta('View Dashboard', data.dashboardUrl)}
     `),
     {
-      preheader: quiet
-        ? `Quiet period for ${data.organizationName}`
-        : `${data.logVolume.current.toLocaleString('en-US')} logs, ${data.security.totalDetections.toLocaleString('en-US')} detections for ${data.organizationName}`,
+      preheader: quiet ? `Quiet period for ${data.organizationName}` : buildPreheader(data),
       unsubscribeUrl: data.unsubscribeUrl,
     }
   );
 
   const lines: string[] = [];
+  // Same shape as before: a blank line, the heading, then a rule of its length.
+  const heading = (text: string): void => {
+    lines.push('');
+    lines.push(text);
+    lines.push('-'.repeat(text.length));
+  };
+
   lines.push(`LogTide ${frequencyLabel} Digest`);
   lines.push(`Organization: ${data.organizationName}`);
   lines.push(`Period: ${data.periodLabel}`);
   lines.push('');
   lines.push('='.repeat(50));
-  lines.push('');
-  lines.push('LOG VOLUME');
-  lines.push('-'.repeat(10));
+  heading('LOG VOLUME');
   if (quiet) {
     lines.push('No activity during this period.');
     lines.push('Your systems have been quiet.');
@@ -1037,9 +1288,24 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
     lines.push(`Trend: ${data.logVolume.trend}`);
     lines.push(`Previous period: ${data.logVolume.previous.toLocaleString('en-US')}`);
   }
-  lines.push('');
-  lines.push('TOP SERVICES BY ERRORS');
-  lines.push('-'.repeat(22));
+  if (data.logBreakdown) {
+    heading('LOG BREAKDOWN');
+    for (const l of data.logBreakdown.levels) {
+      lines.push(
+        `${l.level}: ${l.current.toLocaleString('en-US')} (previous: ${l.previous.toLocaleString('en-US')})`
+      );
+    }
+    lines.push(
+      `Error rate: ${formatPct(data.logBreakdown.errorRatePct)} (previous: ${formatPct(data.logBreakdown.previousErrorRatePct)})`
+    );
+    if (data.logBreakdown.daily?.length) {
+      lines.push('Per day:');
+      for (const d of data.logBreakdown.daily) {
+        lines.push(`${d.date}: ${d.count.toLocaleString('en-US')}`);
+      }
+    }
+  }
+  heading('TOP SERVICES BY ERRORS');
   if (data.topErrorServices.length > 0) {
     for (const s of data.topErrorServices) {
       lines.push(
@@ -1049,9 +1315,13 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
   } else {
     lines.push('No errors recorded in this period.');
   }
-  lines.push('');
-  lines.push('NEW ERROR GROUPS');
-  lines.push('-'.repeat(16));
+  if (data.topErrorMessages) {
+    heading('TOP ERROR MESSAGES');
+    for (const m of data.topErrorMessages) {
+      lines.push(`${truncate(m.message, 120)}: ${m.count.toLocaleString('en-US')}`);
+    }
+  }
+  heading('NEW ERROR GROUPS');
   if (data.newErrorGroups.length > 0) {
     for (const g of data.newErrorGroups) {
       const message = g.exceptionMessage ? `: ${truncate(g.exceptionMessage, 80)}` : '';
@@ -1060,22 +1330,116 @@ export function generateDigestEmail(data: DigestEmailData): { html: string; text
   } else {
     lines.push('No new error groups appeared in this period.');
   }
-  lines.push('');
-  lines.push('SECURITY');
-  lines.push('-'.repeat(8));
+  if (data.traces) {
+    heading('TRACES');
+    lines.push(`Spans: ${data.traces.spanCount.toLocaleString('en-US')}`);
+    lines.push(`Span trend: ${data.traces.trend}`);
+    lines.push(`Previous spans: ${data.traces.previousSpanCount.toLocaleString('en-US')}`);
+    lines.push(`Error spans: ${data.traces.errorSpanCount.toLocaleString('en-US')}`);
+    if (data.traces.services.length > 0) {
+      lines.push('Top services by calls (p95 is the worst project value):');
+      for (const s of data.traces.services) {
+        lines.push(
+          `${s.service}: ${s.calls.toLocaleString('en-US')} calls, ${formatPct(s.errorRatePct)} errors, p95 ${formatMs(s.p95Ms)}`
+        );
+      }
+    }
+    if (data.traces.slowestSpans.length > 0) {
+      lines.push('Slowest spans:');
+      for (const s of data.traces.slowestSpans) {
+        lines.push(`${s.operation} (${s.service}): ${formatMs(s.durationMs)}`);
+      }
+    }
+  }
+  if (data.metrics) {
+    heading('METRICS');
+    lines.push(`Datapoints: ${data.metrics.datapoints.toLocaleString('en-US')}`);
+    lines.push(`Datapoint trend: ${data.metrics.trend}`);
+    lines.push(`Previous datapoints: ${data.metrics.previousDatapoints.toLocaleString('en-US')}`);
+  }
+  if (data.alerts) {
+    heading('ALERTS');
+    lines.push(`Triggers: ${data.alerts.total.toLocaleString('en-US')}`);
+    lines.push(`Alert trend: ${data.alerts.trend}`);
+    lines.push(`Previous triggers: ${data.alerts.previousTotal.toLocaleString('en-US')}`);
+    for (const r of data.alerts.topRules) {
+      lines.push(`${r.name}: ${r.count.toLocaleString('en-US')} triggers`);
+    }
+  }
+  heading('SECURITY');
   lines.push(`Detections: ${data.security.totalDetections.toLocaleString('en-US')}`);
   lines.push(`Open incidents: ${data.security.openIncidents.toLocaleString('en-US')}`);
   for (const r of data.security.topRules) {
     lines.push(`${r.ruleTitle} [${r.severity}]: ${r.count.toLocaleString('en-US')} detections`);
   }
+  if (data.securityActivity) {
+    heading('SECURITY ACTIVITY');
+    lines.push(`Incidents opened: ${incidentsOpened.toLocaleString('en-US')}`);
+    lines.push(
+      `Incidents resolved: ${data.securityActivity.resolvedCount.toLocaleString('en-US')}`
+    );
+    if (data.securityActivity.openedBySeverity.length > 0) {
+      lines.push('Opened by severity:');
+      for (const s of data.securityActivity.openedBySeverity) {
+        lines.push(`${s.severity}: ${s.count.toLocaleString('en-US')}`);
+      }
+    }
+    if (data.securityActivity.topTechniques.length > 0) {
+      lines.push('Top MITRE techniques:');
+      for (const t of data.securityActivity.topTechniques) {
+        lines.push(`${t.technique}: ${t.count.toLocaleString('en-US')}`);
+      }
+    }
+  }
   if (data.uptime) {
-    lines.push('');
-    lines.push('UPTIME');
-    lines.push('-'.repeat(6));
+    heading('UPTIME');
     lines.push(`Overall: ${data.uptime.overallUptimePct.toLocaleString('en-US')}% across ${data.uptime.monitorCount.toLocaleString('en-US')} monitor(s)`);
     for (const m of data.uptime.worstMonitors) {
       lines.push(`${m.name}: ${m.uptimePct.toLocaleString('en-US')}%`);
     }
+  }
+  if (data.monitorPerformance) {
+    heading('MONITOR PERFORMANCE');
+    lines.push('Monitors without response timing (heartbeats) show a dash.');
+    for (const m of data.monitorPerformance) {
+      lines.push(
+        `${m.name}: avg ${formatMs(m.avgMs)}, p95 ${formatMs(m.p95Ms)}, ${m.failedChecks.toLocaleString('en-US')} failed checks`
+      );
+    }
+  }
+  if (data.usage) {
+    heading('USAGE');
+    lines.push(`Log events: ${data.usage.logEvents.toLocaleString('en-US')}`);
+    lines.push(`Log volume: ${formatBytes(data.usage.logBytes)}`);
+    lines.push(`Spans: ${data.usage.spans.toLocaleString('en-US')}`);
+    if (data.usage.topProjects.length > 0) {
+      lines.push('Top projects:');
+      for (const p of data.usage.topProjects) {
+        lines.push(`${p.name}: ${p.events.toLocaleString('en-US')} events`);
+      }
+    }
+    if (data.usage.quotaWarnings.length > 0) {
+      lines.push('Month-to-date usage above 80% of limit:');
+      for (const w of data.usage.quotaWarnings) {
+        lines.push(`${w.capability}: ${w.usedPct}%`);
+      }
+    }
+  }
+  if (data.webhooks) {
+    heading('WEBHOOKS');
+    lines.push(`Delivered: ${data.webhooks.delivered.toLocaleString('en-US')}`);
+    lines.push(`Failed: ${data.webhooks.failed.toLocaleString('en-US')}`);
+    lines.push(`Dead: ${data.webhooks.dead.toLocaleString('en-US')}`);
+    if (data.webhooks.dead > 0) {
+      lines.push('Dead-lettered deliveries need attention.');
+    }
+  }
+  if (data.teamActivity) {
+    heading('TEAM ACTIVITY');
+    lines.push(`Members added: ${data.teamActivity.membersAdded.toLocaleString('en-US')}`);
+    lines.push(`Members removed: ${data.teamActivity.membersRemoved.toLocaleString('en-US')}`);
+    lines.push(`Config changes: ${data.teamActivity.configChanges.toLocaleString('en-US')}`);
+    lines.push(`Failed logins: ${data.teamActivity.failedLogins.toLocaleString('en-US')}`);
   }
   lines.push('');
   lines.push(`View your dashboard: ${data.dashboardUrl}`);

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -63,6 +63,21 @@ export interface DigestReportData {
     trend: string;
     topRules: Array<{ name: string; count: number }>;
   };
+  traces?: {
+    spanCount: number;
+    previousSpanCount: number;
+    trend: string;
+    errorSpanCount: number;
+    /** Top 5 by calls desc */
+    services: Array<{ service: string; calls: number; errorRatePct: number; p95Ms: number | null }>;
+    /** Top 5 slowest spans in the period */
+    slowestSpans: Array<{ service: string; operation: string; durationMs: number }>;
+  };
+  metrics?: {
+    datapoints: number;
+    previousDatapoints: number;
+    trend: string;
+  };
 }
 
 interface DigestRecipient {
@@ -189,6 +204,12 @@ export class DigestGeneratorService {
     const alerts = sections.alerts
       ? await this.calculateAlertsSummary(organizationId, period)
       : undefined;
+    const traces = sections.traces
+      ? await this.calculateTracesSummary(projectIds, period, frequency)
+      : undefined;
+    const metrics = sections.metrics
+      ? await this.calculateMetricsSummary(projectIds, period)
+      : undefined;
 
     return {
       organizationName,
@@ -202,6 +223,8 @@ export class DigestGeneratorService {
       logBreakdown,
       topErrorMessages,
       alerts,
+      traces,
+      metrics,
     };
   }
 
@@ -606,6 +629,146 @@ export class DigestGeneratorService {
       previousTotal,
       trend: this.calculateTrend(total, previousTotal),
       topRules: topRules.map((r) => ({ name: r.name, count: Number(r.count) })),
+    };
+  }
+
+  /**
+   * Span volume and error spans for both windows, the busiest services and the
+   * slowest spans of the period. Engine-agnostic through reservoir.
+   */
+  private async calculateTracesSummary(
+    projectIds: string[],
+    period: Period,
+    frequency: 'daily' | 'weekly'
+  ): Promise<DigestReportData['traces']> {
+    if (projectIds.length === 0) {
+      return undefined;
+    }
+
+    // Hourly buckets over 24h, daily over 7d: either way the row count stays
+    // bounded (24 or 7) and we only ever sum them.
+    const bucket = frequency === 'weekly' ? 'day' : 'hour';
+
+    const currentBuckets = await reservoir.getSpanTimeseries({
+      projectIds,
+      from: period.from,
+      to: period.to,
+      bucket,
+    });
+
+    const previousBuckets = await reservoir.getSpanTimeseries({
+      projectIds,
+      from: period.previousFrom,
+      to: period.previousTo,
+      bucket,
+    });
+
+    const spanCount = currentBuckets.reduce((sum, b) => sum + b.spanCount, 0);
+    const previousSpanCount = previousBuckets.reduce((sum, b) => sum + b.spanCount, 0);
+
+    // No traces in either window: skip the ranking queries and the section
+    if (spanCount === 0 && previousSpanCount === 0) {
+      return undefined;
+    }
+
+    const errorSpanCount = currentBuckets.reduce((sum, b) => sum + b.errorCount, 0);
+
+    // getServiceHealthStats is single-project by design: query each project and
+    // merge by service name.
+    const byService = new Map<string, { calls: number; errors: number; p95Ms: number | null }>();
+
+    for (const projectId of projectIds) {
+      const stats = await reservoir.getServiceHealthStats(projectId, period.from, period.to);
+
+      for (const stat of stats) {
+        const entry = byService.get(stat.serviceName) ?? { calls: 0, errors: 0, p95Ms: null };
+        entry.calls += stat.totalCalls;
+        entry.errors += stat.totalErrors;
+        // Worst-project p95, NOT a merged percentile: percentiles cannot be
+        // combined from per-project values without the raw distribution, so the
+        // digest reports the worst project's p95 for the service.
+        if (
+          stat.p95LatencyMs !== null &&
+          (entry.p95Ms === null || stat.p95LatencyMs > entry.p95Ms)
+        ) {
+          entry.p95Ms = stat.p95LatencyMs;
+        }
+        byService.set(stat.serviceName, entry);
+      }
+    }
+
+    const services = Array.from(byService.entries())
+      .map(([service, entry]) => ({
+        service,
+        calls: entry.calls,
+        errorRatePct: this.errorRate(entry.errors, entry.calls),
+        p95Ms: entry.p95Ms,
+      }))
+      .sort((a, b) => b.calls - a.calls)
+      .slice(0, 5);
+
+    // NOTE: the MongoDB engine only sorts spans by start_time, so on that engine
+    // this is the 5 most recent spans rather than the 5 slowest.
+    const slowest = await reservoir.querySpans({
+      projectId: projectIds,
+      from: period.from,
+      to: period.to,
+      toExclusive: true,
+      sortBy: 'duration_ms',
+      sortOrder: 'desc',
+      limit: 5,
+    });
+
+    return {
+      spanCount,
+      previousSpanCount,
+      trend: this.calculateTrend(spanCount, previousSpanCount),
+      errorSpanCount,
+      services,
+      slowestSpans: slowest.spans.map((s) => ({
+        service: s.serviceName,
+        operation: s.operationName,
+        durationMs: s.durationMs,
+      })),
+    };
+  }
+
+  /**
+   * Metric datapoints ingested in the period vs the previous one. Only the
+   * result total is needed, so both queries ask for a single row.
+   */
+  private async calculateMetricsSummary(
+    projectIds: string[],
+    period: Period
+  ): Promise<DigestReportData['metrics']> {
+    if (projectIds.length === 0) {
+      return undefined;
+    }
+
+    const current = await reservoir.queryMetrics({
+      projectId: projectIds,
+      from: period.from,
+      to: period.to,
+      toExclusive: true,
+      limit: 1,
+    });
+
+    const previous = await reservoir.queryMetrics({
+      projectId: projectIds,
+      from: period.previousFrom,
+      to: period.previousTo,
+      toExclusive: true,
+      limit: 1,
+    });
+
+    if (current.total === 0 && previous.total === 0) {
+      return undefined;
+    }
+
+    return {
+      datapoints: current.total,
+      previousDatapoints: previous.total,
+      trend: this.calculateTrend(current.total, previous.total),
     };
   }
 

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -10,6 +10,8 @@ import nodemailer from 'nodemailer';
 import { db } from '../../database/connection.js';
 import { reservoir } from '../../database/reservoir.js';
 import { hub } from '@logtide/core';
+import { DIGEST_SECTION_DEFAULTS, LOG_LEVELS } from '@logtide/shared';
+import type { DigestSections } from '@logtide/shared';
 import { config } from '../../config/index.js';
 import { generateDigestEmail } from '../../lib/email-templates.js';
 import type { DigestJobPayload } from './scheduler.js';
@@ -45,6 +47,22 @@ export interface DigestReportData {
     overallUptimePct: number;
     worstMonitors: Array<{ name: string; uptimePct: number }>;
   } | null;
+  // Optional sections: undefined means "disabled OR no data", and the email
+  // skips them entirely (no empty-state lines, unlike the five sections above).
+  logBreakdown?: {
+    levels: Array<{ level: string; current: number; previous: number }>;
+    errorRatePct: number;
+    previousErrorRatePct: number;
+    /** Weekly digests only */
+    daily?: Array<{ date: string; count: number }>;
+  };
+  topErrorMessages?: Array<{ message: string; count: number }>;
+  alerts?: {
+    total: number;
+    previousTotal: number;
+    trend: string;
+    topRules: Array<{ name: string; count: number }>;
+  };
 }
 
 interface DigestRecipient {
@@ -115,7 +133,13 @@ export class DigestGeneratorService {
         return;
       }
 
-      const report = await this.buildReportData(organizationId, organization.name, frequency);
+      // Jobs enqueued before section toggles shipped carry no flags: use defaults.
+      const report = await this.buildReportData(
+        organizationId,
+        organization.name,
+        frequency,
+        payload.sections ?? DIGEST_SECTION_DEFAULTS
+      );
 
       await this.sendDigestEmails(recipients, report);
 
@@ -127,13 +151,19 @@ export class DigestGeneratorService {
   }
 
   /**
-   * Compute all report sections for the period. Sections run sequentially:
-   * this is a background cron path where simplicity beats latency.
+   * Compute the enabled report sections for the period. Sections run
+   * sequentially: this is a background cron path where simplicity beats
+   * latency. A disabled section costs zero queries.
+   *
+   * The five original sections always run (they are non-optional fields of
+   * DigestReportData); the optional ones are computed after them, in the
+   * catalog order of DIGEST_SECTION_KEYS, so the order stays unambiguous.
    */
   async buildReportData(
     organizationId: string,
     organizationName: string,
-    frequency: 'daily' | 'weekly'
+    frequency: 'daily' | 'weekly',
+    sections: DigestSections = DIGEST_SECTION_DEFAULTS
   ): Promise<DigestReportData> {
     const period = this.buildPeriod(frequency);
 
@@ -150,6 +180,16 @@ export class DigestGeneratorService {
     const security = await this.calculateSecuritySummary(organizationId, period);
     const uptime = await this.calculateUptimeSummary(organizationId, period);
 
+    const logBreakdown = sections.logBreakdown
+      ? await this.calculateLogBreakdown(projectIds, period, frequency)
+      : undefined;
+    const topErrorMessages = sections.topErrorMessages
+      ? await this.calculateTopErrorMessages(projectIds, period)
+      : undefined;
+    const alerts = sections.alerts
+      ? await this.calculateAlertsSummary(organizationId, period)
+      : undefined;
+
     return {
       organizationName,
       frequency,
@@ -159,6 +199,9 @@ export class DigestGeneratorService {
       newErrorGroups,
       security,
       uptime,
+      logBreakdown,
+      topErrorMessages,
+      alerts,
     };
   }
 
@@ -386,6 +429,183 @@ export class DigestGeneratorService {
       monitorCount: monitors.length,
       overallUptimePct,
       worstMonitors: perMonitor.slice(0, 5),
+    };
+  }
+
+  /**
+   * Per-level counts for both windows plus the error rate, and for weekly
+   * digests a per-day volume table. Engine-agnostic through reservoir.
+   * Levels outside LOG_LEVELS cannot exist (the level column is constrained on
+   * every engine), so the canonical five are the whole population here.
+   */
+  private async calculateLogBreakdown(
+    projectIds: string[],
+    period: Period,
+    frequency: 'daily' | 'weekly'
+  ): Promise<DigestReportData['logBreakdown']> {
+    if (projectIds.length === 0) {
+      return undefined;
+    }
+
+    const current = await reservoir.topValues({
+      field: 'level',
+      projectId: projectIds,
+      from: period.from,
+      to: period.to,
+      toExclusive: true,
+      limit: 10,
+    });
+
+    const previous = await reservoir.topValues({
+      field: 'level',
+      projectId: projectIds,
+      from: period.previousFrom,
+      to: period.previousTo,
+      toExclusive: true,
+      limit: 10,
+    });
+
+    const currentByLevel = new Map(current.values.map((v) => [v.value, v.count]));
+    const previousByLevel = new Map(previous.values.map((v) => [v.value, v.count]));
+
+    const levels = LOG_LEVELS.map((level) => ({
+      level: level as string, // widened: the report shape is engine-agnostic
+      current: currentByLevel.get(level) ?? 0,
+      previous: previousByLevel.get(level) ?? 0,
+    }));
+
+    const currentTotal = levels.reduce((sum, l) => sum + l.current, 0);
+    const previousTotal = levels.reduce((sum, l) => sum + l.previous, 0);
+
+    if (currentTotal === 0 && previousTotal === 0) {
+      return undefined;
+    }
+
+    const errorRatePct = this.errorRate(
+      levels.reduce((sum, l) => sum + (this.isErrorLevel(l.level) ? l.current : 0), 0),
+      currentTotal
+    );
+    const previousErrorRatePct = this.errorRate(
+      levels.reduce((sum, l) => sum + (this.isErrorLevel(l.level) ? l.previous : 0), 0),
+      previousTotal
+    );
+
+    if (frequency !== 'weekly') {
+      return { levels, errorRatePct, previousErrorRatePct };
+    }
+
+    const aggregated = await reservoir.aggregate({
+      projectId: projectIds,
+      from: period.from,
+      to: period.to,
+      interval: '1d',
+    });
+
+    const daily = aggregated.timeseries.map((bucket) => ({
+      date: new Date(bucket.bucket).toISOString().slice(0, 10),
+      count: bucket.total,
+    }));
+
+    return {
+      levels,
+      errorRatePct,
+      previousErrorRatePct,
+      ...(daily.length > 0 ? { daily } : {}),
+    };
+  }
+
+  private isErrorLevel(level: string): boolean {
+    return (ERROR_LEVELS as readonly string[]).includes(level);
+  }
+
+  /** Share of error+critical logs, one decimal. */
+  private errorRate(errorCount: number, total: number): number {
+    if (total === 0) {
+      return 0;
+    }
+
+    return Math.round((errorCount / total) * 1000) / 10;
+  }
+
+  /**
+   * Top 5 error/critical log messages in the period.
+   */
+  private async calculateTopErrorMessages(
+    projectIds: string[],
+    period: Period
+  ): Promise<DigestReportData['topErrorMessages']> {
+    if (projectIds.length === 0) {
+      return undefined;
+    }
+
+    const result = await reservoir.topValues({
+      field: 'message',
+      projectId: projectIds,
+      level: [...ERROR_LEVELS],
+      from: period.from,
+      to: period.to,
+      limit: 5,
+    });
+
+    if (result.values.length === 0) {
+      return undefined;
+    }
+
+    return result.values.map((v) => ({ message: v.value, count: v.count }));
+  }
+
+  /**
+   * Alert triggers in the period vs the previous one, plus the rules that
+   * fired most. alert_history carries no organization_id, so tenant scoping
+   * goes through the alert_rules join.
+   */
+  private async calculateAlertsSummary(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['alerts']> {
+    const currentRow = await db
+      .selectFrom('alert_history')
+      .innerJoin('alert_rules', 'alert_rules.id', 'alert_history.rule_id')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('alert_rules.organization_id', '=', organizationId)
+      .where('alert_history.triggered_at', '>=', period.from)
+      .where('alert_history.triggered_at', '<', period.to)
+      .executeTakeFirst();
+
+    const previousRow = await db
+      .selectFrom('alert_history')
+      .innerJoin('alert_rules', 'alert_rules.id', 'alert_history.rule_id')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('alert_rules.organization_id', '=', organizationId)
+      .where('alert_history.triggered_at', '>=', period.previousFrom)
+      .where('alert_history.triggered_at', '<', period.previousTo)
+      .executeTakeFirst();
+
+    const total = Number(currentRow?.count ?? 0);
+    const previousTotal = Number(previousRow?.count ?? 0);
+
+    // Nothing fired in either window: skip the ranking query and the section
+    if (total === 0 && previousTotal === 0) {
+      return undefined;
+    }
+
+    const topRules = await db
+      .selectFrom('alert_history')
+      .innerJoin('alert_rules', 'alert_rules.id', 'alert_history.rule_id')
+      .select((eb) => ['alert_rules.name', eb.fn.countAll<number>().as('count')] as const)
+      .where('alert_rules.organization_id', '=', organizationId)
+      .where('alert_history.triggered_at', '>=', period.from)
+      .where('alert_history.triggered_at', '<', period.to)
+      .groupBy('alert_rules.name')
+      .orderBy('count', 'desc')
+      .limit(5)
+      .execute();
+
+    return {
+      total,
+      previousTotal,
+      trend: this.calculateTrend(total, previousTotal),
+      topRules: topRules.map((r) => ({ name: r.name, count: Number(r.count) })),
     };
   }
 

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -10,8 +10,11 @@ import nodemailer from 'nodemailer';
 import { sql } from 'kysely';
 import { db } from '../../database/connection.js';
 import { reservoir } from '../../database/reservoir.js';
+// breakdown.js only pulls in the db and the reservoir, both already loaded here.
+// capability-usage.js is NOT imported statically: it constructs five feature
+// services at module init, so it is loaded lazily inside calculateUsageSummary
+// and costs nothing while the usage section is disabled (the default).
 import { getUsageBreakdown } from '../metering/breakdown.js';
-import { getCapabilityUsage } from '../metering/capability-usage.js';
 import { hub } from '@logtide/core';
 import { DIGEST_SECTION_DEFAULTS, LOG_LEVELS } from '@logtide/shared';
 import type { DigestSections } from '@logtide/shared';
@@ -924,6 +927,11 @@ export class DigestGeneratorService {
         ),
       ])
       .where('monitor_results.organization_id', '=', organizationId)
+      // monitor_results.monitor_id carries NO foreign key (migration 034
+      // declares it without one, for hypertable performance) and deleting a
+      // monitor leaves its results behind, so the joined side is scoped
+      // explicitly rather than trusted to be same-tenant.
+      .where('monitors.organization_id', '=', organizationId)
       .where('monitor_results.time', '>=', period.from)
       .where('monitor_results.time', '<', period.to)
       .groupBy(['monitor_results.monitor_id', 'monitors.name'])
@@ -973,6 +981,7 @@ export class DigestGeneratorService {
       .slice(0, 5)
       .map((p) => ({ name: p.projectName, events: p.events }));
 
+    const { getCapabilityUsage } = await import('../metering/capability-usage.js');
     const capabilityUsage = await getCapabilityUsage(organizationId);
 
     const quotaWarnings = capabilityUsage

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -7,8 +7,11 @@
  */
 
 import nodemailer from 'nodemailer';
+import { sql } from 'kysely';
 import { db } from '../../database/connection.js';
 import { reservoir } from '../../database/reservoir.js';
+import { getUsageBreakdown } from '../metering/breakdown.js';
+import { getCapabilityUsage } from '../metering/capability-usage.js';
 import { hub } from '@logtide/core';
 import { DIGEST_SECTION_DEFAULTS, LOG_LEVELS } from '@logtide/shared';
 import type { DigestSections } from '@logtide/shared';
@@ -78,6 +81,40 @@ export interface DigestReportData {
     previousDatapoints: number;
     trend: string;
   };
+  securityActivity?: {
+    /** Only severities with at least one incident, ordered critical first */
+    openedBySeverity: Array<{ severity: string; count: number }>;
+    resolvedCount: number;
+    /** Top 5 MITRE techniques seen in the period */
+    topTechniques: Array<{ technique: string; count: number }>;
+  };
+  /** Top 5 monitors by p95 response time, worst first */
+  monitorPerformance?: Array<{
+    name: string;
+    avgMs: number;
+    p95Ms: number;
+    failedChecks: number;
+  }>;
+  usage?: {
+    logEvents: number;
+    logBytes: number;
+    spans: number;
+    /** Top 5 projects by ingested events */
+    topProjects: Array<{ name: string; events: number }>;
+    /** Capabilities at or above 80% of their configured limit (month to date) */
+    quotaWarnings: Array<{ capability: string; usedPct: number }>;
+  };
+  webhooks?: {
+    delivered: number;
+    failed: number;
+    dead: number;
+  };
+  teamActivity?: {
+    membersAdded: number;
+    membersRemoved: number;
+    configChanges: number;
+    failedLogins: number;
+  };
 }
 
 interface DigestRecipient {
@@ -93,6 +130,12 @@ interface Period {
 }
 
 const ERROR_LEVELS = ['error', 'critical'] as const;
+
+/** Reporting order for incident severities, worst first. */
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'informational'] as const;
+
+/** A capability at or above this share of its limit is worth warning about. */
+const QUOTA_WARNING_THRESHOLD = 0.8;
 
 let emailTransporter: nodemailer.Transporter | null = null;
 
@@ -210,6 +253,21 @@ export class DigestGeneratorService {
     const metrics = sections.metrics
       ? await this.calculateMetricsSummary(projectIds, period)
       : undefined;
+    const securityActivity = sections.securityActivity
+      ? await this.calculateSecurityActivity(organizationId, period)
+      : undefined;
+    const monitorPerformance = sections.monitorPerformance
+      ? await this.calculateMonitorPerformance(organizationId, period)
+      : undefined;
+    const usage = sections.usage
+      ? await this.calculateUsageSummary(organizationId, period)
+      : undefined;
+    const webhooks = sections.webhooks
+      ? await this.calculateWebhookSummary(organizationId, period)
+      : undefined;
+    const teamActivity = sections.teamActivity
+      ? await this.calculateTeamActivity(organizationId, period)
+      : undefined;
 
     return {
       organizationName,
@@ -225,6 +283,11 @@ export class DigestGeneratorService {
       alerts,
       traces,
       metrics,
+      securityActivity,
+      monitorPerformance,
+      usage,
+      webhooks,
+      teamActivity,
     };
   }
 
@@ -768,6 +831,235 @@ export class DigestGeneratorService {
       previousDatapoints: previous.total,
       trend: this.calculateTrend(current.total, previous.total),
     };
+  }
+
+  /**
+   * Incident flow of the period: what was opened (by severity), what was
+   * resolved, and which MITRE techniques the detections mapped to.
+   */
+  private async calculateSecurityActivity(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['securityActivity']> {
+    const openedRows = await db
+      .selectFrom('incidents')
+      .select((eb) => ['severity', eb.fn.countAll<number>().as('count')] as const)
+      .where('organization_id', '=', organizationId)
+      .where('created_at', '>=', period.from)
+      .where('created_at', '<', period.to)
+      .groupBy('severity')
+      .execute();
+
+    const resolvedRow = await db
+      .selectFrom('incidents')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('organization_id', '=', organizationId)
+      .where('resolved_at', '>=', period.from)
+      .where('resolved_at', '<', period.to)
+      .executeTakeFirst();
+
+    // Only mitre_techniques is unnested here. Unnesting mitre_techniques and
+    // mitre_tactics in the same SELECT makes PostgreSQL evaluate them in
+    // lockstep and NULL-pad the shorter array, which is bug #200.
+    const techniqueRows = await db
+      .selectFrom('detection_events')
+      .select([
+        sql<string>`unnest(mitre_techniques)`.as('technique'),
+        sql<number>`count(*)::int`.as('count'),
+      ])
+      .where('organization_id', '=', organizationId)
+      .where('time', '>=', period.from)
+      .where('time', '<', period.to)
+      .where('mitre_techniques', 'is not', null)
+      .groupBy('technique')
+      .orderBy('count', 'desc')
+      .limit(5)
+      .execute();
+
+    const openedBySeverity = openedRows
+      .map((r) => ({ severity: String(r.severity), count: Number(r.count) }))
+      .filter((r) => r.count > 0)
+      .sort((a, b) => this.severityRank(a.severity) - this.severityRank(b.severity));
+
+    const topTechniques = techniqueRows
+      .filter((r) => r.technique)
+      .map((r) => ({ technique: r.technique, count: Number(r.count) }));
+
+    const resolvedCount = Number(resolvedRow?.count ?? 0);
+    const openedTotal = openedBySeverity.reduce((sum, r) => sum + r.count, 0);
+
+    if (openedTotal === 0 && resolvedCount === 0 && topTechniques.length === 0) {
+      return undefined;
+    }
+
+    return { openedBySeverity, resolvedCount, topTechniques };
+  }
+
+  /** Position in SEVERITY_ORDER; unknown severities sort last. */
+  private severityRank(severity: string): number {
+    const index = (SEVERITY_ORDER as readonly string[]).indexOf(severity);
+    return index === -1 ? SEVERITY_ORDER.length : index;
+  }
+
+  /**
+   * Response time and failure count per monitor over the period, worst p95
+   * first. GROUP BY only yields monitors that were actually checked in the
+   * window, so idle monitors never reach the email.
+   */
+  private async calculateMonitorPerformance(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['monitorPerformance']> {
+    const rows = await db
+      .selectFrom('monitor_results')
+      .innerJoin('monitors', 'monitors.id', 'monitor_results.monitor_id')
+      .select([
+        'monitors.name as name',
+        sql<number | null>`avg(monitor_results.response_time_ms)`.as('avg_ms'),
+        sql<number | null>`percentile_cont(0.95) within group (order by monitor_results.response_time_ms)`.as(
+          'p95_ms'
+        ),
+        sql<number>`count(*) filter (where monitor_results.status = 'down')::int`.as(
+          'failed_checks'
+        ),
+      ])
+      .where('monitor_results.organization_id', '=', organizationId)
+      .where('monitor_results.time', '>=', period.from)
+      .where('monitor_results.time', '<', period.to)
+      .groupBy(['monitor_results.monitor_id', 'monitors.name'])
+      .execute();
+
+    if (rows.length === 0) {
+      return undefined;
+    }
+
+    // Sorted here rather than in SQL: heartbeat monitors record no
+    // response_time_ms, so their percentile is NULL and PostgreSQL would sort
+    // those rows first under ORDER BY ... DESC.
+    return rows
+      .map((r) => ({
+        name: r.name,
+        avgMs: Math.round(Number(r.avg_ms ?? 0)),
+        p95Ms: Math.round(Number(r.p95_ms ?? 0)),
+        failedChecks: Number(r.failed_checks ?? 0),
+      }))
+      .sort((a, b) => b.p95Ms - a.p95Ms)
+      .slice(0, 5);
+  }
+
+  /**
+   * Ingestion volume for the period plus capabilities close to their cap.
+   * Quota usage is month-to-date by definition (that is the quota window), not
+   * period-scoped: the email labels it as such.
+   */
+  private async calculateUsageSummary(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['usage']> {
+    const breakdown = await getUsageBreakdown({
+      organizationId,
+      from: period.from,
+      to: period.to,
+      limit: 5,
+    });
+
+    const quantityByType = new Map(breakdown.byType.map((t) => [t.type, t.quantity]));
+    const logEvents = Number(quantityByType.get('logs.ingested.events') ?? 0);
+    const logBytes = Number(quantityByType.get('logs.ingested.bytes') ?? 0);
+    const spans = Number(quantityByType.get('spans.ingested') ?? 0);
+
+    // byProject already comes sorted by events desc
+    const topProjects = breakdown.byProject
+      .slice(0, 5)
+      .map((p) => ({ name: p.projectName, events: p.events }));
+
+    const capabilityUsage = await getCapabilityUsage(organizationId);
+
+    const quotaWarnings = capabilityUsage
+      .filter(
+        (c): c is typeof c & { limit: number } =>
+          c.limit !== null && c.limit > 0 && c.current / c.limit >= QUOTA_WARNING_THRESHOLD
+      )
+      .map((c) => ({
+        capability: c.capability as string,
+        usedPct: Math.round((c.current / c.limit) * 100),
+      }));
+
+    if (logEvents === 0 && spans === 0 && quotaWarnings.length === 0) {
+      return undefined;
+    }
+
+    return { logEvents, logBytes, spans, topProjects, quotaWarnings };
+  }
+
+  /**
+   * Outbound webhook deliveries created in the period, by outcome. `status` is
+   * mutable row state (a pending row can still turn into delivered or dead
+   * after the digest is sent), so windowing on created_at is the digest's
+   * deliberate approximation. Pending rows are in-flight, not an outcome, and
+   * are left out of both the report and the empty check.
+   */
+  private async calculateWebhookSummary(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['webhooks']> {
+    const rows = await db
+      .selectFrom('webhook_deliveries')
+      .select((eb) => ['status', eb.fn.countAll<number>().as('count')] as const)
+      .where('organization_id', '=', organizationId)
+      .where('created_at', '>=', period.from)
+      .where('created_at', '<', period.to)
+      .groupBy('status')
+      .execute();
+
+    const countByStatus = new Map(rows.map((r) => [String(r.status), Number(r.count)]));
+    const delivered = countByStatus.get('delivered') ?? 0;
+    const failed = countByStatus.get('failed') ?? 0;
+    const dead = countByStatus.get('dead') ?? 0;
+
+    if (delivered + failed + dead === 0) {
+      return undefined;
+    }
+
+    return { delivered, failed, dead };
+  }
+
+  /**
+   * Membership and configuration churn from the audit log. One pass with
+   * filtered counts: four separate COUNT queries would scan the same rows four
+   * times.
+   */
+  private async calculateTeamActivity(
+    organizationId: string,
+    period: Period
+  ): Promise<DigestReportData['teamActivity']> {
+    const row = await db
+      .selectFrom('audit_log')
+      .select([
+        sql<number>`count(*) filter (where action = 'user.invite_accepted')::int`.as(
+          'members_added'
+        ),
+        sql<number>`count(*) filter (where action in ('user.removed', 'user.left'))::int`.as(
+          'members_removed'
+        ),
+        sql<number>`count(*) filter (where category = 'config_change')::int`.as('config_changes'),
+        sql<number>`count(*) filter (where action = 'auth.login_failed')::int`.as('failed_logins'),
+      ])
+      .where('organization_id', '=', organizationId)
+      .where('time', '>=', period.from)
+      .where('time', '<', period.to)
+      .executeTakeFirst();
+
+    const membersAdded = Number(row?.members_added ?? 0);
+    const membersRemoved = Number(row?.members_removed ?? 0);
+    const configChanges = Number(row?.config_changes ?? 0);
+    const failedLogins = Number(row?.failed_logins ?? 0);
+
+    if (membersAdded === 0 && membersRemoved === 0 && configChanges === 0 && failedLogins === 0) {
+      return undefined;
+    }
+
+    return { membersAdded, membersRemoved, configChanges, failedLogins };
   }
 
   private async fetchRecipients(

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -707,8 +707,6 @@ export class DigestGeneratorService {
       .sort((a, b) => b.calls - a.calls)
       .slice(0, 5);
 
-    // NOTE: the MongoDB engine only sorts spans by start_time, so on that engine
-    // this is the 5 most recent spans rather than the 5 slowest.
     const slowest = await reservoir.querySpans({
       projectId: projectIds,
       from: period.from,

--- a/packages/backend/src/modules/digests/generator.ts
+++ b/packages/backend/src/modules/digests/generator.ts
@@ -26,34 +26,37 @@ export interface DigestReportData {
   organizationName: string;
   frequency: 'daily' | 'weekly';
   periodLabel: string;
-  logVolume: {
+  // The five original sections: undefined ONLY when the section is disabled.
+  // Enabled but empty keeps their own semantics (zeros, empty arrays, null
+  // uptime) and the email still renders them with their empty-state lines.
+  logVolume?: {
     current: number;
     previous: number;
     trend: string;
   };
-  topErrorServices: Array<{
+  topErrorServices?: Array<{
     service: string;
     errorCount: number;
     previousCount: number;
     delta: number;
   }>;
-  newErrorGroups: Array<{
+  newErrorGroups?: Array<{
     exceptionType: string;
     exceptionMessage: string;
     occurrenceCount: number;
     language: string;
   }>;
-  security: {
+  security?: {
     totalDetections: number;
     topRules: Array<{ ruleTitle: string; severity: string; count: number }>;
     openIncidents: number;
   };
-  uptime: {
+  uptime?: {
     monitorCount: number;
     overallUptimePct: number;
     worstMonitors: Array<{ name: string; uptimePct: number }>;
   } | null;
-  // Optional sections: undefined means "disabled OR no data", and the email
+  // Expanded sections: undefined means "disabled OR no data", and the email
   // skips them entirely (no empty-state lines, unlike the five sections above).
   logBreakdown?: {
     levels: Array<{ level: string; current: number; previous: number }>;
@@ -216,9 +219,9 @@ export class DigestGeneratorService {
    * sequentially: this is a background cron path where simplicity beats
    * latency. A disabled section costs zero queries.
    *
-   * The five original sections always run (they are non-optional fields of
-   * DigestReportData); the optional ones are computed after them, in the
-   * catalog order of DIGEST_SECTION_KEYS, so the order stays unambiguous.
+   * Every section is gated, the five original ones included: their toggles are
+   * real, not decorative. Sections are computed in the catalog order of
+   * DIGEST_SECTION_KEYS so the order stays unambiguous.
    */
   async buildReportData(
     organizationId: string,
@@ -235,11 +238,21 @@ export class DigestGeneratorService {
       .execute();
     const projectIds = projects.map((p) => p.id);
 
-    const logVolume = await this.calculateLogVolume(projectIds, period);
-    const topErrorServices = await this.calculateTopErrorServices(projectIds, period);
-    const newErrorGroups = await this.calculateNewErrorGroups(organizationId, period);
-    const security = await this.calculateSecuritySummary(organizationId, period);
-    const uptime = await this.calculateUptimeSummary(organizationId, period);
+    const logVolume = sections.logVolume
+      ? await this.calculateLogVolume(projectIds, period)
+      : undefined;
+    const topErrorServices = sections.topErrorServices
+      ? await this.calculateTopErrorServices(projectIds, period)
+      : undefined;
+    const newErrorGroups = sections.newErrorGroups
+      ? await this.calculateNewErrorGroups(organizationId, period)
+      : undefined;
+    const security = sections.security
+      ? await this.calculateSecuritySummary(organizationId, period)
+      : undefined;
+    const uptime = sections.uptime
+      ? await this.calculateUptimeSummary(organizationId, period)
+      : undefined;
 
     const logBreakdown = sections.logBreakdown
       ? await this.calculateLogBreakdown(projectIds, period, frequency)
@@ -307,7 +320,7 @@ export class DigestGeneratorService {
   private async calculateLogVolume(
     projectIds: string[],
     period: Period
-  ): Promise<DigestReportData['logVolume']> {
+  ): Promise<NonNullable<DigestReportData['logVolume']>> {
     if (projectIds.length === 0) {
       return { current: 0, previous: 0, trend: this.calculateTrend(0, 0) };
     }
@@ -340,7 +353,7 @@ export class DigestGeneratorService {
   private async calculateTopErrorServices(
     projectIds: string[],
     period: Period
-  ): Promise<DigestReportData['topErrorServices']> {
+  ): Promise<NonNullable<DigestReportData['topErrorServices']>> {
     if (projectIds.length === 0) {
       return [];
     }
@@ -387,7 +400,7 @@ export class DigestGeneratorService {
   private async calculateNewErrorGroups(
     organizationId: string,
     period: Period
-  ): Promise<DigestReportData['newErrorGroups']> {
+  ): Promise<NonNullable<DigestReportData['newErrorGroups']>> {
     const groups = await db
       .selectFrom('error_groups')
       .select(['exception_type', 'exception_message', 'occurrence_count', 'language'])
@@ -414,7 +427,7 @@ export class DigestGeneratorService {
   private async calculateSecuritySummary(
     organizationId: string,
     period: Period
-  ): Promise<DigestReportData['security']> {
+  ): Promise<NonNullable<DigestReportData['security']>> {
     const totalRow = await db
       .selectFrom('detection_events')
       .select((eb) => eb.fn.countAll<number>().as('count'))

--- a/packages/backend/src/modules/digests/routes.ts
+++ b/packages/backend/src/modules/digests/routes.ts
@@ -14,6 +14,7 @@ import { context } from '@logtide/shared/context';
 import { assertWithinLimit, withLimitLock } from '../../capabilities/index.js';
 import { CapabilityError } from '../../capabilities/errors.js';
 import { auditLogService } from '../audit-log/service.js';
+import { DIGEST_SECTION_KEYS, mergeDigestSections } from '@logtide/shared';
 
 const organizationsService = new OrganizationsService();
 
@@ -25,12 +26,21 @@ const orgQuerySchema = z.object({
   organizationId: z.string().uuid('organizationId must be a valid uuid'),
 });
 
+// Generated from the shared catalog so the API cannot drift from it; strict so
+// unknown section keys are rejected instead of silently stored.
+const sectionsSchema = z
+  .object(Object.fromEntries(DIGEST_SECTION_KEYS.map((key) => [key, z.boolean().optional()])))
+  .strict()
+  .optional()
+  .nullable();
+
 const configBodySchema = z
   .object({
     frequency: z.enum(['daily', 'weekly']),
     deliveryHour: z.number().int().min(0).max(23),
     deliveryDayOfWeek: z.number().int().min(0).max(6).nullish(),
     enabled: z.boolean(),
+    sections: sectionsSchema,
   })
   .refine((body) => body.frequency !== 'weekly' || body.deliveryDayOfWeek != null, {
     message: 'deliveryDayOfWeek is required for weekly digests',
@@ -85,7 +95,11 @@ export async function digestsRoutes(fastify: FastifyInstance) {
       const config = await digestsService.getConfig(organizationId);
       const recipients = await digestsService.listRecipients(organizationId);
 
-      return reply.send({ config: config ?? null, recipients });
+      // sections is always the merged record so clients never duplicate defaults
+      return reply.send({
+        config: config ? { ...config, sections: mergeDigestSections(config.sections) } : null,
+        recipients,
+      });
     } catch (error) {
       if (error instanceof z.ZodError) {
         return reply.status(400).send({ error: 'Validation error', details: error.errors });
@@ -119,7 +133,10 @@ export async function digestsRoutes(fastify: FastifyInstance) {
         deliveryHour: body.deliveryHour,
         deliveryDayOfWeek: body.deliveryDayOfWeek,
         enabled: body.enabled,
+        sections: body.sections,
       });
+
+      const sections = mergeDigestSections(config.sections);
 
       await auditLogService.record({
         action: 'digest.config_updated',
@@ -129,10 +146,11 @@ export async function digestsRoutes(fastify: FastifyInstance) {
           frequency: config.frequency,
           deliveryHour: config.delivery_hour,
           enabled: config.enabled,
+          enabledSections: DIGEST_SECTION_KEYS.filter((key) => sections[key]),
         },
       });
 
-      return reply.send({ config });
+      return reply.send({ config: { ...config, sections } });
     } catch (error) {
       if (error instanceof z.ZodError) {
         return reply.status(400).send({ error: 'Validation error', details: error.errors });

--- a/packages/backend/src/modules/digests/scheduler.ts
+++ b/packages/backend/src/modules/digests/scheduler.ts
@@ -16,11 +16,14 @@
 
 import { getCronRegistry } from '../../queue/queue-factory.js';
 import { hub } from '@logtide/core';
+import type { DigestSections } from '@logtide/shared';
 
 export interface DigestJobPayload {
   organizationId: string;
   digestConfigId: string;
   frequency: 'daily' | 'weekly';
+  /** Merged section toggles; absent on jobs enqueued before this shipped. */
+  sections?: DigestSections;
 }
 
 export const DIGEST_DISPATCH_CRON = '0 * * * *'; // every hour on the hour

--- a/packages/backend/src/modules/digests/service.ts
+++ b/packages/backend/src/modules/digests/service.ts
@@ -8,12 +8,15 @@
 import crypto from 'crypto';
 import { db } from '../../database/connection.js';
 import type { DigestFrequency } from '../../database/types.js';
+import type { DigestSections } from '@logtide/shared';
 
 export interface DigestConfigInput {
   frequency: DigestFrequency;
   deliveryHour: number;
   deliveryDayOfWeek?: number | null;
   enabled: boolean;
+  /** Partial section map; undefined leaves the stored value alone, null resets to defaults. */
+  sections?: Partial<DigestSections> | null;
 }
 
 export class DigestsService {
@@ -27,6 +30,7 @@ export class DigestsService {
         'delivery_day_of_week',
         'enabled',
         'last_sent_at',
+        'sections',
         'created_at',
         'updated_at',
       ])
@@ -41,6 +45,8 @@ export class DigestsService {
       delivery_hour: input.deliveryHour,
       delivery_day_of_week: input.frequency === 'weekly' ? input.deliveryDayOfWeek ?? null : null,
       enabled: input.enabled,
+      // The partial is stored as given; defaults live in code, not in the row
+      sections: input.sections ?? null,
     };
 
     return db
@@ -52,6 +58,9 @@ export class DigestsService {
           delivery_hour: values.delivery_hour,
           delivery_day_of_week: values.delivery_day_of_week,
           enabled: values.enabled,
+          // An omitted sections field keeps whatever is stored; an explicit
+          // null resets the organization to the code-side defaults.
+          ...(input.sections !== undefined ? { sections: input.sections } : {}),
           updated_at: new Date(),
         })
       )
@@ -62,6 +71,7 @@ export class DigestsService {
         'delivery_day_of_week',
         'enabled',
         'last_sent_at',
+        'sections',
         'created_at',
         'updated_at',
       ])

--- a/packages/backend/src/queue/jobs/digest-dispatch.ts
+++ b/packages/backend/src/queue/jobs/digest-dispatch.ts
@@ -17,6 +17,7 @@ import { createQueue } from '../connection.js';
 import { hub } from '@logtide/core';
 import type { IJob } from '../abstractions/types.js';
 import type { DigestJobPayload } from '../../modules/digests/scheduler.js';
+import { mergeDigestSections } from '@logtide/shared';
 
 interface DispatchableConfig {
   frequency: 'daily' | 'weekly';
@@ -61,6 +62,7 @@ export async function processDigestDispatch(_job: IJob<Record<string, never>>): 
       'delivery_hour',
       'delivery_day_of_week',
       'last_sent_at',
+      'sections',
     ])
     .where('enabled', '=', true)
     .execute();
@@ -94,6 +96,8 @@ export async function processDigestDispatch(_job: IJob<Record<string, never>>): 
         organizationId: config.organization_id,
         digestConfigId: config.id,
         frequency: config.frequency,
+        // Merged here so the generator never re-reads the config row
+        sections: mergeDigestSections(config.sections),
       },
       {
         // Hour-keyed so a duplicate dispatch within the same slot dedupes

--- a/packages/backend/src/tests/lib/email-templates.test.ts
+++ b/packages/backend/src/tests/lib/email-templates.test.ts
@@ -1219,4 +1219,98 @@ describe('Email Templates - Digest', () => {
     expect(result.html).toContain('12 alerts');
     expect(result.html).toContain('3 incidents');
   });
+
+  // ==========================================================================
+  // Gating of the five original sections: undefined means the section was
+  // disabled, and then nothing of it renders (not even its title).
+  // ==========================================================================
+
+  it('omits the log volume section when it is undefined', () => {
+    const result = generateDigestEmail({ ...baseData, logVolume: undefined });
+
+    expect(result.html).not.toContain('Log Volume');
+    expect(result.text).not.toContain('LOG VOLUME');
+    expect(result.text).not.toContain('Total logs:');
+  });
+
+  it('omits the top services section when it is undefined', () => {
+    const result = generateDigestEmail({ ...baseData, topErrorServices: undefined });
+
+    expect(result.html).not.toContain('Top Services by Errors');
+    expect(result.text).not.toContain('TOP SERVICES BY ERRORS');
+    expect(result.html).not.toContain('No errors recorded in this period.');
+  });
+
+  it('omits the new error groups section when it is undefined', () => {
+    const result = generateDigestEmail({ ...baseData, newErrorGroups: undefined });
+
+    expect(result.html).not.toContain('New Error Groups');
+    expect(result.text).not.toContain('NEW ERROR GROUPS');
+    expect(result.html).not.toContain('No new error groups appeared in this period.');
+  });
+
+  it('omits the security section when it is undefined', () => {
+    const result = generateDigestEmail({ ...baseData, security: undefined });
+
+    expect(result.html).not.toContain('Security');
+    expect(result.text).not.toContain('SECURITY');
+    expect(result.text).not.toContain('Open incidents:');
+  });
+
+  it('omits the uptime section when it is undefined', () => {
+    const result = generateDigestEmail({ ...baseData, uptime: undefined });
+
+    expect(result.html).not.toContain('Uptime');
+    expect(result.text).not.toContain('UPTIME');
+  });
+
+  it('keeps the enabled-but-empty sections with their empty-state lines', () => {
+    const empty: DigestEmailData = {
+      ...baseData,
+      logVolume: { current: 0, previous: 0, trend: 'no change' },
+      topErrorServices: [],
+      newErrorGroups: [],
+      security: { totalDetections: 0, topRules: [], openIncidents: 0 },
+      uptime: null,
+    };
+
+    const result = generateDigestEmail(empty);
+
+    expect(result.html).toContain('Top Services by Errors');
+    expect(result.html).toContain('No errors recorded in this period.');
+    expect(result.html).toContain('New Error Groups');
+    expect(result.html).toContain('No new error groups appeared in this period.');
+    expect(result.text).toContain('SECURITY');
+    expect(result.text).toContain('Open incidents: 0');
+  });
+
+  it('is never a quiet period when the log volume section is disabled', () => {
+    const result = generateDigestEmail({ ...fullData, logVolume: undefined });
+
+    expect(result.html).not.toContain('No activity during this period');
+    expect(result.text).not.toContain('No activity during this period');
+    expect(result.html).not.toContain('Quiet period for Acme Corp');
+  });
+
+  it('drops the logs and detections parts of the preheader with those sections off', () => {
+    const result = generateDigestEmail({
+      ...fullData,
+      logVolume: undefined,
+      security: undefined,
+    });
+
+    expect(result.html).not.toContain('logs, ');
+    expect(result.html).not.toContain('11 detections');
+    expect(result.html).toContain('12 alerts, 3 incidents for Acme Corp');
+  });
+
+  it('falls back to a generic preheader when no section feeds it', () => {
+    const result = generateDigestEmail({
+      ...baseData,
+      logVolume: undefined,
+      security: undefined,
+    });
+
+    expect(result.html).toContain('Digest for Acme Corp');
+  });
 });

--- a/packages/backend/src/tests/lib/email-templates.test.ts
+++ b/packages/backend/src/tests/lib/email-templates.test.ts
@@ -870,4 +870,353 @@ describe('Email Templates - Digest', () => {
     expect(result.text).toContain('Weekly Digest');
     expect(result.text).toContain('last 7 days');
   });
+
+  it('keeps the preheader unchanged when no expanded section is present', () => {
+    const result = generateDigestEmail(baseData);
+
+    expect(result.html).toContain('15,000 logs, 11 detections for Acme Corp');
+  });
+
+  // ==========================================================================
+  // Expanded digest sections (#154 expansion)
+  // ==========================================================================
+
+  const longMessage = 'x'.repeat(200);
+
+  const fullData: DigestEmailData = {
+    ...baseData,
+    frequency: 'weekly',
+    periodLabel: 'last 7 days',
+    logBreakdown: {
+      levels: [
+        { level: 'info', current: 9000, previous: 7000 },
+        { level: 'error', current: 500, previous: 300 },
+      ],
+      errorRatePct: 3.3,
+      previousErrorRatePct: 2,
+      daily: [{ date: '2026-08-10', count: 1200 }],
+    },
+    topErrorMessages: [
+      { message: '<script>alert(1)</script> connection refused', count: 120 },
+      { message: longMessage, count: 9 },
+    ],
+    alerts: {
+      total: 12,
+      previousTotal: 4,
+      trend: '+8 (+200.0%)',
+      topRules: [{ name: 'High <error> rate', count: 7 }],
+    },
+    traces: {
+      spanCount: 40000,
+      previousSpanCount: 30000,
+      trend: '+10000 (+33.3%)',
+      errorSpanCount: 250,
+      services: [
+        { service: 'checkout-<svc>', calls: 1200, errorRatePct: 3, p95Ms: 450 },
+        { service: 'billing', calls: 300, errorRatePct: 0, p95Ms: null },
+      ],
+      slowestSpans: [{ service: 'checkout-<svc>', operation: 'GET /<pay>', durationMs: 5200 }],
+    },
+    metrics: { datapoints: 88000, previousDatapoints: 80000, trend: '+8000 (+10.0%)' },
+    securityActivity: {
+      openedBySeverity: [
+        { severity: 'critical', count: 2 },
+        { severity: 'low', count: 1 },
+      ],
+      resolvedCount: 5,
+      topTechniques: [{ technique: 'T1110<script>', count: 9 }],
+    },
+    monitorPerformance: [
+      { name: 'API <Health>', avgMs: 120, p95Ms: 450, failedChecks: 3 },
+      { name: 'Heartbeat <hb>', avgMs: 0, p95Ms: 0, failedChecks: 0 },
+    ],
+    usage: {
+      logEvents: 1500000,
+      logBytes: 1610612736,
+      spans: 40000,
+      topProjects: [{ name: 'Payments <prj>', events: 900000 }],
+      quotaWarnings: [{ capability: 'logs.retention<days>', usedPct: 92 }],
+    },
+    webhooks: { delivered: 500, failed: 12, dead: 3 },
+    teamActivity: { membersAdded: 2, membersRemoved: 1, configChanges: 7, failedLogins: 4 },
+  };
+
+  it('renders every expanded section title in HTML and plaintext', () => {
+    const result = generateDigestEmail(fullData);
+
+    const htmlTitles = [
+      'Log Breakdown',
+      'Top Error Messages',
+      'Traces',
+      'Metrics',
+      'Alerts',
+      'Security Activity',
+      'Monitor Performance',
+      'Usage',
+      'Webhooks',
+      'Team Activity',
+    ];
+    for (const title of htmlTitles) {
+      expect(result.html, `html should contain the ${title} section`).toContain(title);
+    }
+
+    const textTitles = [
+      'LOG BREAKDOWN',
+      'TOP ERROR MESSAGES',
+      'TRACES',
+      'METRICS',
+      'ALERTS',
+      'SECURITY ACTIVITY',
+      'MONITOR PERFORMANCE',
+      'USAGE',
+      'WEBHOOKS',
+      'TEAM ACTIVITY',
+    ];
+    for (const title of textTitles) {
+      expect(result.text, `text should contain the ${title} section`).toContain(title);
+    }
+  });
+
+  it('orders the sections as specified', () => {
+    const { html } = generateDigestEmail(fullData);
+
+    const order = [
+      'Log Volume',
+      'Log Breakdown',
+      'Top Services by Errors',
+      'Top Error Messages',
+      'New Error Groups',
+      'Traces',
+      'Metrics',
+      'Alerts',
+      'Security',
+      'Security Activity',
+      'Uptime',
+      'Monitor Performance',
+      'Usage',
+      'Webhooks',
+      'Team Activity',
+      'View Dashboard',
+    ];
+
+    const positions = order.map((title) => html.indexOf(title));
+    for (const [index, position] of positions.entries()) {
+      expect(position, `${order[index]} should be present`).toBeGreaterThan(-1);
+      if (index > 0) {
+        expect(position, `${order[index]} should follow ${order[index - 1]}`).toBeGreaterThan(
+          positions[index - 1]
+        );
+      }
+    }
+  });
+
+  it('renders the log breakdown numbers in both formats', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('9,000');
+    expect(result.html).toContain('3.3%');
+    expect(result.html).toContain('2026-08-10');
+    expect(result.text).toContain('info: 9,000');
+    expect(result.text).toContain('Error rate: 3.3% (previous: 2%)');
+    expect(result.text).toContain('2026-08-10: 1,200');
+  });
+
+  it('renders traces with a worst-project p95 label and a dash for missing p95', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('40,000');
+    expect(result.html).toContain('p95 (worst)');
+    expect(result.html).toContain('worst project');
+    expect(result.html).toContain('450ms');
+    expect(result.html).toContain('3%');
+    expect(result.text).toContain('Spans: 40,000');
+    expect(result.text).toContain('Error spans: 250');
+    expect(result.text).toContain('p95 450ms');
+    expect(result.text).toContain('p95 -');
+    expect(result.text).toContain('GET /<pay>');
+  });
+
+  it('renders alert totals and the top rules table', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('+8 (+200.0%)');
+    expect(result.text).toContain('Triggers: 12');
+    expect(result.text).toContain('Previous triggers: 4');
+    expect(result.text).toContain('High <error> rate: 7');
+  });
+
+  it('renders the alerts section without a rules table when nothing fired this period', () => {
+    const data: DigestEmailData = {
+      ...fullData,
+      alerts: { total: 0, previousTotal: 6, trend: '-6 (-100.0%)', topRules: [] },
+    };
+
+    const result = generateDigestEmail(data);
+
+    expect(result.html).toContain('Alerts');
+    expect(result.html).toContain('-6 (-100.0%)');
+    expect(result.html).not.toContain('Triggers</th>');
+    expect(result.text).toContain('Triggers: 0');
+    expect(result.text).toContain('Previous triggers: 6');
+  });
+
+  it('renders security activity counts and MITRE techniques', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('T1110');
+    expect(result.text).toContain('Incidents opened: 3');
+    expect(result.text).toContain('Incidents resolved: 5');
+    expect(result.text).toContain('critical: 2');
+  });
+
+  it('renders untimed monitors with a dash instead of 0ms', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('120ms');
+    // Untimed (heartbeat) monitors render a dash cell, never "0ms"
+    expect(result.html).toContain('>-</td>');
+    expect(result.html).not.toContain('>0ms</td>');
+    expect(result.text).toContain('avg 120ms, p95 450ms');
+    expect(result.text).toContain('avg -, p95 -');
+  });
+
+  it('humanizes usage bytes and labels quota warnings as month-to-date', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('1.5 GB');
+    expect(result.html).toContain('Month-to-date usage above 80% of limit');
+    expect(result.html).toContain('92%');
+    expect(result.text).toContain('Log events: 1,500,000');
+    expect(result.text).toContain('Log volume: 1.5 GB');
+    expect(result.text).toContain('Month-to-date usage above 80% of limit');
+    expect(result.text).toContain('logs.retention<days>: 92%');
+  });
+
+  it('highlights dead webhook deliveries and renders team activity', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('dead-letter queue');
+    expect(result.text).toContain('Delivered: 500');
+    expect(result.text).toContain('Dead: 3');
+    expect(result.text).toContain('Members added: 2');
+    expect(result.text).toContain('Failed logins: 4');
+  });
+
+  it('truncates long error messages to 120 characters', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('x'.repeat(117) + '...');
+    expect(result.html).not.toContain('x'.repeat(121));
+    expect(result.text).toContain('x'.repeat(117) + '...');
+    expect(result.text).not.toContain('x'.repeat(121));
+  });
+
+  it('escapes user-controlled values from the expanded sections', () => {
+    const result = generateDigestEmail(fullData);
+
+    const payloads = [
+      '<script>alert(1)</script>',
+      'High <error> rate',
+      'checkout-<svc>',
+      'GET /<pay>',
+      'API <Health>',
+      'Heartbeat <hb>',
+      'Payments <prj>',
+      'T1110<script>',
+      'logs.retention<days>',
+    ];
+    for (const payload of payloads) {
+      expect(result.html, `html should escape ${payload}`).not.toContain(payload);
+    }
+
+    expect(result.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(result.html).toContain('High &lt;error&gt; rate');
+    expect(result.html).toContain('logs.retention&lt;days&gt;');
+  });
+
+  it('omits expanded sections that are undefined', () => {
+    const result = generateDigestEmail(baseData);
+
+    const htmlTitles = [
+      'Log Breakdown',
+      'Top Error Messages',
+      'Traces',
+      'Metrics',
+      'Alerts',
+      'Security Activity',
+      'Monitor Performance',
+      'Usage',
+      'Webhooks',
+      'Team Activity',
+    ];
+    for (const title of htmlTitles) {
+      expect(result.html, `html should omit the ${title} section`).not.toContain(title);
+    }
+
+    const textTitles = [
+      'LOG BREAKDOWN',
+      'TOP ERROR MESSAGES',
+      'TRACES',
+      'METRICS',
+      'ALERTS',
+      'SECURITY ACTIVITY',
+      'MONITOR PERFORMANCE',
+      'USAGE',
+      'WEBHOOKS',
+      'TEAM ACTIVITY',
+    ];
+    for (const title of textTitles) {
+      expect(result.text, `text should omit the ${title} section`).not.toContain(title);
+    }
+  });
+
+  it('stays quiet when logs and spans are both zero', () => {
+    const data: DigestEmailData = {
+      ...baseData,
+      logVolume: { current: 0, previous: 0, trend: 'no change' },
+      traces: {
+        spanCount: 0,
+        previousSpanCount: 0,
+        trend: 'no change',
+        errorSpanCount: 0,
+        services: [],
+        slowestSpans: [],
+      },
+    };
+
+    const result = generateDigestEmail(data);
+
+    expect(result.html).toContain('No activity during this period');
+    expect(result.text).toContain('No activity during this period');
+    expect(result.html).toContain('Quiet period for Acme Corp');
+  });
+
+  it('is not a quiet period when the traces section carries spans', () => {
+    const data: DigestEmailData = {
+      ...baseData,
+      logVolume: { current: 0, previous: 0, trend: 'no change' },
+      traces: {
+        spanCount: 500,
+        previousSpanCount: 0,
+        trend: '+500 (new activity)',
+        errorSpanCount: 1,
+        services: [],
+        slowestSpans: [],
+      },
+    };
+
+    const result = generateDigestEmail(data);
+
+    expect(result.html).not.toContain('No activity during this period');
+    expect(result.text).not.toContain('No activity during this period');
+    expect(result.text).toContain('Total logs: 0');
+    expect(result.text).toContain('Spans: 500');
+  });
+
+  it('adds alert and incident counts to the preheader when those sections are present', () => {
+    const result = generateDigestEmail(fullData);
+
+    expect(result.html).toContain('12 alerts');
+    expect(result.html).toContain('3 incidents');
+  });
 });

--- a/packages/backend/src/tests/modules/digests/generator-integration.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator-integration.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DigestGeneratorService } from '../../../modules/digests/generator.js';
 import { db } from '../../../database/connection.js';
 import { reservoir } from '../../../database/reservoir.js';
+import { DIGEST_SECTION_KEYS } from '@logtide/shared';
+import type { DigestSections } from '@logtide/shared';
 
 // Hoisted: other modules in the generator's import graph build a transporter at
 // module-init time, so the factory must not close over a plain const.
@@ -309,5 +311,191 @@ describe('DigestGeneratorService Integration', () => {
     expect(html).toContain('TypeError');
     expect(html).toContain('Suspicious Login Burst');
     expect(html).toContain('unsubscribe?token=sections_token');
+  });
+
+  it('renders only the expanded sections that carry data when every section is enabled', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'expanded@example.com',
+        password_hash: 'test_hash',
+        name: 'Expanded User',
+      })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    const org = await db
+      .insertInto('organizations')
+      .values({
+        name: 'Expanded Org',
+        slug: 'expanded-org',
+        owner_id: user.id,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    const project = await db
+      .insertInto('projects')
+      .values({
+        organization_id: org.id,
+        name: 'Expanded Project',
+        slug: 'expanded-project',
+        user_id: user.id,
+      })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    const config = await db
+      .insertInto('digest_configs')
+      .values({
+        organization_id: org.id,
+        frequency: 'daily',
+        delivery_hour: 8,
+      })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto('digest_recipients')
+      .values({
+        organization_id: org.id,
+        digest_config_id: config.id,
+        email: 'expanded-digest@example.com',
+        unsubscribe_token: 'expanded_token',
+      })
+      .execute();
+
+    const now = new Date();
+    // Every seeded row is aged explicitly: the digest window ends at the node
+    // clock's "now", so rows written with the Postgres default created_at can
+    // land after the window when the two clocks drift.
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+    // Logs: feeds logVolume, logBreakdown and topErrorMessages
+    await reservoir.ingest(
+      Array.from({ length: 10 }, (_, i) => ({
+        organizationId: org.id,
+        projectId: project.id,
+        service: 'expanded-service',
+        level: (i < 2 ? 'error' : 'info') as 'error' | 'info',
+        message: i < 2 ? 'db connection refused' : `expanded log ${i}`,
+        time: oneHourAgo,
+      }))
+    );
+
+    // Alert rule + one trigger inside the period
+    const rule = await db
+      .insertInto('alert_rules')
+      .values({
+        organization_id: org.id,
+        project_id: project.id,
+        name: 'Expanded Error Spike',
+        level: ['error'],
+        time_window: 5,
+        threshold: 10,
+        enabled: true,
+        alert_type: 'threshold',
+        email_recipients: [],
+      })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto('alert_history')
+      .values({
+        rule_id: rule.id,
+        triggered_at: oneHourAgo,
+        log_count: 25,
+        notified: true,
+      })
+      .execute();
+
+    // Incident opened inside the period: feeds securityActivity
+    await db
+      .insertInto('incidents')
+      .values({
+        organization_id: org.id,
+        project_id: project.id,
+        title: 'Expanded incident',
+        severity: 'high',
+        status: 'open',
+        created_at: oneHourAgo,
+      })
+      .execute();
+
+    // Webhook delivery created inside the period
+    await db
+      .insertInto('webhook_deliveries')
+      .values({
+        organization_id: org.id,
+        event_type: 'alert.triggered',
+        event_id: 'expanded-event-1',
+        url: 'https://example.com/hook',
+        status: 'delivered',
+        attempt_count: 1,
+        max_attempts: 5,
+        metadata: null,
+        created_at: oneHourAgo,
+      })
+      .execute();
+
+    // Audit row: feeds teamActivity (config_change category)
+    await db
+      .insertInto('audit_log')
+      .values({
+        time: oneHourAgo,
+        organization_id: org.id,
+        user_id: user.id,
+        user_email: 'expanded@example.com',
+        action: 'digest.config_updated',
+        category: 'config_change',
+        resource_type: 'digest_config',
+        resource_id: config.id,
+        ip_address: null,
+        user_agent: null,
+        metadata: null,
+      })
+      .execute();
+
+    const allSections = Object.fromEntries(
+      DIGEST_SECTION_KEYS.map((key) => [key, true])
+    ) as DigestSections;
+
+    await generator.generateAndSendDigest({
+      organizationId: org.id,
+      digestConfigId: config.id,
+      frequency: 'daily',
+      sections: allSections,
+    });
+
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+    const emailCall = mockSendMail.mock.calls[0][0];
+    const html = emailCall.html as string;
+    const text = emailCall.text as string;
+
+    // Sections with seeded data render
+    for (const title of [
+      'Log Breakdown',
+      'Top Error Messages',
+      'Alerts',
+      'Security Activity',
+      'Webhooks',
+      'Team Activity',
+    ]) {
+      expect(html, `html should contain the ${title} section`).toContain(title);
+    }
+
+    expect(text).toContain('error: 2');
+    expect(text).toContain('db connection refused');
+    expect(text).toContain('Triggers: 1');
+    expect(text).toContain('Expanded Error Spike: 1 triggers');
+    expect(text).toContain('Incidents opened: 1');
+    expect(text).toContain('Delivered: 1');
+    expect(text).toContain('Config changes: 1');
+
+    // Nothing was seeded for these verticals, so they are skipped entirely
+    for (const title of ['Traces', 'Metrics', 'Monitor Performance', 'Usage']) {
+      expect(html, `html should omit the ${title} section`).not.toContain(title);
+    }
   });
 });

--- a/packages/backend/src/tests/modules/digests/generator-integration.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator-integration.test.ts
@@ -3,7 +3,11 @@ import { DigestGeneratorService } from '../../../modules/digests/generator.js';
 import { db } from '../../../database/connection.js';
 import { reservoir } from '../../../database/reservoir.js';
 
-const mockSendMail = vi.fn().mockResolvedValue({ messageId: 'test-message-id' });
+// Hoisted: other modules in the generator's import graph build a transporter at
+// module-init time, so the factory must not close over a plain const.
+const { mockSendMail } = vi.hoisted(() => ({
+  mockSendMail: vi.fn().mockResolvedValue({ messageId: 'test-message-id' }),
+}));
 vi.mock('nodemailer', () => ({
   default: {
     createTransport: vi.fn(() => ({

--- a/packages/backend/src/tests/modules/digests/generator.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator.test.ts
@@ -531,6 +531,115 @@ describe('DigestGeneratorService', () => {
     });
   });
 
+  describe('gating of the five original sections', () => {
+    /**
+     * The five sections that shipped with the original digest are toggleable
+     * like every other one: disabled means undefined AND zero queries, never a
+     * zeroed section. Enabled-but-empty keeps its own semantics (zeros, empty
+     * arrays, null uptime) and is covered by the buildReportData tests above.
+     */
+    const queriedTables = (): string[] =>
+      mockDb.selectFrom.mock.calls.map((c: unknown[]) => c[0] as string);
+
+    it('omits logVolume and issues no count queries when disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        logVolume: false,
+      });
+
+      expect(report.logVolume).toBeUndefined();
+      expect(mockReservoir.count).not.toHaveBeenCalled();
+    });
+
+    it('omits topErrorServices and issues no topValues query when disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        topErrorServices: false,
+      });
+
+      expect(report.topErrorServices).toBeUndefined();
+      expect(mockReservoir.topValues).not.toHaveBeenCalled();
+    });
+
+    it('omits newErrorGroups and never reads error_groups when disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        newErrorGroups: false,
+      });
+
+      expect(report.newErrorGroups).toBeUndefined();
+      expect(queriedTables()).not.toContain('error_groups');
+    });
+
+    it('omits security and issues no detection queries when disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        security: false,
+      });
+
+      expect(report.security).toBeUndefined();
+      expect(queriedTables()).not.toContain('detection_events');
+      expect(queriedTables()).not.toContain('incidents');
+      // The detection total and the open-incident count are the only two
+      // single-row queries of the default section set.
+      expect(mockDb.executeTakeFirst).not.toHaveBeenCalled();
+    });
+
+    it('omits uptime and never reads the monitor tables when disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        uptime: false,
+      });
+
+      expect(report.uptime).toBeUndefined();
+      expect(queriedTables()).not.toContain('monitors');
+      expect(queriedTables()).not.toContain('monitor_uptime_daily');
+    });
+
+    it('issues only the project lookup when every section is disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const allOff = Object.fromEntries(
+        Object.keys(DIGEST_SECTION_DEFAULTS).map((key) => [key, false])
+      ) as typeof DIGEST_SECTION_DEFAULTS;
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', allOff);
+
+      expect(report.logVolume).toBeUndefined();
+      expect(report.topErrorServices).toBeUndefined();
+      expect(report.newErrorGroups).toBeUndefined();
+      expect(report.security).toBeUndefined();
+      expect(report.uptime).toBeUndefined();
+      expect(queriedTables()).toEqual(['projects']);
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      expect(mockDb.executeTakeFirst).not.toHaveBeenCalled();
+      expect(mockReservoir.count).not.toHaveBeenCalled();
+      expect(mockReservoir.topValues).not.toHaveBeenCalled();
+    });
+
+    it('still reports zeros and empty arrays when the sections are enabled but empty', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily');
+
+      expect(report.logVolume).toEqual({ current: 0, previous: 0, trend: 'no change' });
+      expect(report.topErrorServices).toEqual([]);
+      expect(report.newErrorGroups).toEqual([]);
+      expect(report.security).toEqual({ totalDetections: 0, topRules: [], openIncidents: 0 });
+      expect(report.uptime).toBeNull();
+    });
+  });
+
   describe('optional sections', () => {
     /**
      * The optional sections are computed AFTER the five original ones, in

--- a/packages/backend/src/tests/modules/digests/generator.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator.test.ts
@@ -8,6 +8,10 @@ vi.mock('../../../database/reservoir.js', () => ({
     count: vi.fn(),
     topValues: vi.fn(),
     aggregate: vi.fn(),
+    getSpanTimeseries: vi.fn(),
+    getServiceHealthStats: vi.fn(),
+    querySpans: vi.fn(),
+    queryMetrics: vi.fn(),
   },
 }));
 
@@ -73,6 +77,14 @@ describe('DigestGeneratorService', () => {
     mockReservoir.count.mockReset().mockResolvedValue({ count: 0 });
     mockReservoir.topValues.mockReset().mockResolvedValue({ values: [] });
     mockReservoir.aggregate.mockReset().mockResolvedValue({ timeseries: [], total: 0 });
+    mockReservoir.getSpanTimeseries.mockReset().mockResolvedValue([]);
+    mockReservoir.getServiceHealthStats.mockReset().mockResolvedValue([]);
+    mockReservoir.querySpans
+      .mockReset()
+      .mockResolvedValue({ spans: [], total: 0, hasMore: false, limit: 5, offset: 0 });
+    mockReservoir.queryMetrics
+      .mockReset()
+      .mockResolvedValue({ metrics: [], total: 0, hasMore: false, limit: 1, offset: 0 });
     mockSendMail.mockReset().mockResolvedValue({ messageId: 'test-message-id' });
 
     generator = new DigestGeneratorService();
@@ -699,6 +711,256 @@ describe('DigestGeneratorService', () => {
       });
 
       expect(report.alerts).toBeUndefined();
+    });
+  });
+
+  describe('traces and metrics sections', () => {
+    /**
+     * Both sections talk to the reservoir only, so they never move the shared
+     * fluent db mock's call cursor.
+     */
+    it('computes traces section when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }, { id: 'project_2' }]); // projects
+
+      mockReservoir.getSpanTimeseries.mockResolvedValueOnce([
+        {
+          time: new Date('2026-08-15T10:00:00.000Z'),
+          spanCount: 300,
+          errorCount: 15,
+          p50: 10,
+          p95: 100,
+          p99: 200,
+        },
+        {
+          time: new Date('2026-08-15T11:00:00.000Z'),
+          spanCount: 200,
+          errorCount: 10,
+          p50: 12,
+          p95: 110,
+          p99: 210,
+        },
+      ]); // current window
+      mockReservoir.getSpanTimeseries.mockResolvedValueOnce([
+        {
+          time: new Date('2026-08-14T10:00:00.000Z'),
+          spanCount: 400,
+          errorCount: 40,
+          p50: 11,
+          p95: 105,
+          p99: 205,
+        },
+      ]); // previous window
+
+      // Same service seen in both projects: calls and errors sum, p95 is the max
+      mockReservoir.getServiceHealthStats.mockResolvedValueOnce([
+        { serviceName: 'api', totalCalls: 300, totalErrors: 16, avgLatencyMs: 20, p95LatencyMs: 120 },
+      ]); // project_1
+      mockReservoir.getServiceHealthStats.mockResolvedValueOnce([
+        { serviceName: 'api', totalCalls: 200, totalErrors: 5, avgLatencyMs: 30, p95LatencyMs: 180 },
+        { serviceName: 'web', totalCalls: 100, totalErrors: 3, avgLatencyMs: 5, p95LatencyMs: 40 },
+      ]); // project_2
+
+      mockReservoir.querySpans.mockResolvedValueOnce({
+        spans: [
+          { serviceName: 'api', operationName: 'GET /users', durationMs: 900 },
+          { serviceName: 'web', operationName: 'render', durationMs: 500 },
+        ],
+        total: 2,
+        hasMore: false,
+        limit: 5,
+        offset: 0,
+      });
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        traces: true,
+      });
+
+      expect(report.traces).toEqual({
+        spanCount: 500,
+        previousSpanCount: 400,
+        trend: '+100 (+25.0%)',
+        errorSpanCount: 25,
+        services: [
+          { service: 'api', calls: 500, errorRatePct: 4.2, p95Ms: 180 },
+          { service: 'web', calls: 100, errorRatePct: 3, p95Ms: 40 },
+        ],
+        slowestSpans: [
+          { service: 'api', operation: 'GET /users', durationMs: 900 },
+          { service: 'web', operation: 'render', durationMs: 500 },
+        ],
+      });
+
+      const timeseriesCall = mockReservoir.getSpanTimeseries.mock.calls[0][0];
+      expect(timeseriesCall.projectIds).toEqual(['project_1', 'project_2']);
+      expect(timeseriesCall.bucket).toBe('hour');
+
+      // getServiceHealthStats is single-project: one call per project
+      expect(mockReservoir.getServiceHealthStats).toHaveBeenCalledTimes(2);
+      expect(mockReservoir.getServiceHealthStats.mock.calls[0][0]).toBe('project_1');
+      expect(mockReservoir.getServiceHealthStats.mock.calls[1][0]).toBe('project_2');
+
+      const spanCall = mockReservoir.querySpans.mock.calls[0][0];
+      expect(spanCall.projectId).toEqual(['project_1', 'project_2']);
+      expect(spanCall.sortBy).toBe('duration_ms');
+      expect(spanCall.sortOrder).toBe('desc');
+      expect(spanCall.limit).toBe(5);
+    });
+
+    it('buckets weekly span volume by day', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockReservoir.getSpanTimeseries.mockResolvedValue([
+        {
+          time: new Date('2026-08-15T00:00:00.000Z'),
+          spanCount: 10,
+          errorCount: 1,
+          p50: null,
+          p95: null,
+          p99: null,
+        },
+      ]);
+
+      await generator.buildReportData('org_1', 'Test Org', 'weekly', {
+        ...DIGEST_SECTION_DEFAULTS,
+        traces: true,
+      });
+
+      expect(mockReservoir.getSpanTimeseries.mock.calls[0][0].bucket).toBe('day');
+      expect(mockReservoir.getSpanTimeseries.mock.calls[1][0].bucket).toBe('day');
+    });
+
+    it('keeps only the top 5 services by calls', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockReservoir.getSpanTimeseries.mockResolvedValueOnce([
+        {
+          time: new Date('2026-08-15T10:00:00.000Z'),
+          spanCount: 60,
+          errorCount: 0,
+          p50: null,
+          p95: null,
+          p99: null,
+        },
+      ]);
+
+      mockReservoir.getServiceHealthStats.mockResolvedValueOnce(
+        ['a', 'b', 'c', 'd', 'e', 'f'].map((name, i) => ({
+          serviceName: name,
+          totalCalls: (i + 1) * 10,
+          totalErrors: 0,
+          avgLatencyMs: 1,
+          p95LatencyMs: null,
+        }))
+      );
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        traces: true,
+      });
+
+      expect(report.traces?.services.map((s) => s.service)).toEqual(['f', 'e', 'd', 'c', 'b']);
+      expect(report.traces?.services[0]).toEqual({
+        service: 'f',
+        calls: 60,
+        errorRatePct: 0,
+        p95Ms: null,
+      });
+    });
+
+    it('returns undefined traces when no spans in either window', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        traces: true,
+      });
+
+      expect(report.traces).toBeUndefined();
+      // Nothing to rank: the follow-up queries never run
+      expect(mockReservoir.getServiceHealthStats).not.toHaveBeenCalled();
+      expect(mockReservoir.querySpans).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined traces when the org has no projects', async () => {
+      mockDb.execute.mockResolvedValueOnce([]); // no projects
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        traces: true,
+        metrics: true,
+      });
+
+      expect(report.traces).toBeUndefined();
+      expect(report.metrics).toBeUndefined();
+      expect(mockReservoir.getSpanTimeseries).not.toHaveBeenCalled();
+      expect(mockReservoir.queryMetrics).not.toHaveBeenCalled();
+    });
+
+    it('traces disabled by default issues no span queries', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily');
+
+      expect(report.traces).toBeUndefined();
+      expect(mockReservoir.getSpanTimeseries).not.toHaveBeenCalled();
+      expect(mockReservoir.getServiceHealthStats).not.toHaveBeenCalled();
+      expect(mockReservoir.querySpans).not.toHaveBeenCalled();
+    });
+
+    it('computes metrics section when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockReservoir.queryMetrics.mockResolvedValueOnce({
+        metrics: [],
+        total: 1200,
+        hasMore: true,
+        limit: 1,
+        offset: 0,
+      });
+      mockReservoir.queryMetrics.mockResolvedValueOnce({
+        metrics: [],
+        total: 1000,
+        hasMore: true,
+        limit: 1,
+        offset: 0,
+      });
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        metrics: true,
+      });
+
+      expect(report.metrics).toEqual({
+        datapoints: 1200,
+        previousDatapoints: 1000,
+        trend: '+200 (+20.0%)',
+      });
+
+      const metricCall = mockReservoir.queryMetrics.mock.calls[0][0];
+      expect(metricCall.projectId).toEqual(['project_1']);
+      expect(metricCall.limit).toBe(1);
+      expect(mockReservoir.queryMetrics).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns undefined metrics when both windows are empty', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        metrics: true,
+      });
+
+      expect(report.metrics).toBeUndefined();
+    });
+
+    it('metrics disabled by default issues no queryMetrics call', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily');
+
+      expect(report.metrics).toBeUndefined();
+      expect(mockReservoir.queryMetrics).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/tests/modules/digests/generator.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator.test.ts
@@ -21,6 +21,22 @@ vi.mock('@logtide/core', () => ({
   },
 }));
 
+// The usage section reads the metering module directly (not through the db
+// mock), so both functions are stubbed at module level and never move the
+// shared fluent db mock's call cursor.
+const { mockGetUsageBreakdown, mockGetCapabilityUsage } = vi.hoisted(() => ({
+  mockGetUsageBreakdown: vi.fn(),
+  mockGetCapabilityUsage: vi.fn(),
+}));
+
+vi.mock('../../../modules/metering/breakdown.js', () => ({
+  getUsageBreakdown: mockGetUsageBreakdown,
+}));
+
+vi.mock('../../../modules/metering/capability-usage.js', () => ({
+  getCapabilityUsage: mockGetCapabilityUsage,
+}));
+
 vi.mock('../../../database/connection.js', () => ({
     db: {
       selectFrom: vi.fn().mockReturnThis(),
@@ -86,6 +102,10 @@ describe('DigestGeneratorService', () => {
       .mockReset()
       .mockResolvedValue({ metrics: [], total: 0, hasMore: false, limit: 1, offset: 0 });
     mockSendMail.mockReset().mockResolvedValue({ messageId: 'test-message-id' });
+    mockGetUsageBreakdown
+      .mockReset()
+      .mockResolvedValue({ byType: [], byProject: [], byService: [], byLevel: [] });
+    mockGetCapabilityUsage.mockReset().mockResolvedValue([]);
 
     generator = new DigestGeneratorService();
   });
@@ -961,6 +981,299 @@ describe('DigestGeneratorService', () => {
 
       expect(report.metrics).toBeUndefined();
       expect(mockReservoir.queryMetrics).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('security activity, monitors, usage, webhooks and team sections', () => {
+    /**
+     * These five sections are computed last, after metrics, in the order
+     * securityActivity -> monitorPerformance -> usage -> webhooks -> teamActivity.
+     * With every one of them disabled the shared fluent db mock only sees the
+     * five original sections, so the mocks below queue behind:
+     *   execute:          projects, error_groups, security top rules, monitors
+     *   executeTakeFirst: detection total, open incidents
+     */
+    it('issues no queries at all when the five sections are disabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily');
+
+      expect(report.securityActivity).toBeUndefined();
+      expect(report.monitorPerformance).toBeUndefined();
+      expect(report.usage).toBeUndefined();
+      expect(report.webhooks).toBeUndefined();
+      expect(report.teamActivity).toBeUndefined();
+
+      // Only the five original sections queried
+      expect(mockDb.execute).toHaveBeenCalledTimes(4);
+      expect(mockDb.executeTakeFirst).toHaveBeenCalledTimes(2);
+      expect(mockGetUsageBreakdown).not.toHaveBeenCalled();
+      expect(mockGetCapabilityUsage).not.toHaveBeenCalled();
+    });
+
+    it('computes securityActivity when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+      mockDb.execute.mockResolvedValueOnce([]); // error_groups
+      mockDb.execute.mockResolvedValueOnce([]); // security top rules
+      mockDb.execute.mockResolvedValueOnce([]); // monitors (uptime null)
+      mockDb.execute.mockResolvedValueOnce([
+        { severity: 'high', count: 4 },
+        { severity: 'critical', count: 2 },
+        { severity: 'low', count: 0 },
+      ]); // incidents opened by severity
+      mockDb.execute.mockResolvedValueOnce([
+        { technique: 'T1078', count: 9 },
+        { technique: null, count: 5 },
+        { technique: 'T1059', count: 2 },
+      ]); // unnested mitre techniques
+
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // detections total
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // open incidents
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 3 }); // incidents resolved
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        securityActivity: true,
+      });
+
+      expect(report.securityActivity).toEqual({
+        // severity order critical..informational, zero-count severities dropped
+        openedBySeverity: [
+          { severity: 'critical', count: 2 },
+          { severity: 'high', count: 4 },
+        ],
+        resolvedCount: 3,
+        // null techniques (NULL-padded rows) are never emitted
+        topTechniques: [
+          { technique: 'T1078', count: 9 },
+          { technique: 'T1059', count: 2 },
+        ],
+      });
+
+      expect(mockDb.where).toHaveBeenCalledWith('organization_id', '=', 'org_1');
+    });
+
+    it('returns undefined securityActivity when nothing happened', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        securityActivity: true,
+      });
+
+      expect(report.securityActivity).toBeUndefined();
+    });
+
+    it('computes monitorPerformance when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+      mockDb.execute.mockResolvedValueOnce([]); // error_groups
+      mockDb.execute.mockResolvedValueOnce([]); // security top rules
+      mockDb.execute.mockResolvedValueOnce([]); // monitors (uptime null)
+      mockDb.execute.mockResolvedValueOnce([
+        { name: 'm1', avg_ms: 10.4, p95_ms: 20.6, failed_checks: 0 },
+        { name: 'm2', avg_ms: 20, p95_ms: 40, failed_checks: 1 },
+        { name: 'm3', avg_ms: 30, p95_ms: 60, failed_checks: 2 },
+        { name: 'm4', avg_ms: 40, p95_ms: 80, failed_checks: 3 },
+        { name: 'm5', avg_ms: 50, p95_ms: 100, failed_checks: 4 },
+        { name: 'm6', avg_ms: null, p95_ms: null, failed_checks: 5 },
+      ]); // monitor_results aggregate
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        monitorPerformance: true,
+      });
+
+      // Top 5 by p95 desc; m6 (no timed checks) sorts last and falls off
+      expect(report.monitorPerformance).toEqual([
+        { name: 'm5', avgMs: 50, p95Ms: 100, failedChecks: 4 },
+        { name: 'm4', avgMs: 40, p95Ms: 80, failedChecks: 3 },
+        { name: 'm3', avgMs: 30, p95Ms: 60, failedChecks: 2 },
+        { name: 'm2', avgMs: 20, p95Ms: 40, failedChecks: 1 },
+        { name: 'm1', avgMs: 10, p95Ms: 21, failedChecks: 0 },
+      ]);
+
+      expect(mockDb.innerJoin).toHaveBeenCalledWith(
+        'monitors',
+        'monitors.id',
+        'monitor_results.monitor_id'
+      );
+      expect(mockDb.where).toHaveBeenCalledWith(
+        'monitor_results.organization_id',
+        '=',
+        'org_1'
+      );
+    });
+
+    it('returns undefined monitorPerformance when no monitor was checked', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        monitorPerformance: true,
+      });
+
+      expect(report.monitorPerformance).toBeUndefined();
+    });
+
+    it('computes usage from the metering module when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockGetUsageBreakdown.mockResolvedValueOnce({
+        byType: [
+          { type: 'logs.ingested.bytes', quantity: 4500000 },
+          { type: 'logs.ingested.events', quantity: 12000 },
+        ],
+        byProject: [
+          { projectId: 'p1', projectName: 'Prod', events: 9000, bytes: 900 },
+          { projectId: 'p2', projectName: 'Staging', events: 1500, bytes: 150 },
+          { projectId: 'p3', projectName: 'Dev', events: 800, bytes: 80 },
+          { projectId: 'p4', projectName: 'QA', events: 400, bytes: 40 },
+          { projectId: 'p5', projectName: 'Sandbox', events: 200, bytes: 20 },
+          { projectId: 'p6', projectName: 'Scratch', events: 100, bytes: 10 },
+        ],
+        byService: [],
+        byLevel: [],
+      });
+
+      mockGetCapabilityUsage.mockResolvedValueOnce([
+        {
+          capability: 'ingestion.max_events_month',
+          kind: 'quota',
+          current: 900,
+          limit: 1000,
+          description: '',
+        },
+        { capability: 'alerts.max_rules', kind: 'limit', current: 1, limit: 10, description: '' },
+        // unlimited: never a warning, and never a division by null
+        { capability: 'apikeys.max', kind: 'limit', current: 5, limit: null, description: '' },
+        // limit 0: excluded so it cannot produce an Infinity percentage
+        {
+          capability: 'dashboards.max_custom',
+          kind: 'limit',
+          current: 3,
+          limit: 0,
+          description: '',
+        },
+      ]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        usage: true,
+      });
+
+      expect(report.usage).toEqual({
+        logEvents: 12000,
+        logBytes: 4500000,
+        spans: 0,
+        topProjects: [
+          { name: 'Prod', events: 9000 },
+          { name: 'Staging', events: 1500 },
+          { name: 'Dev', events: 800 },
+          { name: 'QA', events: 400 },
+          { name: 'Sandbox', events: 200 },
+        ],
+        quotaWarnings: [{ capability: 'ingestion.max_events_month', usedPct: 90 }],
+      });
+
+      const breakdownCall = mockGetUsageBreakdown.mock.calls[0][0];
+      expect(breakdownCall.organizationId).toBe('org_1');
+      expect(breakdownCall.limit).toBe(5);
+      expect(mockGetCapabilityUsage).toHaveBeenCalledWith('org_1');
+    });
+
+    it('returns undefined usage when nothing was ingested and no quota is close', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        usage: true,
+      });
+
+      expect(report.usage).toBeUndefined();
+      expect(mockGetUsageBreakdown).toHaveBeenCalledTimes(1);
+    });
+
+    it('computes webhooks delivery counts when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+      mockDb.execute.mockResolvedValueOnce([]); // error_groups
+      mockDb.execute.mockResolvedValueOnce([]); // security top rules
+      mockDb.execute.mockResolvedValueOnce([]); // monitors (uptime null)
+      mockDb.execute.mockResolvedValueOnce([
+        { status: 'delivered', count: 10 },
+        { status: 'failed', count: 2 },
+        { status: 'dead', count: 1 },
+        { status: 'pending', count: 7 },
+      ]); // webhook_deliveries by status
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        webhooks: true,
+      });
+
+      // pending is in-flight state, not an outcome: never reported
+      expect(report.webhooks).toEqual({ delivered: 10, failed: 2, dead: 1 });
+    });
+
+    it('returns undefined webhooks when only pending deliveries exist', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+      mockDb.execute.mockResolvedValueOnce([]);
+      mockDb.execute.mockResolvedValueOnce([]);
+      mockDb.execute.mockResolvedValueOnce([]);
+      mockDb.execute.mockResolvedValueOnce([{ status: 'pending', count: 5 }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        webhooks: true,
+      });
+
+      expect(report.webhooks).toBeUndefined();
+    });
+
+    it('computes teamActivity counters when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // detections total
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // open incidents
+      mockDb.executeTakeFirst.mockResolvedValueOnce({
+        members_added: 2,
+        members_removed: 1,
+        config_changes: 5,
+        failed_logins: 9,
+      }); // audit_log counters
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        teamActivity: true,
+      });
+
+      expect(report.teamActivity).toEqual({
+        membersAdded: 2,
+        membersRemoved: 1,
+        configChanges: 5,
+        failedLogins: 9,
+      });
+
+      expect(mockDb.where).toHaveBeenCalledWith('organization_id', '=', 'org_1');
+    });
+
+    it('returns undefined teamActivity when every counter is zero', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 });
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 });
+      mockDb.executeTakeFirst.mockResolvedValueOnce({
+        members_added: 0,
+        members_removed: 0,
+        config_changes: 0,
+        failed_logins: 0,
+      });
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        teamActivity: true,
+      });
+
+      expect(report.teamActivity).toBeUndefined();
     });
   });
 });

--- a/packages/backend/src/tests/modules/digests/generator.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DIGEST_SECTION_DEFAULTS } from '@logtide/shared';
 import { DigestGeneratorService } from '../../../modules/digests/generator.js';
 import type { DigestJobPayload } from '../../../modules/digests/scheduler.js';
 
@@ -6,6 +7,7 @@ vi.mock('../../../database/reservoir.js', () => ({
   reservoir: {
     count: vi.fn(),
     topValues: vi.fn(),
+    aggregate: vi.fn(),
   },
 }));
 
@@ -18,6 +20,7 @@ vi.mock('@logtide/core', () => ({
 vi.mock('../../../database/connection.js', () => ({
     db: {
       selectFrom: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       groupBy: vi.fn().mockReturnThis(),
@@ -69,6 +72,7 @@ describe('DigestGeneratorService', () => {
     mockDb.executeTakeFirst.mockReset().mockResolvedValue({ count: 0 });
     mockReservoir.count.mockReset().mockResolvedValue({ count: 0 });
     mockReservoir.topValues.mockReset().mockResolvedValue({ values: [] });
+    mockReservoir.aggregate.mockReset().mockResolvedValue({ timeseries: [], total: 0 });
     mockSendMail.mockReset().mockResolvedValue({ messageId: 'test-message-id' });
 
     generator = new DigestGeneratorService();
@@ -492,6 +496,209 @@ describe('DigestGeneratorService', () => {
       mockDb.execute.mockResolvedValueOnce([]);
       const weekly = await generator.buildReportData('org_1', 'Test Org', 'weekly');
       expect(weekly.periodLabel).toBe('last 7 days');
+    });
+  });
+
+  describe('optional sections', () => {
+    /**
+     * The optional sections are computed AFTER the five original ones, in
+     * catalog order (logBreakdown, topErrorMessages, alerts), so their mocked
+     * responses queue behind the existing sections' ones.
+     */
+    it('skips disabled sections without issuing their queries', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      // top error services current + previous (the only two topValues calls)
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [{ value: 'api', count: 3 }] });
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [] });
+
+      const report = await generator.buildReportData(
+        'org_1',
+        'Test Org',
+        'daily',
+        DIGEST_SECTION_DEFAULTS
+      );
+
+      expect(report.logBreakdown).toBeUndefined();
+      expect(report.topErrorMessages).toBeUndefined();
+      expect(report.alerts).toBeUndefined();
+      expect(mockReservoir.topValues).toHaveBeenCalledTimes(2);
+      expect(mockReservoir.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('defaults to the section defaults when no flags are passed', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily');
+
+      expect(report.logBreakdown).toBeUndefined();
+      expect(report.topErrorMessages).toBeUndefined();
+      expect(report.alerts).toBeUndefined();
+    });
+
+    it('computes logBreakdown when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [] }); // top error services
+      mockReservoir.topValues.mockResolvedValueOnce({
+        values: [
+          { value: 'info', count: 80 },
+          { value: 'error', count: 20 },
+        ],
+      }); // levels, current window
+      mockReservoir.topValues.mockResolvedValueOnce({
+        values: [{ value: 'info', count: 100 }],
+      }); // levels, previous window
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        logBreakdown: true,
+      });
+
+      expect(report.logBreakdown).toEqual({
+        levels: [
+          { level: 'debug', current: 0, previous: 0 },
+          { level: 'info', current: 80, previous: 100 },
+          { level: 'warn', current: 0, previous: 0 },
+          { level: 'error', current: 20, previous: 0 },
+          { level: 'critical', current: 0, previous: 0 },
+        ],
+        errorRatePct: 20,
+        previousErrorRatePct: 0,
+      });
+
+      const levelCall = mockReservoir.topValues.mock.calls[1][0];
+      expect(levelCall.field).toBe('level');
+      expect(levelCall.projectId).toEqual(['project_1']);
+      expect(levelCall.toExclusive).toBe(true);
+
+      // Daily digests never build the per-day table
+      expect(mockReservoir.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined logBreakdown when both windows are empty', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        logBreakdown: true,
+      });
+
+      expect(report.logBreakdown).toBeUndefined();
+    });
+
+    it('adds the per-day table for weekly logBreakdown', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [] }); // top error services
+      mockReservoir.topValues.mockResolvedValueOnce({
+        values: [{ value: 'info', count: 10 }],
+      });
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [] });
+
+      mockReservoir.aggregate.mockResolvedValueOnce({
+        timeseries: [
+          { bucket: new Date('2026-08-10T00:00:00.000Z'), total: 4 },
+          { bucket: new Date('2026-08-11T00:00:00.000Z'), total: 6 },
+        ],
+        total: 10,
+      });
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'weekly', {
+        ...DIGEST_SECTION_DEFAULTS,
+        logBreakdown: true,
+      });
+
+      expect(report.logBreakdown?.daily).toEqual([
+        { date: '2026-08-10', count: 4 },
+        { date: '2026-08-11', count: 6 },
+      ]);
+
+      const aggregateCall = mockReservoir.aggregate.mock.calls[0][0];
+      expect(aggregateCall.interval).toBe('1d');
+      expect(aggregateCall.projectId).toEqual(['project_1']);
+    });
+
+    it('computes topErrorMessages when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      mockReservoir.topValues.mockResolvedValueOnce({ values: [] }); // top error services
+      mockReservoir.topValues.mockResolvedValueOnce({
+        values: [
+          { value: 'db timeout', count: 12 },
+          { value: 'null pointer', count: 3 },
+        ],
+      });
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        topErrorMessages: true,
+      });
+
+      expect(report.topErrorMessages).toEqual([
+        { message: 'db timeout', count: 12 },
+        { message: 'null pointer', count: 3 },
+      ]);
+
+      const messageCall = mockReservoir.topValues.mock.calls[1][0];
+      expect(messageCall.field).toBe('message');
+      expect(messageCall.level).toEqual(['error', 'critical']);
+      expect(messageCall.limit).toBe(5);
+    });
+
+    it('returns undefined topErrorMessages when there are none', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        topErrorMessages: true,
+      });
+
+      expect(report.topErrorMessages).toBeUndefined();
+    });
+
+    it('computes alerts section when enabled', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+      mockDb.execute.mockResolvedValueOnce([]); // error_groups
+      mockDb.execute.mockResolvedValueOnce([]); // security top rules
+      mockDb.execute.mockResolvedValueOnce([]); // monitors (uptime null)
+      mockDb.execute.mockResolvedValueOnce([{ name: 'High error rate', count: 5 }]); // alert rules
+
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // detections total
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 0 }); // open incidents
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 7 }); // alerts current
+      mockDb.executeTakeFirst.mockResolvedValueOnce({ count: 3 }); // alerts previous
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        alerts: true,
+      });
+
+      expect(report.alerts).toEqual({
+        total: 7,
+        previousTotal: 3,
+        trend: '+4 (+133.3%)',
+        topRules: [{ name: 'High error rate', count: 5 }],
+      });
+
+      // Org scoping goes through the alert_rules join, alert_history has no org column
+      expect(mockDb.innerJoin).toHaveBeenCalledWith(
+        'alert_rules',
+        'alert_rules.id',
+        'alert_history.rule_id'
+      );
+      expect(mockDb.where).toHaveBeenCalledWith('alert_rules.organization_id', '=', 'org_1');
+    });
+
+    it('returns undefined alerts when no triggers in either window', async () => {
+      mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]);
+
+      const report = await generator.buildReportData('org_1', 'Test Org', 'daily', {
+        ...DIGEST_SECTION_DEFAULTS,
+        alerts: true,
+      });
+
+      expect(report.alerts).toBeUndefined();
     });
   });
 });

--- a/packages/backend/src/tests/modules/digests/generator.test.ts
+++ b/packages/backend/src/tests/modules/digests/generator.test.ts
@@ -1011,6 +1011,68 @@ describe('DigestGeneratorService', () => {
       expect(mockGetCapabilityUsage).not.toHaveBeenCalled();
     });
 
+    it('pins the window column and bounds of every new query', async () => {
+      // Frozen clock so period.from/period.to are exact values rather than
+      // "whatever new Date() returned", which is what makes the bounds
+      // assertable at all.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+
+      try {
+        const from = new Date('2026-08-15T12:00:00.000Z');
+        const to = new Date('2026-08-16T12:00:00.000Z');
+
+        mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
+        // every later list query falls through to the [] default, and every
+        // count to { count: 0 }: this test asserts the SQL windows, not the data
+
+        await generator.buildReportData('org_1', 'Test Org', 'daily', {
+          ...DIGEST_SECTION_DEFAULTS,
+          securityActivity: true,
+          monitorPerformance: true,
+          usage: true,
+          webhooks: true,
+          teamActivity: true,
+        });
+
+        const windowCalls = mockDb.where.mock.calls.filter(
+          (c: unknown[]) => c[1] === '>=' || c[1] === '<'
+        );
+
+        // Ordered, exhaustive: pins the column each query windows on AND that
+        // every one of them uses the CURRENT period, never previousFrom/previousTo.
+        expect(windowCalls).toEqual([
+          ['first_seen', '>=', from], // error_groups (existing section)
+          ['first_seen', '<', to],
+          ['time', '>=', from], // detection_events total, security section (existing)
+          ['time', '<', to],
+          ['time', '>=', from], // detection_events top rules (existing)
+          ['time', '<', to],
+          ['created_at', '>=', from], // incidents opened in the period
+          ['created_at', '<', to],
+          ['resolved_at', '>=', from], // incidents resolved in the period
+          ['resolved_at', '<', to],
+          ['time', '>=', from], // detection_events, unnested techniques
+          ['time', '<', to],
+          ['monitor_results.time', '>=', from],
+          ['monitor_results.time', '<', to],
+          ['created_at', '>=', from], // webhook_deliveries
+          ['created_at', '<', to],
+          ['time', '>=', from], // audit_log
+          ['time', '<', to],
+        ]);
+
+        expect(mockGetUsageBreakdown).toHaveBeenCalledWith({
+          organizationId: 'org_1',
+          from,
+          to,
+          limit: 5,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('computes securityActivity when enabled', async () => {
       mockDb.execute.mockResolvedValueOnce([{ id: 'project_1' }]); // projects
       mockDb.execute.mockResolvedValueOnce([]); // error_groups
@@ -1102,6 +1164,10 @@ describe('DigestGeneratorService', () => {
         '=',
         'org_1'
       );
+      // monitor_id has no foreign key (migration 034 declares it without one,
+      // for hypertable performance) and deleted monitors leave orphan results,
+      // so the joined side must be scoped too
+      expect(mockDb.where).toHaveBeenCalledWith('monitors.organization_id', '=', 'org_1');
     });
 
     it('returns undefined monitorPerformance when no monitor was checked', async () => {

--- a/packages/backend/src/tests/modules/digests/routes.test.ts
+++ b/packages/backend/src/tests/modules/digests/routes.test.ts
@@ -112,6 +112,23 @@ describe('Digests Routes', () => {
       expect(body.recipients[0].unsubscribe_token).toBeUndefined();
     });
 
+    it('returns merged defaults for a config saved without sections', async () => {
+      await insertConfig(testOrganization.id);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const { sections } = JSON.parse(res.body).config;
+      expect(sections.logVolume).toBe(true);
+      expect(sections.uptime).toBe(true);
+      expect(sections.traces).toBe(false);
+      expect(sections.teamActivity).toBe(false);
+    });
+
     it('rejects non-members', async () => {
       const outsider = await createTestUser({ email: 'outsider@example.com' });
       const outsiderToken = await createTestSession(outsider.id);
@@ -189,6 +206,86 @@ describe('Digests Routes', () => {
         url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
         headers: { Authorization: `Bearer ${authToken}` },
         payload: { frequency: 'daily', deliveryHour: 24, enabled: true },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('accepts a partial sections object and returns the merged record', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        payload: { frequency: 'daily', deliveryHour: 8, enabled: true, sections: { traces: true } },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).config.sections.traces).toBe(true);
+
+      const getRes = await app.inject({
+        method: 'GET',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      const cfg = JSON.parse(getRes.body).config;
+      expect(cfg.sections.traces).toBe(true);
+      expect(cfg.sections.logVolume).toBe(true);
+      expect(cfg.sections.teamActivity).toBe(false);
+
+      // only the partial is persisted, defaults stay code-side
+      const row = await db
+        .selectFrom('digest_configs')
+        .select(['sections'])
+        .where('organization_id', '=', testOrganization.id)
+        .executeTakeFirstOrThrow();
+      expect(row.sections).toEqual({ traces: true });
+    });
+
+    it('keeps stored sections when a later save omits them', async () => {
+      await insertConfig(testOrganization.id, { sections: { traces: true } });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        payload: { frequency: 'daily', deliveryHour: 10, enabled: true },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).config.sections.traces).toBe(true);
+    });
+
+    it('resets to defaults when sections is explicitly null', async () => {
+      await insertConfig(testOrganization.id, { sections: { traces: true } });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        payload: { frequency: 'daily', deliveryHour: 10, enabled: true, sections: null },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).config.sections.traces).toBe(false);
+    });
+
+    it('rejects unknown section keys', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        payload: { frequency: 'daily', deliveryHour: 8, enabled: true, sections: { bogus: true } },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects non-boolean section values', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/digests/config?organizationId=${testOrganization.id}`,
+        headers: { Authorization: `Bearer ${authToken}` },
+        payload: { frequency: 'daily', deliveryHour: 8, enabled: true, sections: { traces: 'yes' } },
       });
 
       expect(res.statusCode).toBe(400);

--- a/packages/backend/src/tests/queue/jobs/digest-dispatch.test.ts
+++ b/packages/backend/src/tests/queue/jobs/digest-dispatch.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../../database/connection.js', () => ({
 
 import { isConfigDue, processDigestDispatch } from '../../../queue/jobs/digest-dispatch.js';
 import { db } from '../../../database/connection.js';
+import { DIGEST_SECTION_DEFAULTS } from '@logtide/shared';
 
 function makeJob(): IJob<Record<string, never>> {
   return { id: 'dispatch_1', name: 'digest-dispatch', data: {} };
@@ -109,11 +110,40 @@ describe('processDigestDispatch', () => {
       organizationId: 'org_1',
       digestConfigId: 'conf_due',
       frequency: 'daily',
+      // a row without stored sections travels as the plain defaults
+      sections: DIGEST_SECTION_DEFAULTS,
     });
     // hour-keyed jobKey dedupes double enqueues within the same hour
     expect(options.jobKey).toBe('digest:conf_due:2026-07-13T08');
 
     expect(db.updateTable).toHaveBeenCalledWith('digest_configs');
+    vi.useRealTimers();
+  });
+
+  it('carries the stored section toggles merged over the defaults', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-13T08:00:30.000Z'));
+
+    mockExecute.mockResolvedValueOnce([
+      {
+        id: 'conf_due',
+        organization_id: 'org_1',
+        frequency: 'daily',
+        delivery_hour: 8,
+        delivery_day_of_week: null,
+        last_sent_at: null,
+        sections: { traces: true },
+      },
+    ]);
+    mockExecute.mockResolvedValue(undefined);
+
+    await processDigestDispatch(makeJob());
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    const [, payload] = mockAdd.mock.calls[0];
+    expect(payload.sections.traces).toBe(true);
+    expect(payload.sections.logVolume).toBe(true);
+    expect(payload.sections.teamActivity).toBe(false);
     vi.useRealTimers();
   });
 

--- a/packages/frontend/src/lib/api/digests.ts
+++ b/packages/frontend/src/lib/api/digests.ts
@@ -10,6 +10,8 @@ export interface DigestConfig {
   delivery_day_of_week: number | null;
   enabled: boolean;
   last_sent_at: string | null;
+  /** Always the full merged record: the API resolves defaults server side. */
+  sections: Record<string, boolean>;
   created_at: string;
   updated_at: string;
 }
@@ -27,6 +29,8 @@ export interface DigestConfigInput {
   deliveryHour: number;
   deliveryDayOfWeek?: number | null;
   enabled: boolean;
+  /** Partial on purpose: only keys that differ from the defaults are stored. */
+  sections?: Partial<Record<string, boolean>>;
 }
 
 async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {

--- a/packages/frontend/src/routes/dashboard/settings/digests/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/digests/+page.svelte
@@ -22,8 +22,13 @@
     SelectValue,
   } from '$lib/components/ui/select';
   import { Separator } from '$lib/components/ui/separator';
-  import { canManageMembers } from '@logtide/shared';
-  import type { OrganizationWithRole } from '@logtide/shared';
+  import {
+    canManageMembers,
+    DIGEST_SECTION_KEYS,
+    DIGEST_SECTION_DEFAULTS,
+    mergeDigestSections,
+  } from '@logtide/shared';
+  import type { DigestSectionKey, OrganizationWithRole } from '@logtide/shared';
   import Save from '@lucide/svelte/icons/save';
   import Mail from '@lucide/svelte/icons/mail';
   import Trash2 from '@lucide/svelte/icons/trash-2';
@@ -44,11 +49,92 @@
   let deliveryHour = $state(8);
   let deliveryDayOfWeek = $state(1);
   let newRecipientEmail = $state('');
+  // Always a complete record: the API returns the merged sections, and before
+  // the first load (or after a failed one) the shared defaults stand in.
+  let sections = $state<Record<string, boolean>>(mergeDigestSections(null));
 
   let canManage = $derived(currentOrg ? canManageMembers(currentOrg.role) : false);
 
   const dayLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
   const hours = Array.from({ length: 24 }, (_, i) => i);
+
+  const sectionMeta: Record<DigestSectionKey, { label: string; description: string }> = {
+    logVolume: {
+      label: 'Log volume',
+      description: 'Total logs with trend vs the previous period',
+    },
+    topErrorServices: {
+      label: 'Top services by errors',
+      description: 'Services with the most error and critical logs',
+    },
+    newErrorGroups: {
+      label: 'New error groups',
+      description: 'Exceptions first seen during the period',
+    },
+    security: {
+      label: 'Security',
+      description: 'Sigma detections, top rules and open incidents',
+    },
+    uptime: {
+      label: 'Uptime',
+      description: 'Monitor availability and worst performers',
+    },
+    logBreakdown: {
+      label: 'Log level breakdown',
+      description: 'Per-level counts, error rate and daily volumes',
+    },
+    topErrorMessages: {
+      label: 'Top error messages',
+      description: 'Most frequent error and critical messages',
+    },
+    traces: {
+      label: 'Traces',
+      description: 'Span volume, service latency and slowest spans',
+    },
+    metrics: {
+      label: 'Metrics',
+      description: 'Metric datapoints ingested with trend',
+    },
+    alerts: {
+      label: 'Alerts',
+      description: 'Alert rules triggered during the period',
+    },
+    securityActivity: {
+      label: 'Security activity',
+      description: 'Incidents opened and resolved, top MITRE techniques',
+    },
+    monitorPerformance: {
+      label: 'Monitor performance',
+      description: 'Response times and failed checks per monitor',
+    },
+    usage: {
+      label: 'Usage',
+      description: 'Ingestion volumes per project and quota warnings',
+    },
+    webhooks: {
+      label: 'Webhook deliveries',
+      description: 'Delivered, failed and dead webhook deliveries',
+    },
+    teamActivity: {
+      label: 'Team activity',
+      description: 'Member changes, config changes and failed logins',
+    },
+  };
+
+  /**
+   * Only the keys that differ from the shared defaults are persisted. Storing
+   * all 15 booleans would freeze today's defaults into the row and stop future
+   * default changes from ever reaching this organization.
+   */
+  function changedSections(): Record<string, boolean> {
+    const changed: Record<string, boolean> = {};
+    for (const key of DIGEST_SECTION_KEYS) {
+      if (sections[key] !== DIGEST_SECTION_DEFAULTS[key]) {
+        changed[key] = sections[key];
+      }
+    }
+    return changed;
+  }
 
   function hourLabel(hour: number): string {
     return `${hour.toString().padStart(2, '0')}:00 UTC`;
@@ -85,6 +171,7 @@
         deliveryHour = config.delivery_hour;
         deliveryDayOfWeek = config.delivery_day_of_week ?? 1;
       }
+      sections = mergeDigestSections(config?.sections);
     } catch (e) {
       toastStore.error(e instanceof Error ? e.message : 'Failed to load digest settings');
     } finally {
@@ -101,7 +188,9 @@
         deliveryHour,
         deliveryDayOfWeek: frequency === 'weekly' ? deliveryDayOfWeek : null,
         enabled,
+        sections: changedSections(),
       });
+      sections = mergeDigestSections(config.sections);
       toastStore.success('Digest settings saved');
     } catch (e) {
       toastStore.error(e instanceof Error ? e.message : 'Failed to save digest settings');
@@ -261,6 +350,31 @@
             {saving ? 'Saving...' : 'Save Schedule'}
           </Button>
         </form>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Sections</CardTitle>
+        <CardDescription>
+          Choose what the digest reports on. New sections are off by default.
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        {#each DIGEST_SECTION_KEYS as key (key)}
+          <div class="flex items-center justify-between gap-4">
+            <div class="space-y-0.5">
+              <Label>{sectionMeta[key].label}</Label>
+              <p class="text-sm text-muted-foreground">{sectionMeta[key].description}</p>
+            </div>
+            <Switch
+              checked={sections[key]}
+              onCheckedChange={(v) => (sections[key] = v)}
+              disabled={!canManage || saving}
+              aria-label={sectionMeta[key].label}
+            />
+          </div>
+        {/each}
       </CardContent>
     </Card>
 

--- a/packages/frontend/src/routes/dashboard/settings/digests/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/settings/digests/+page.svelte
@@ -252,131 +252,137 @@
   {#if loading}
     <p class="text-sm text-muted-foreground">Loading digest settings...</p>
   {:else}
-    <Card>
-      <CardHeader>
-        <CardTitle>Schedule</CardTitle>
-        <CardDescription>
-          When the digest report is generated and sent. Times are in UTC.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <form
-          onsubmit={(e) => {
-            e.preventDefault();
-            saveConfig();
-          }}
-          class="space-y-4"
-        >
-          <div class="flex items-center justify-between">
-            <div class="space-y-0.5">
-              <Label>Enable digest emails</Label>
-              <p class="text-sm text-muted-foreground">
-                Subscribed recipients receive the report on the schedule below.
-              </p>
-            </div>
-            <Switch checked={enabled} onCheckedChange={(v) => (enabled = v)} disabled={!canManage || saving} />
-          </div>
-
-          <Separator />
-
-          <div class="grid gap-4 sm:grid-cols-3">
-            <div class="space-y-2">
-              <Label>Frequency</Label>
-              <Select
-                type="single"
-                value={frequency}
-                onValueChange={(v) => (frequency = v as DigestFrequency)}
-                disabled={!canManage || saving}
-              >
-                <SelectTrigger>
-                  <SelectValue>{frequency === 'daily' ? 'Daily' : 'Weekly'}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="daily">Daily</SelectItem>
-                  <SelectItem value="weekly">Weekly</SelectItem>
-                </SelectContent>
-              </Select>
+    <!-- Schedule and Sections are one form: a single Save Settings button at
+         the end of the Sections card commits both. -->
+    <form
+      onsubmit={(e) => {
+        e.preventDefault();
+        saveConfig();
+      }}
+      class="space-y-6"
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle>Schedule</CardTitle>
+          <CardDescription>
+            When the digest report is generated and sent. Times are in UTC.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <div class="space-y-0.5">
+                <Label>Enable digest emails</Label>
+                <p class="text-sm text-muted-foreground">
+                  Subscribed recipients receive the report on the schedule below.
+                </p>
+              </div>
+              <Switch checked={enabled} onCheckedChange={(v) => (enabled = v)} disabled={!canManage || saving} />
             </div>
 
-            <div class="space-y-2">
-              <Label>Delivery time</Label>
-              <Select
-                type="single"
-                value={String(deliveryHour)}
-                onValueChange={(v) => (deliveryHour = Number(v))}
-                disabled={!canManage || saving}
-              >
-                <SelectTrigger>
-                  <SelectValue>{hourLabel(deliveryHour)}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {#each hours as hour (hour)}
-                    <SelectItem value={String(hour)}>{hourLabel(hour)}</SelectItem>
-                  {/each}
-                </SelectContent>
-              </Select>
-            </div>
+            <Separator />
 
-            {#if frequency === 'weekly'}
+            <div class="grid gap-4 sm:grid-cols-3">
               <div class="space-y-2">
-                <Label>Day of week</Label>
+                <Label>Frequency</Label>
                 <Select
                   type="single"
-                  value={String(deliveryDayOfWeek)}
-                  onValueChange={(v) => (deliveryDayOfWeek = Number(v))}
+                  value={frequency}
+                  onValueChange={(v) => (frequency = v as DigestFrequency)}
                   disabled={!canManage || saving}
                 >
                   <SelectTrigger>
-                    <SelectValue>{dayLabels[deliveryDayOfWeek]}</SelectValue>
+                    <SelectValue>{frequency === 'daily' ? 'Daily' : 'Weekly'}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {#each dayLabels as day, index (day)}
-                      <SelectItem value={String(index)}>{day}</SelectItem>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div class="space-y-2">
+                <Label>Delivery time</Label>
+                <Select
+                  type="single"
+                  value={String(deliveryHour)}
+                  onValueChange={(v) => (deliveryHour = Number(v))}
+                  disabled={!canManage || saving}
+                >
+                  <SelectTrigger>
+                    <SelectValue>{hourLabel(deliveryHour)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {#each hours as hour (hour)}
+                      <SelectItem value={String(hour)}>{hourLabel(hour)}</SelectItem>
                     {/each}
                   </SelectContent>
                 </Select>
               </div>
+
+              {#if frequency === 'weekly'}
+                <div class="space-y-2">
+                  <Label>Day of week</Label>
+                  <Select
+                    type="single"
+                    value={String(deliveryDayOfWeek)}
+                    onValueChange={(v) => (deliveryDayOfWeek = Number(v))}
+                    disabled={!canManage || saving}
+                  >
+                    <SelectTrigger>
+                      <SelectValue>{dayLabels[deliveryDayOfWeek]}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {#each dayLabels as day, index (day)}
+                        <SelectItem value={String(index)}>{day}</SelectItem>
+                      {/each}
+                    </SelectContent>
+                  </Select>
+                </div>
+              {/if}
+            </div>
+
+            {#if config?.last_sent_at}
+              <p class="text-xs text-muted-foreground">
+                Last sent: {new Date(config.last_sent_at).toLocaleString()}
+              </p>
             {/if}
           </div>
+        </CardContent>
+      </Card>
 
-          {#if config?.last_sent_at}
-            <p class="text-xs text-muted-foreground">
-              Last sent: {new Date(config.last_sent_at).toLocaleString()}
-            </p>
-          {/if}
+      <Card>
+        <CardHeader>
+          <CardTitle>Sections</CardTitle>
+          <CardDescription>
+            Choose what the digest reports on. New sections are off by default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          {#each DIGEST_SECTION_KEYS as key (key)}
+            <div class="flex items-center justify-between gap-4">
+              <div class="space-y-0.5">
+                <Label>{sectionMeta[key].label}</Label>
+                <p class="text-sm text-muted-foreground">{sectionMeta[key].description}</p>
+              </div>
+              <Switch
+                checked={sections[key]}
+                onCheckedChange={(v) => (sections[key] = v)}
+                disabled={!canManage || saving}
+                aria-label={sectionMeta[key].label}
+              />
+            </div>
+          {/each}
+
+          <Separator />
 
           <Button type="submit" disabled={!canManage || saving} class="gap-2">
             <Save class="w-4 h-4" />
-            {saving ? 'Saving...' : 'Save Schedule'}
+            {saving ? 'Saving...' : 'Save Settings'}
           </Button>
-        </form>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <CardTitle>Sections</CardTitle>
-        <CardDescription>
-          Choose what the digest reports on. New sections are off by default.
-        </CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-4">
-        {#each DIGEST_SECTION_KEYS as key (key)}
-          <div class="flex items-center justify-between gap-4">
-            <div class="space-y-0.5">
-              <Label>{sectionMeta[key].label}</Label>
-              <p class="text-sm text-muted-foreground">{sectionMeta[key].description}</p>
-            </div>
-            <Switch
-              checked={sections[key]}
-              onCheckedChange={(v) => (sections[key] = v)}
-              disabled={!canManage || saving}
-              aria-label={sectionMeta[key].label}
-            />
-          </div>
-        {/each}
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </form>
 
     <Card>
       <CardHeader>

--- a/packages/frontend/src/routes/dashboard/settings/digests/page.test.ts
+++ b/packages/frontend/src/routes/dashboard/settings/digests/page.test.ts
@@ -142,7 +142,7 @@ describe('digest sections card', () => {
 
     await fireEvent.click(sectionSwitch('Team activity'));
     await fireEvent.click(sectionSwitch('Log volume'));
-    await fireEvent.click(screen.getByRole('button', { name: 'Save Schedule' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
 
     expect(saveConfig).toHaveBeenCalledTimes(1);
     expect(saveConfig.mock.calls[0][1].sections).toEqual({
@@ -159,7 +159,7 @@ describe('digest sections card', () => {
     render(Page);
     await screen.findByText('Sections');
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Save Schedule' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
 
     expect(saveConfig.mock.calls[0][1].sections).toEqual({});
   });

--- a/packages/frontend/src/routes/dashboard/settings/digests/page.test.ts
+++ b/packages/frontend/src/routes/dashboard/settings/digests/page.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+const { getConfig, saveConfig, addRecipient, removeRecipient, resubscribeRecipient } = vi.hoisted(
+  () => ({
+    getConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    addRecipient: vi.fn(),
+    removeRecipient: vi.fn(),
+    resubscribeRecipient: vi.fn(),
+  })
+);
+
+vi.mock('$lib/api/digests', () => ({
+  digestsAPI: { getConfig, saveConfig, addRecipient, removeRecipient, resubscribeRecipient },
+}));
+
+import Page from './+page.svelte';
+import { authStore } from '$lib/stores/auth';
+import { organizationStore } from '$lib/stores/organization';
+import { DIGEST_SECTION_KEYS, DIGEST_SECTION_DEFAULTS, mergeDigestSections } from '@logtide/shared';
+
+const baseOrg = {
+  id: 'org-1',
+  name: 'Acme',
+  slug: 'acme',
+  ownerId: 'user-1',
+  role: 'owner' as const,
+  retentionDays: 90,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+// The API always returns the MERGED record, so the page never has to resolve
+// defaults itself; here traces is the one section turned on by the operator.
+function serverConfig(sections: Record<string, boolean> = mergeDigestSections({ traces: true })) {
+  return {
+    id: 'cfg-1',
+    frequency: 'daily' as const,
+    delivery_hour: 8,
+    delivery_day_of_week: null,
+    enabled: true,
+    last_sent_at: null,
+    sections,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const SECTION_LABELS: Array<[(typeof DIGEST_SECTION_KEYS)[number], string]> = [
+  ['logVolume', 'Log volume'],
+  ['topErrorServices', 'Top services by errors'],
+  ['newErrorGroups', 'New error groups'],
+  ['security', 'Security'],
+  ['uptime', 'Uptime'],
+  ['logBreakdown', 'Log level breakdown'],
+  ['topErrorMessages', 'Top error messages'],
+  ['traces', 'Traces'],
+  ['metrics', 'Metrics'],
+  ['alerts', 'Alerts'],
+  ['securityActivity', 'Security activity'],
+  ['monitorPerformance', 'Monitor performance'],
+  ['usage', 'Usage'],
+  ['webhooks', 'Webhook deliveries'],
+  ['teamActivity', 'Team activity'],
+];
+
+function sectionSwitch(label: string): HTMLElement {
+  return screen.getByRole('switch', { name: label });
+}
+
+describe('digest sections card', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getConfig.mockReset();
+    saveConfig.mockReset();
+    authStore.setAuth({ id: 'user-1', email: 'a@b.c', name: 'Test User' }, 'token-1');
+    organizationStore.clear();
+    getConfig.mockResolvedValue({ config: serverConfig(), recipients: [] });
+    saveConfig.mockResolvedValue(serverConfig());
+  });
+
+  it('renders one switch per catalog section', async () => {
+    organizationStore.setCurrentOrganization({ ...baseOrg });
+
+    render(Page);
+    await screen.findByText('Sections');
+
+    for (const [, label] of SECTION_LABELS) {
+      expect(sectionSwitch(label)).toBeInTheDocument();
+    }
+    // 15 sections plus the "Enable digest emails" switch on the Schedule card.
+    expect(screen.getAllByRole('switch')).toHaveLength(DIGEST_SECTION_KEYS.length + 1);
+  });
+
+  it('reflects the merged sections returned by the API', async () => {
+    organizationStore.setCurrentOrganization({ ...baseOrg });
+
+    render(Page);
+    await screen.findByText('Sections');
+
+    // The five original sections stay on by default.
+    for (const label of [
+      'Log volume',
+      'Top services by errors',
+      'New error groups',
+      'Security',
+      'Uptime',
+    ]) {
+      expect(sectionSwitch(label)).toHaveAttribute('aria-checked', 'true');
+    }
+    // Enabled by the stored partial.
+    expect(sectionSwitch('Traces')).toHaveAttribute('aria-checked', 'true');
+    // Still off: a default-off section nobody enabled.
+    expect(sectionSwitch('Team activity')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('falls back to the defaults when no config exists yet', async () => {
+    getConfig.mockResolvedValue({ config: null, recipients: [] });
+    organizationStore.setCurrentOrganization({ ...baseOrg });
+
+    render(Page);
+    await screen.findByText('Sections');
+
+    for (const [key, label] of SECTION_LABELS) {
+      expect(sectionSwitch(label)).toHaveAttribute(
+        'aria-checked',
+        String(DIGEST_SECTION_DEFAULTS[key])
+      );
+    }
+  });
+
+  // Binding ruling: only keys that DIFFER from the shared defaults are sent, so
+  // a future change to the defaults still propagates to saved organizations.
+  it('saves only the sections that differ from the defaults', async () => {
+    organizationStore.setCurrentOrganization({ ...baseOrg });
+
+    render(Page);
+    await screen.findByText('Sections');
+
+    await fireEvent.click(sectionSwitch('Team activity'));
+    await fireEvent.click(sectionSwitch('Log volume'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Save Schedule' }));
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig.mock.calls[0][1].sections).toEqual({
+      traces: true,
+      teamActivity: true,
+      logVolume: false,
+    });
+  });
+
+  it('sends an empty sections object when nothing differs from the defaults', async () => {
+    getConfig.mockResolvedValue({ config: serverConfig(mergeDigestSections(null)), recipients: [] });
+    organizationStore.setCurrentOrganization({ ...baseOrg });
+
+    render(Page);
+    await screen.findByText('Sections');
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Save Schedule' }));
+
+    expect(saveConfig.mock.calls[0][1].sections).toEqual({});
+  });
+});

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine-integration.test.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine-integration.test.ts
@@ -840,6 +840,72 @@ describe('MongoDBEngine (integration)', () => {
       expect(result.spans).toHaveLength(1);
       expect(result.hasMore).toBe(true);
     });
+
+    it('sorts by duration_ms when requested', async () => {
+      // Inserted out of duration order on purpose: sorting by the insertion
+      // default (start_time) would return 120, 900, 30
+      await engine.ingestSpans([
+        makeSpan({ spanId: 'span-d1', projectId: 'proj-sort', operationName: 'mid', durationMs: 120 }),
+        makeSpan({ spanId: 'span-d2', projectId: 'proj-sort', operationName: 'slow', durationMs: 900 }),
+        makeSpan({ spanId: 'span-d3', projectId: 'proj-sort', operationName: 'fast', durationMs: 30 }),
+      ]);
+
+      const result = await engine.querySpans({
+        projectId: 'proj-sort',
+        from: new Date('2025-01-15T00:00:00Z'),
+        to: new Date('2025-01-16T00:00:00Z'),
+        sortBy: 'duration_ms',
+        sortOrder: 'desc',
+      });
+
+      expect(result.spans.map((s) => s.durationMs)).toEqual([900, 120, 30]);
+      expect(result.spans.map((s) => s.operationName)).toEqual(['slow', 'mid', 'fast']);
+    });
+
+    it('sorts by service_name and operation_name', async () => {
+      await engine.ingestSpans([
+        makeSpan({ spanId: 'span-s1', projectId: 'proj-sort', serviceName: 'worker' }),
+        makeSpan({ spanId: 'span-s2', projectId: 'proj-sort', serviceName: 'api' }),
+        makeSpan({ spanId: 'span-s3', projectId: 'proj-sort', serviceName: 'db' }),
+      ]);
+
+      const result = await engine.querySpans({
+        projectId: 'proj-sort',
+        from: new Date('2025-01-15T00:00:00Z'),
+        to: new Date('2025-01-16T00:00:00Z'),
+        sortBy: 'service_name',
+        sortOrder: 'asc',
+      });
+
+      expect(result.spans.map((s) => s.serviceName)).toEqual(['api', 'db', 'worker']);
+    });
+
+    it('falls back to start_time for unsupported sort fields', async () => {
+      await engine.ingestSpans([
+        makeSpan({
+          spanId: 'span-f1',
+          projectId: 'proj-sort',
+          startTime: new Date('2025-01-15T14:00:00Z'),
+          durationMs: 10,
+        }),
+        makeSpan({
+          spanId: 'span-f2',
+          projectId: 'proj-sort',
+          startTime: new Date('2025-01-15T13:00:00Z'),
+          durationMs: 999,
+        }),
+      ]);
+
+      const result = await engine.querySpans({
+        projectId: 'proj-sort',
+        from: new Date('2025-01-15T00:00:00Z'),
+        to: new Date('2025-01-16T00:00:00Z'),
+        sortBy: 'attributes; drop',
+        sortOrder: 'asc',
+      });
+
+      expect(result.spans.map((s) => s.spanId)).toEqual(['span-f2', 'span-f1']);
+    });
   });
 
   describe('getSpansByTraceId', () => {

--- a/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
+++ b/packages/reservoir/src/engines/mongodb/mongodb-engine.ts
@@ -666,7 +666,16 @@ export class MongoDBEngine extends StorageEngine {
     const offset = params.offset ?? 0;
 
     const filter = this.buildSpanFilter(params);
-    const sortBy = params.sortBy === 'start_time' || params.sortBy === 'time' ? params.sortBy : 'start_time';
+    // Same allowlist as the Timescale and ClickHouse engines so callers get the
+    // same ordering on every engine (there it also guards against SQL injection)
+    const ALLOWED_SORT_FIELDS = new Set([
+      'start_time',
+      'end_time',
+      'duration_ms',
+      'service_name',
+      'operation_name',
+    ]);
+    const sortBy = ALLOWED_SORT_FIELDS.has(params.sortBy ?? '') ? params.sortBy! : 'start_time';
     const sortOrder = params.sortOrder === 'desc' ? -1 : 1;
 
     const [docs, total] = await Promise.all([

--- a/packages/shared/src/types/digest.test.ts
+++ b/packages/shared/src/types/digest.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { DIGEST_SECTION_KEYS, DIGEST_SECTION_DEFAULTS, mergeDigestSections } from './digest.js';
+
+describe('digest sections', () => {
+  it('has 15 keys, first five enabled by default', () => {
+    expect(DIGEST_SECTION_KEYS).toHaveLength(15);
+    expect(DIGEST_SECTION_DEFAULTS.logVolume).toBe(true);
+    expect(DIGEST_SECTION_DEFAULTS.uptime).toBe(true);
+    expect(DIGEST_SECTION_DEFAULTS.traces).toBe(false);
+    expect(DIGEST_SECTION_DEFAULTS.teamActivity).toBe(false);
+  });
+
+  it('merges partials over defaults', () => {
+    const merged = mergeDigestSections({ traces: true, logVolume: false });
+    expect(merged.traces).toBe(true);
+    expect(merged.logVolume).toBe(false);
+    expect(merged.security).toBe(true);
+  });
+
+  it('null/undefined yields pure defaults and ignores junk keys', () => {
+    expect(mergeDigestSections(null)).toEqual(DIGEST_SECTION_DEFAULTS);
+    expect(mergeDigestSections(undefined)).toEqual(DIGEST_SECTION_DEFAULTS);
+    expect(mergeDigestSections({ nope: true } as never)).toEqual(DIGEST_SECTION_DEFAULTS);
+    expect(mergeDigestSections({ traces: 'yes' } as never).traces).toBe(false);
+  });
+
+  it('does not mutate the defaults', () => {
+    mergeDigestSections({ logVolume: false });
+    expect(DIGEST_SECTION_DEFAULTS.logVolume).toBe(true);
+  });
+});

--- a/packages/shared/src/types/digest.ts
+++ b/packages/shared/src/types/digest.ts
@@ -1,0 +1,72 @@
+/**
+ * Digest section catalog (#154 expansion)
+ *
+ * The digest email is assembled from a fixed set of sections. Each one can be
+ * toggled per organization; the stored value is a PARTIAL map merged over the
+ * defaults below, so a NULL column (or a missing key) always means "default".
+ *
+ * The five sections that shipped with the original digest stay enabled by
+ * default; every section added by the expansion ships disabled so existing
+ * subscribers keep receiving the exact same email.
+ *
+ * Backend Zod validation and the frontend toggle list are both generated from
+ * DIGEST_SECTION_KEYS so they cannot drift from this catalog.
+ */
+
+export const DIGEST_SECTION_KEYS = [
+  'logVolume',
+  'topErrorServices',
+  'newErrorGroups',
+  'security',
+  'uptime',
+  'logBreakdown',
+  'topErrorMessages',
+  'traces',
+  'metrics',
+  'alerts',
+  'securityActivity',
+  'monitorPerformance',
+  'usage',
+  'webhooks',
+  'teamActivity',
+] as const;
+
+export type DigestSectionKey = (typeof DIGEST_SECTION_KEYS)[number];
+
+export type DigestSections = Record<DigestSectionKey, boolean>;
+
+/** The five original sections on, the ten added by the expansion off. */
+export const DIGEST_SECTION_DEFAULTS: DigestSections = {
+  logVolume: true,
+  topErrorServices: true,
+  newErrorGroups: true,
+  security: true,
+  uptime: true,
+  logBreakdown: false,
+  topErrorMessages: false,
+  traces: false,
+  metrics: false,
+  alerts: false,
+  securityActivity: false,
+  monitorPerformance: false,
+  usage: false,
+  webhooks: false,
+  teamActivity: false,
+};
+
+/** Merge a stored partial over the defaults; ignores unknown keys defensively. */
+export function mergeDigestSections(partial?: Partial<DigestSections> | null): DigestSections {
+  const merged: DigestSections = { ...DIGEST_SECTION_DEFAULTS };
+  if (!partial || typeof partial !== 'object') {
+    return merged;
+  }
+
+  for (const key of DIGEST_SECTION_KEYS) {
+    const value = partial[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -16,6 +16,9 @@ export * from './notification-channel.js';
 // Re-export webhook delivery types
 export * from './webhook-delivery.js';
 
+// Re-export digest section catalog
+export * from './digest.js';
+
 // Re-export custom dashboard types
 export * from './dashboard.js';
 export * from './dashboard-migrations.js';


### PR DESCRIPTION
Expands the daily/weekly digest email so every LogTide vertical can report into it. Ten new sections, all disabled by default and individually toggleable per organization; the five original sections are now toggleable too (enabled by default), so existing digests are unchanged until someone opts in.

## What's included

- **Section toggles**: `digest_configs` gains a `sections` JSONB column (migration 057, NULL = defaults). The shared catalog (`DIGEST_SECTION_KEYS`, `DIGEST_SECTION_DEFAULTS`, `mergeDigestSections` in `@logtide/shared`) drives the backend Zod schema, the generator gating and the settings UI, so the three cannot drift. Stored values are minimal partials (the UI sends only keys that differ from defaults); the dispatch cron enqueues the merged record in the job payload, so the generator adds no config query and pre-deploy queued jobs fall back to defaults.
- **New sections** (off by default): log level breakdown with error rate and per-day volumes (weekly), top error messages, traces (span volume, per-service p95/error rate, slowest spans), metrics datapoints, alerts triggered with top rules, security activity (incidents opened/resolved by severity, top MITRE techniques), monitor performance (avg/p95 response time, failed checks), usage (per-project ingestion, month-to-date quota warnings), webhook deliveries (delivered/failed/dead), team activity (member changes, config changes, failed logins).
- **Settings UI**: new Sections card in Settings > Email Digests with one switch per section; the form now saves schedule and sections together ("Save Settings").
- **Email template**: all sections render in HTML and plaintext, every user-controlled string escaped (injection payloads tested per section), disabled or empty sections skipped entirely, quiet-period and preheader logic section-aware.
- **Multi-engine fix**: MongoDB span queries now accept the same sort fields as TimescaleDB and ClickHouse (`duration_ms`, `end_time`, `service_name`, `operation_name`); previously any sort other than `start_time` was silently ignored, which would have made "slowest spans" render most-recent spans on Mongo.

## Tenancy and safety

- Every new query is org-scoped; `alert_history` through the `alert_rules` join (it has no org column), `monitor_results` on both sides of the `monitors` join (no FK exists on the hypertable). `check:tenant-scoping` passes (324 sites).
- Detection MITRE aggregation unnests a single array (avoids the #200 lockstep NULL-padding bug).
- Disabled sections cost zero queries; the heavyweight capability-usage module is lazily imported only when the usage section is enabled.

## Verification

- Backend full suite green (exit 0; digests dir 87, email templates 91, tsc clean)
- Reservoir: 483 passed / 7 skipped (Redis transport only), ClickHouse and MongoDB integration suites running against real containers including the new sort-parity tests
- Frontend: 159 tests passing; svelte-check at the pre-existing 9 errors / 23 warnings baseline
- Shared: 199 tests passing