### PR TITLE
panel time ranges, dashboard override and geo map viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Panel time ranges**: every window-scoped dashboard panel (`time_series`, `top_n_table`, `geo_map`, `log_table`, `metric_chart`, `metric_stat`, `trace_latency`, `trace_volume`, `detection_events`, `activity_overview`) now accepts one shared preset list: 15m, 1h, 6h, 12h, 24h, 48h, 3d, 7d, 14d and 30d; config forms label the control "Time range" with human-readable labels (#305).
+- **Dashboard time override**: a toolbar picker on custom dashboards temporarily overrides the time range of every window-scoped panel (per-panel configs and saved dashboards are untouched); "Panel defaults" restores per-panel windows (#305).
+
+### Fixed
+
+- **Time series panel window**: the `time_series` panel always rendered the last 24 hours regardless of its configured interval; it now honors the window with adaptive bucketing (1m/5m/15m/1h/1d), zero-filled buckets and date-aware axis labels on multi-day ranges (#305).
+- **Top services window**: the `top_n_table` service dimension always aggregated the last 7 days regardless of its configured interval; it now honors the window (the continuous-aggregate fast path remains for the 7d default) and supports the Last seen column (#305).
+- **Geo map viewport**: the `geo_map` panel no longer destroys and re-fits the map on every auto-refresh; pan/zoom is preserved across refreshes, the map auto-fits only on first paint or when the panel config changes, and a new "Fit data" control re-frames on demand (#304).
+
 
 ## [1.3.1] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Time series panel window**: the `time_series` panel always rendered the last 24 hours regardless of its configured interval; it now honors the window with adaptive bucketing (1m/5m/15m/1h/1d), zero-filled buckets and date-aware axis labels on multi-day ranges (#305).
 - **Top services window**: the `top_n_table` service dimension always aggregated the last 7 days regardless of its configured interval; it now honors the window (the continuous-aggregate fast path remains for the 7d default) and supports the Last seen column (#305).
-- **Geo map viewport**: the `geo_map` panel no longer destroys and re-fits the map on every auto-refresh; pan/zoom is preserved across refreshes, the map auto-fits only on first paint or when the panel config changes, and a new "Fit data" control re-frames on demand. Mouse wheel over the panel now scrolls the dashboard instead of zooming the map (zoom stays available via the +/- controls, double click and pinch), so scrolling past the panel cannot silently reset the framing (#304).
+- **Geo map viewport**: the `geo_map` panel no longer destroys and re-fits the map on every auto-refresh; pan/zoom is preserved across refreshes, the map auto-fits only on first paint or when the panel config changes, and a new "Fit data" control re-frames on demand. Mouse wheel over the panel now scrolls the dashboard instead of zooming the map (zoom stays available via the +/- controls, double click and pinch), so scrolling past the panel cannot silently reset the framing, and the map no longer paints above open dialogs (Leaflet pane z-indexes are now contained to the panel) (#304).
 
 
 ## [1.3.1] - 2026-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Time series panel window**: the `time_series` panel always rendered the last 24 hours regardless of its configured interval; it now honors the window with adaptive bucketing (1m/5m/15m/1h/1d), zero-filled buckets and date-aware axis labels on multi-day ranges (#305).
 - **Top services window**: the `top_n_table` service dimension always aggregated the last 7 days regardless of its configured interval; it now honors the window (the continuous-aggregate fast path remains for the 7d default) and supports the Last seen column (#305).
-- **Geo map viewport**: the `geo_map` panel no longer destroys and re-fits the map on every auto-refresh; pan/zoom is preserved across refreshes, the map auto-fits only on first paint or when the panel config changes, and a new "Fit data" control re-frames on demand (#304).
+- **Geo map viewport**: the `geo_map` panel no longer destroys and re-fits the map on every auto-refresh; pan/zoom is preserved across refreshes, the map auto-fits only on first paint or when the panel config changes, and a new "Fit data" control re-frames on demand. Mouse wheel over the panel now scrolls the dashboard instead of zooming the map (zoom stays available via the +/- controls, double click and pinch), so scrolling past the panel cannot silently reset the framing (#304).
 
 
 ## [1.3.1] - 2026-08-18

--- a/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
+++ b/packages/backend/src/modules/custom-dashboards/panel-data-service.ts
@@ -30,7 +30,8 @@ import type {
   GeoMapConfig,
   LogTableConfig,
 } from '@logtide/shared';
-import { resolveMetadataPath, formatMetadataCell } from '@logtide/shared';
+import { resolveMetadataPath, formatMetadataCell, panelTimeRangeToMs } from '@logtide/shared';
+import type { PanelTimeRange } from '@logtide/shared';
 import { dashboardService } from '../dashboard/service.js';
 import { alertsService } from '../alerts/service.js';
 import { metricsService } from '../metrics/service.js';
@@ -67,6 +68,9 @@ export interface TimeSeriesPanelData {
     critical: number;
   }>;
   interval: string;
+  // Bucket granularity actually used for the window, so the frontend can pick
+  // a matching axis label style ('1m' | '5m' | '15m' | '1h' | '1d').
+  bucket: string;
 }
 
 export interface SingleStatPanelData {
@@ -222,35 +226,160 @@ export interface SystemStatusData {
 
 // ─── Fetchers ──────────────────────────────────────────────────────────────
 
+// Bucket granularity per window (#305): small windows need sub-hour buckets
+// to draw a useful line, hourly stays readable up to two weeks (14d = 336
+// points), and only the 30d window drops to daily buckets.
+type TimeSeriesBucket = '1m' | '5m' | '15m' | '1h' | '1d';
+
+const TIME_SERIES_BUCKET_MS: Record<TimeSeriesBucket, number> = {
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '15m': 15 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+};
+
+function timeSeriesBucketFor(windowMs: number): TimeSeriesBucket {
+  const hour = 60 * 60 * 1000;
+  if (windowMs <= hour) return '1m';
+  if (windowMs <= 6 * hour) return '5m';
+  if (windowMs <= 12 * hour) return '15m';
+  if (windowMs <= 14 * 24 * hour) return '1h';
+  return '1d';
+}
+
+// Bucket timestamps stepping by stepMs, epoch-floor aligned (the same rule
+// time_bucket / toStartOf* / $dateTrunc use in UTC). The start is CEILED to
+// the first boundary at or after `from`, so the series never begins with a
+// bucket the window only partially covers (it would always render short).
+function buildBucketTimesForStep(from: Date, to: Date, stepMs: number): string[] {
+  const out: string[] = [];
+  for (let t = Math.ceil(from.getTime() / stepMs) * stepMs; t <= to.getTime(); t += stepMs) {
+    out.push(new Date(t).toISOString());
+  }
+  return out;
+}
+
 const timeSeriesFetcher: PanelDataSource<TimeSeriesConfig, TimeSeriesPanelData> = {
   type: 'time_series',
   async fetchData(config, ctx) {
-    // For now, the existing dashboardService.getTimeseries returns last 24h.
-    // Interval other than 24h falls back to whatever the service supports;
-    // future iterations can parameterize the time window in dashboardService.
-    const series = await dashboardService.getTimeseries(
-      ctx.organizationId,
-      config.projectId ?? undefined
-    );
+    const windowMs = panelTimeRangeToMs(config.interval);
+    const bucket = timeSeriesBucketFor(windowMs);
 
-    // Filter levels client-side based on config (the backend already returns
-    // all levels per bucket - we zero out unwanted ones to keep the chart's
-    // type stable).
-    const allowed = new Set(config.levels);
-    const filtered = series.map((point) => ({
-      time: point.time,
-      total: 0,
-      debug: allowed.has('debug') ? point.debug : 0,
-      info: allowed.has('info') ? point.info : 0,
-      warn: allowed.has('warn') ? point.warn : 0,
-      error: allowed.has('error') ? point.error : 0,
-      critical: allowed.has('critical') ? point.critical : 0,
-    }));
-    for (const point of filtered) {
-      point.total = point.debug + point.info + point.warn + point.error + point.critical;
+    const projectIds = config.projectId
+      ? [config.projectId]
+      : await resolveProjectIdsForOrg(ctx.organizationId);
+    if (projectIds.length === 0) {
+      return { series: [], interval: config.interval, bucket };
     }
 
-    return { series: filtered, interval: config.interval };
+    const now = new Date();
+    const from = new Date(now.getTime() - windowMs);
+
+    const bucketTimes = buildBucketTimesForStep(from, now, TIME_SERIES_BUCKET_MS[bucket]);
+    const index = new Map<string, number>();
+    bucketTimes.forEach((t, i) => index.set(t, i));
+    const series: TimeSeriesPanelData['series'] = bucketTimes.map((time) => ({
+      time,
+      total: 0,
+      debug: 0,
+      info: 0,
+      warn: 0,
+      error: 0,
+      critical: 0,
+    }));
+
+    // Levels outside the config stay zero (the chart only draws configured
+    // levels, but the payload shape stays stable) and total counts only the
+    // configured ones, matching the pre-#305 behavior.
+    const allowed = new Set<string>(config.levels);
+    const add = (key: string, level: string, count: number) => {
+      const i = index.get(key);
+      if (i === undefined || count <= 0 || !allowed.has(level)) return;
+      const point = series[i];
+      switch (level) {
+        case 'debug': point.debug += count; break;
+        case 'info': point.info += count; break;
+        case 'warn': point.warn += count; break;
+        case 'error': point.error += count; break;
+        case 'critical': point.critical += count; break;
+        default: return;
+      }
+      point.total += count;
+    };
+
+    const isTimescale = reservoir.getEngineType() === 'timescale';
+
+    if (isTimescale && (bucket === '1h' || bucket === '1d')) {
+      // Cagg fast path with live tail backfill, same strategy (and caveats) as
+      // the activity_overview fetcher: the cagg lags real time, so read it only
+      // up to a bucket-aligned cutoff and take the recent tail from raw logs.
+      const caggBucket = bucket === '1h' ? ('hour' as const) : ('day' as const);
+      const caggTable = bucket === '1h' ? ('logs_hourly_stats' as const) : ('logs_daily_stats' as const);
+      const { caggCutoff, tailEnd } = computeCaggBackfillWindow(now, caggBucket);
+      const trunc = bucket === '1h'
+        ? sql<Date>`date_trunc('hour', time)`
+        : sql<Date>`date_trunc('day', time)`;
+
+      const rawRows = (fromD: Date, toD: Date) => {
+        let q = db
+          .selectFrom('logs')
+          .select([trunc.as('bucket'), 'level', sql<string>`COUNT(*)`.as('count')])
+          .where('project_id', 'in', projectIds)
+          .where('time', '>=', fromD)
+          .where('time', '<', toD);
+        if (config.service) q = q.where('service', '=', config.service);
+        return q
+          .groupBy([trunc, 'level'])
+          .execute()
+          .catch(() => [] as Array<{ bucket: unknown; level: string; count: string }>);
+      };
+
+      let caggQuery = db
+        .selectFrom(caggTable)
+        .select(['bucket', 'level', sql<string>`SUM(log_count)`.as('count')])
+        .where('project_id', 'in', projectIds)
+        .where('bucket', '>=', from)
+        .where('bucket', '<', caggCutoff)
+        .groupBy(['bucket', 'level']);
+      if (config.service) caggQuery = caggQuery.where('service', '=', config.service);
+      const caggRows = await caggQuery
+        .execute()
+        .catch(() => [] as Array<{ bucket: unknown; level: string; count: string }>);
+
+      // Raw fallback when the cagg is still empty (fresh install).
+      const olderRows = caggRows.length > 0 ? caggRows : await rawRows(from, caggCutoff);
+      const tailRows = await rawRows(caggCutoff, tailEnd);
+
+      for (const r of [...olderRows, ...tailRows]) {
+        add(new Date(r.bucket as unknown as string).toISOString(), r.level, Number(r.count ?? 0));
+      }
+    } else {
+      // Minute buckets have no cagg, and ClickHouse / MongoDB have no caggs at
+      // all: aggregate over raw storage through the reservoir abstraction.
+      const aggResult = await reservoir
+        .aggregate({
+          projectId: projectIds,
+          from,
+          to: now,
+          interval: bucket,
+          service: config.service ?? undefined,
+        })
+        .catch(() => ({
+          timeseries: [] as Array<{ bucket: Date; byLevel?: Record<string, number> }>,
+          total: 0,
+        }));
+
+      for (const b of aggResult.timeseries) {
+        const key = (b.bucket instanceof Date ? b.bucket : new Date(b.bucket)).toISOString();
+        if (!b.byLevel) continue;
+        for (const [level, count] of Object.entries(b.byLevel) as Array<[string, number]>) {
+          add(key, level, count);
+        }
+      }
+    }
+
+    return { series, interval: config.interval, bucket };
   },
 };
 
@@ -303,9 +432,12 @@ const TOP_N_METADATA_FIELD = /^[a-zA-Z_][a-zA-Z0-9_.]{0,63}$/;
 const topNTableFetcher: PanelDataSource<TopNTableConfig, TopNTableData> = {
   type: 'top_n_table',
   async fetchData(config, ctx) {
-    if (config.dimension === 'service') {
-      // showLastSeen is ignored here on purpose: this dimension is served by the
-      // continuous-aggregate fast path, which has no per-value max event time.
+    // The classic getTopServices fast path reads the daily continuous
+    // aggregate, but it hardcodes a 7-day window and has no per-value max
+    // event time. Use it only when the config asks for exactly that shape;
+    // every other service-dimension request goes through the same windowed
+    // reservoir path the other dimensions use (#305).
+    if (config.dimension === 'service' && config.interval === '7d' && config.showLastSeen !== true) {
       const services = await dashboardService.getTopServices(
         ctx.organizationId,
         config.limit,
@@ -331,8 +463,36 @@ const topNTableFetcher: PanelDataSource<TopNTableConfig, TopNTableData> = {
     }
 
     const now = new Date();
-    const intervalMs = intervalToMs(config.interval);
+    const intervalMs = panelTimeRangeToMs(config.interval);
     const from = new Date(now.getTime() - intervalMs);
+
+    if (config.dimension === 'service') {
+      // RULING (#299, unchanged): levels/service filters stay metadata-dim
+      // only; the service dimension ranks all logs in the window.
+      const [top, totalResult] = await Promise.all([
+        reservoir.topValues({
+          field: 'service',
+          projectId: projectIds,
+          from,
+          to: now,
+          limit: config.limit,
+          includeLastSeen: config.showLastSeen === true,
+        }),
+        // True total of all logs in the window, so percentages are a share of
+        // the whole (same rule as the metadata/error_message dimensions).
+        reservoir.count({ projectId: projectIds, from, to: now }),
+      ]);
+      const total = totalResult.count;
+      return {
+        rows: top.values.map((v: { value: string; count: number; lastSeen?: string }) => ({
+          key: v.value,
+          count: v.count,
+          percentage: total > 0 ? Math.round((v.count / total) * 100) : 0,
+          ...(v.lastSeen !== undefined ? { lastSeen: v.lastSeen } : {}),
+        })),
+        total,
+      };
+    }
 
     if (config.dimension === 'metadata') {
       // Rank a flat metadata key (GeoIP `geo_place`, `http_host`, ...) with the
@@ -440,7 +600,7 @@ const geoMapFetcher: PanelDataSource<GeoMapConfig, GeoMapData> = {
     }
 
     const now = new Date();
-    const from = new Date(now.getTime() - intervalToMs(config.interval));
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.interval));
 
     const suffix = config.mode === 'country' ? '_country_code' : '_place';
     const result = await reservoir.topValues({
@@ -543,14 +703,6 @@ const liveLogStreamFetcher: PanelDataSource<
   },
 };
 
-const LOG_TABLE_RANGE_MS: Record<LogTableConfig['timeRange'], number> = {
-  '15m': 15 * 60 * 1000,
-  '1h': 60 * 60 * 1000,
-  '6h': 6 * 60 * 60 * 1000,
-  '24h': 24 * 60 * 60 * 1000,
-  '7d': 7 * 24 * 60 * 60 * 1000,
-};
-
 const logTableFetcher: PanelDataSource<LogTableConfig, LogTableSnapshot> = {
   type: 'log_table',
   async fetchData(config, ctx) {
@@ -570,7 +722,7 @@ const logTableFetcher: PanelDataSource<LogTableConfig, LogTableSnapshot> = {
     }
 
     const now = new Date();
-    const from = new Date(now.getTime() - LOG_TABLE_RANGE_MS[config.timeRange]);
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.timeRange));
 
     const result = await reservoir.query({
       projectId: projectIds,
@@ -680,7 +832,7 @@ const metricChartFetcher: PanelDataSource<MetricChartConfig, MetricChartData> = 
     }
 
     const now = new Date();
-    const from = new Date(now.getTime() - timeRangeToMs(config.timeRange));
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.timeRange));
 
     const result = await metricsService.aggregateMetrics({
       projectId: projectIds,
@@ -723,11 +875,11 @@ const metricStatFetcher: PanelDataSource<MetricStatConfig, MetricStatData> = {
     }
 
     const now = new Date();
-    const from = new Date(now.getTime() - timeRangeToMs(config.timeRange));
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.timeRange));
 
-    // Use a single bucket spanning the whole window for the stat value.
-    // 1d is the largest supported aggregation interval that fits any
-    // timeRange this panel exposes (1h, 6h, 24h).
+    // Aggregate at the coarsest supported interval (1d); the combine step
+    // below folds however many buckets the window spans (a 30d range at 1d
+    // interval yields up to 31) into a single stat value.
     const result = await metricsService.aggregateMetrics({
       projectId: projectIds,
       metricName: config.metricName,
@@ -773,7 +925,7 @@ const traceLatencyFetcher: PanelDataSource<TraceLatencyConfig, TraceLatencyData>
     }
 
     const now = new Date();
-    const rangeMs = timeRangeToMs(config.timeRange);
+    const rangeMs = panelTimeRangeToMs(config.timeRange);
     const from = new Date(now.getTime() - rangeMs);
     const bucket: 'hour' | 'day' = rangeMs <= 48 * 60 * 60 * 1000 ? 'hour' : 'day';
 
@@ -809,7 +961,7 @@ const traceVolumeFetcher: PanelDataSource<TraceVolumeConfig, TraceVolumePanelDat
       : await resolveProjectIdsForOrg(ctx.organizationId);
 
     const bucket: 'hour' | 'day' =
-      timeRangeToMs(config.timeRange) <= 48 * 60 * 60 * 1000 ? 'hour' : 'day';
+      panelTimeRangeToMs(config.timeRange) <= 48 * 60 * 60 * 1000 ? 'hour' : 'day';
 
     if (projectIds.length === 0) {
       return {
@@ -821,7 +973,7 @@ const traceVolumeFetcher: PanelDataSource<TraceVolumeConfig, TraceVolumePanelDat
     }
 
     const now = new Date();
-    const from = new Date(now.getTime() - timeRangeToMs(config.timeRange));
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.timeRange));
 
     // Multi-engine span volume straight from raw spans via the reservoir
     // abstraction (works on Timescale, ClickHouse and MongoDB alike).
@@ -853,7 +1005,7 @@ const activityOverviewFetcher: PanelDataSource<
   type: 'activity_overview',
   async fetchData(config, ctx) {
     const bucket: 'hour' | 'day' =
-      timeRangeToMs(config.timeRange) <= 48 * 60 * 60 * 1000 ? 'hour' : 'day';
+      panelTimeRangeToMs(config.timeRange) <= 48 * 60 * 60 * 1000 ? 'hour' : 'day';
     const enabled = new Set(config.series);
 
     const projectIds = config.projectId
@@ -861,7 +1013,7 @@ const activityOverviewFetcher: PanelDataSource<
       : await resolveProjectIdsForOrg(ctx.organizationId);
 
     const now = new Date();
-    const from = new Date(now.getTime() - timeRangeToMs(config.timeRange));
+    const from = new Date(now.getTime() - panelTimeRangeToMs(config.timeRange));
 
     // Build the ordered list of bucket timestamps we expect in the window,
     // truncated to bucket boundary (same rule Postgres date_trunc would use).
@@ -1252,17 +1404,6 @@ const systemStatusFetcher: PanelDataSource<SystemStatusConfig, SystemStatusData>
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
-function timeRangeToMs(range: string): number {
-  switch (range) {
-    case '1h': return 60 * 60 * 1000;
-    case '6h': return 6 * 60 * 60 * 1000;
-    case '24h': return 24 * 60 * 60 * 1000;
-    case '7d': return 7 * 24 * 60 * 60 * 1000;
-    case '30d': return 30 * 24 * 60 * 60 * 1000;
-    default: return 24 * 60 * 60 * 1000;
-  }
-}
-
 async function resolveProjectIdsForOrg(organizationId: string): Promise<string[]> {
   const { db } = await import('../../database/index.js');
   const rows = await db
@@ -1346,17 +1487,6 @@ function buildBucketTimes(
   return out;
 }
 
-function intervalToMs(interval: '1h' | '24h' | '7d'): number {
-  switch (interval) {
-    case '1h':
-      return 60 * 60 * 1000;
-    case '24h':
-      return 24 * 60 * 60 * 1000;
-    case '7d':
-      return 7 * 24 * 60 * 60 * 1000;
-  }
-}
-
 // ─── Registry ──────────────────────────────────────────────────────────────
 
 type AnyFetcher = PanelDataSource<PanelConfig, unknown>;
@@ -1378,6 +1508,35 @@ const dataFetchers: Record<PanelType, AnyFetcher> = {
   geo_map: geoMapFetcher as AnyFetcher,
   log_table: logTableFetcher as AnyFetcher,
 };
+
+/**
+ * Dashboard-level time override (#305): return a copy of the panel config with
+ * its lookback window replaced by `range`. The override is a view-level tool,
+ * never persisted: panels without window semantics (single_stat, streams,
+ * alert/monitor status) and live-mode log tables are returned untouched.
+ */
+export function applyTimeRangeOverride(
+  config: PanelConfig,
+  range: PanelTimeRange
+): PanelConfig {
+  switch (config.type) {
+    case 'time_series':
+    case 'top_n_table':
+    case 'geo_map':
+      return { ...config, interval: range };
+    case 'log_table':
+      return config.mode === 'snapshot' ? { ...config, timeRange: range } : config;
+    case 'metric_chart':
+    case 'metric_stat':
+    case 'trace_latency':
+    case 'trace_volume':
+    case 'detection_events':
+    case 'activity_overview':
+      return { ...config, timeRange: range };
+    default:
+      return config;
+  }
+}
 
 export async function fetchPanelData(
   config: PanelConfig,

--- a/packages/backend/src/modules/custom-dashboards/panel-registry.ts
+++ b/packages/backend/src/modules/custom-dashboards/panel-registry.ts
@@ -14,16 +14,22 @@
 // No other backend file needs to change.
 
 import { z } from 'zod';
+import { PANEL_TIME_RANGES } from '@logtide/shared';
 import type { PanelType, PanelConfig, PanelLayout } from '@logtide/shared';
 
 const levelEnum = z.enum(['debug', 'info', 'warn', 'error', 'critical']);
+
+// One shared preset list for every window-scoped panel (#305). The catalog
+// lives in @logtide/shared so the config forms and this validator can never
+// drift apart.
+const timeRangeEnum = z.enum(PANEL_TIME_RANGES);
 
 const timeSeriesSchema = z.object({
   type: z.literal('time_series'),
   title: z.string().min(1).max(100),
   source: z.literal('logs'),
   projectId: z.string().uuid().nullable(),
-  interval: z.enum(['1h', '6h', '24h', '7d', '30d']),
+  interval: timeRangeEnum,
   levels: z.array(levelEnum).min(1),
   service: z.string().max(200).nullable(),
   // Optional per-level legend/tooltip labels. Absent on every dashboard saved
@@ -66,7 +72,7 @@ const topNTableBaseSchema = z.object({
   metadataField: z.string().regex(TOP_N_METADATA_FIELD).nullable().optional(),
   limit: z.number().int().min(3).max(50),
   projectId: z.string().uuid().nullable(),
-  interval: z.enum(['1h', '24h', '7d']),
+  interval: timeRangeEnum,
   showLastSeen: z.boolean().optional(),
   levels: z.array(levelEnum).optional(),
   service: z.string().max(200).nullable().optional(),
@@ -127,7 +133,7 @@ const metricChartSchema = z.object({
   metricName: z.string().min(1).max(255),
   aggregation: metricAggregationEnum,
   interval: metricIntervalEnum,
-  timeRange: z.enum(['1h', '6h', '24h', '7d', '30d']),
+  timeRange: timeRangeEnum,
   serviceName: z.string().max(200).nullable(),
 });
 
@@ -138,7 +144,7 @@ const metricStatSchema = z.object({
   projectId: z.string().uuid().nullable(),
   metricName: z.string().min(1).max(255),
   aggregation: metricAggregationEnum,
-  timeRange: z.enum(['1h', '6h', '24h']),
+  timeRange: timeRangeEnum,
   serviceName: z.string().max(200).nullable(),
   unit: z.string().max(20).nullable(),
 });
@@ -149,7 +155,7 @@ const traceLatencySchema = z.object({
   source: z.literal('traces'),
   projectId: z.string().uuid().nullable(),
   serviceName: z.string().max(200).nullable(),
-  timeRange: z.enum(['1h', '6h', '24h', '7d']),
+  timeRange: timeRangeEnum,
   showPercentiles: z.array(z.enum(['p50', 'p95', 'p99'])).min(1),
 });
 
@@ -159,7 +165,7 @@ const traceVolumeSchema = z.object({
   source: z.literal('traces'),
   projectId: z.string().uuid().nullable(),
   serviceName: z.string().max(200).nullable(),
-  timeRange: z.enum(['1h', '6h', '24h', '7d']),
+  timeRange: timeRangeEnum,
   showErrors: z.boolean(),
 });
 
@@ -168,7 +174,7 @@ const detectionEventsSchema = z.object({
   title: z.string().min(1).max(100),
   source: z.literal('detections'),
   projectId: z.string().uuid().nullable(),
-  timeRange: z.enum(['24h', '7d', '30d']),
+  timeRange: timeRangeEnum,
   severities: z
     .array(z.enum(['critical', 'high', 'medium', 'low', 'informational']))
     .min(1),
@@ -205,7 +211,7 @@ const activityOverviewSchema = z.object({
   title: z.string().min(1).max(100),
   source: z.literal('mixed'),
   projectId: z.string().uuid().nullable(),
-  timeRange: z.enum(['24h', '7d', '30d']),
+  timeRange: timeRangeEnum,
   series: z.array(activityOverviewSeriesEnum).min(1),
 });
 
@@ -218,7 +224,7 @@ const geoMapSchema = z.object({
   title: z.string().min(1).max(100),
   source: z.literal('logs'),
   projectId: z.string().uuid().nullable(),
-  interval: z.enum(['1h', '24h', '7d']),
+  interval: timeRangeEnum,
   mode: z.enum(['country', 'points']),
   limit: z.number().int().min(10).max(500),
   fieldPrefix: z.string().regex(/^[a-zA-Z_][a-zA-Z0-9_]{0,31}$/),
@@ -238,7 +244,7 @@ const logTableBaseSchema = z.object({
   source: z.literal('logs'),
   projectId: z.string().uuid().nullable(),
   mode: z.enum(['snapshot', 'live']),
-  timeRange: z.enum(['15m', '1h', '6h', '24h', '7d']),
+  timeRange: timeRangeEnum,
   levels: z.array(levelEnum),
   service: z.string().max(200).nullable(),
   maxRows: z.number().int().min(10).max(100),

--- a/packages/backend/src/modules/custom-dashboards/routes.ts
+++ b/packages/backend/src/modules/custom-dashboards/routes.ts
@@ -4,7 +4,8 @@ import { authenticate } from '../auth/middleware.js';
 import { OrganizationsService } from '../organizations/service.js';
 import { customDashboardsService } from './service.js';
 import { panelInstanceSchema } from './panel-registry.js';
-import { fetchPanelData } from './panel-data-service.js';
+import { fetchPanelData, applyTimeRangeOverride } from './panel-data-service.js';
+import { PANEL_TIME_RANGES } from '@logtide/shared';
 import { context } from '@logtide/shared/context';
 import { assertWithinLimit, withLimitLock } from '../../capabilities/index.js';
 import { CapabilityError } from '../../capabilities/errors.js';
@@ -36,6 +37,9 @@ const importYamlSchema = z.object({
 const panelDataBatchSchema = z.object({
   organizationId: z.string().uuid(),
   panelIds: z.array(z.string()).optional(),
+  // Dashboard-level time override (#305): applied to every window-scoped
+  // panel for this request only, never persisted.
+  timeRange: z.enum(PANEL_TIME_RANGES).optional(),
 });
 
 async function checkMembership(userId: string, orgId: string): Promise<boolean> {
@@ -368,7 +372,12 @@ export async function customDashboardsRoutes(fastify: FastifyInstance) {
       const ctx = { organizationId: body.organizationId, userId: request.user.id };
       const settled = await Promise.allSettled(
         panelsToFetch.map((panel) =>
-          fetchPanelData(panel.config, ctx).then((data) => ({
+          fetchPanelData(
+            body.timeRange
+              ? applyTimeRangeOverride(panel.config, body.timeRange)
+              : panel.config,
+            ctx
+          ).then((data) => ({
             id: panel.id,
             data,
           }))

--- a/packages/backend/src/modules/siem/dashboard-service.ts
+++ b/packages/backend/src/modules/siem/dashboard-service.ts
@@ -1,5 +1,5 @@
 import { Kysely, sql } from 'kysely';
-import { MITRE_TECHNIQUES } from '@logtide/shared';
+import { MITRE_TECHNIQUES, panelTimeRangeToMs } from '@logtide/shared';
 import type { Database } from '../../database/types';
 import type {
   DashboardStats,
@@ -338,40 +338,26 @@ export class SiemDashboardService {
     };
   }
 
-  private getTimeRange(timeRange: '24h' | '7d' | '30d'): {
+  private getTimeRange(timeRange: string): {
     startTime: Date;
     endTime: Date;
   } {
     const endTime = new Date();
-    const startTime = new Date();
-
-    switch (timeRange) {
-      case '24h':
-        startTime.setHours(startTime.getHours() - 24);
-        break;
-      case '7d':
-        startTime.setDate(startTime.getDate() - 7);
-        break;
-      case '30d':
-        startTime.setDate(startTime.getDate() - 30);
-        break;
-    }
-
+    const startTime = new Date(endTime.getTime() - panelTimeRangeToMs(timeRange));
     return { startTime, endTime };
   }
 
-  private getBucketInterval(
-    timeRange: '24h' | '7d' | '30d'
-  ): string {
-    switch (timeRange) {
-      case '24h':
-        return '1 hour';
-      case '7d':
-        return '6 hours';
-      case '30d':
-        return '1 day';
-      default:
-        return '1 hour';
-    }
+  // Timeline bucket width by window size. The historical mapping is preserved
+  // (24h -> 1 hour, 7d -> 6 hours, 30d -> 1 day); the added tiers serve the
+  // wider panel presets (#305).
+  private getBucketInterval(timeRange: string): string {
+    const hour = 60 * 60 * 1000;
+    const ms = panelTimeRangeToMs(timeRange);
+    if (ms <= hour) return '5 minutes';
+    if (ms <= 6 * hour) return '15 minutes';
+    if (ms <= 12 * hour) return '30 minutes';
+    if (ms <= 48 * hour) return '1 hour';
+    if (ms <= 14 * 24 * hour) return '6 hours';
+    return '1 day';
   }
 }

--- a/packages/backend/src/tests/modules/custom-dashboards/panel-data-service.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/panel-data-service.test.ts
@@ -273,6 +273,70 @@ describe('time_series panel', () => {
       ),
     ).rejects.toThrow(/belong/);
   });
+
+  // #305: the fetcher used to delegate to dashboardService.getTimeseries,
+  // which hardcoded a 24h window whatever the configured interval said.
+  const windowBase = () => ({
+    type: 'time_series' as const,
+    title: 'Window',
+    source: 'logs' as const,
+    projectId,
+    levels: ['debug', 'info', 'warn', 'error', 'critical'] as Array<'debug' | 'info' | 'warn' | 'error' | 'critical'>,
+    service: null,
+  });
+  const sumSeries = (r: { series: Array<{ total: number }> }) =>
+    r.series.reduce((acc, p) => acc + p.total, 0);
+
+  it('honors the configured window (#305)', async () => {
+    // A log 3 days old: outside a 24h window, inside a 7d one.
+    await createTestLog({
+      projectId,
+      service: 'api',
+      level: 'info',
+      message: 'old log',
+      time: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    });
+
+    const day = (await fetchPanelData({ ...windowBase(), interval: '24h' }, ctx())) as {
+      series: Array<{ total: number }>; bucket: string;
+    };
+    const week = (await fetchPanelData({ ...windowBase(), interval: '7d' }, ctx())) as {
+      series: Array<{ total: number }>; bucket: string;
+    };
+
+    expect(day.bucket).toBe('1h');
+    expect(week.bucket).toBe('1h');
+    expect(sumSeries(day)).toBe(3); // the three fresh seeded logs
+    expect(sumSeries(week)).toBe(4); // plus the 3-day-old one
+  });
+
+  it('uses minute buckets for a 1h window (#305)', async () => {
+    const result = (await fetchPanelData({ ...windowBase(), interval: '1h' }, ctx())) as {
+      series: Array<{ total: number; time: string }>; bucket: string;
+    };
+    expect(result.bucket).toBe('1m');
+    expect(sumSeries(result)).toBe(3);
+    // Zero-filled minute buckets across the hour.
+    expect(result.series.length).toBeGreaterThanOrEqual(59);
+  });
+
+  it('uses day buckets for a 30d window (#305)', async () => {
+    const result = (await fetchPanelData({ ...windowBase(), interval: '30d' }, ctx())) as {
+      series: Array<{ total: number }>; bucket: string;
+    };
+    expect(result.bucket).toBe('1d');
+    expect(sumSeries(result)).toBe(3);
+    expect(result.series.length).toBeGreaterThanOrEqual(29);
+  });
+
+  it('applies the service filter (#305)', async () => {
+    const result = (await fetchPanelData(
+      { ...windowBase(), interval: '24h', service: 'api' },
+      ctx(),
+    )) as { series: Array<{ total: number }> };
+    // Seeded: api info + api error + worker warn; worker must be excluded.
+    expect(sumSeries(result)).toBe(2);
+  });
 });
 
 // ─── single_stat ──────────────────────────────────────────────────────────────
@@ -401,6 +465,45 @@ describe('top_n_table panel', () => {
         ctx(),
       ),
     ).rejects.toThrow(/belong/);
+  });
+
+  it('service dimension honors the interval window (#305)', async () => {
+    // A service that only logged 3 days ago must not rank in a 24h window.
+    await createTestLog({
+      projectId,
+      service: 'ancient',
+      level: 'info',
+      message: 'old service log',
+      time: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    });
+
+    const day = (await fetchPanelData(
+      {
+        type: 'top_n_table',
+        title: 'Top services',
+        source: 'logs',
+        dimension: 'service',
+        limit: 10,
+        projectId,
+        interval: '24h',
+      },
+      ctx(),
+    )) as { rows: Array<{ key: string }> };
+    expect(day.rows.map((r) => r.key)).not.toContain('ancient');
+
+    const month = (await fetchPanelData(
+      {
+        type: 'top_n_table',
+        title: 'Top services',
+        source: 'logs',
+        dimension: 'service',
+        limit: 10,
+        projectId,
+        interval: '30d',
+      },
+      ctx(),
+    )) as { rows: Array<{ key: string }> };
+    expect(month.rows.map((r) => r.key)).toContain('ancient');
   });
 
   it('metadata dimension: ranks values with counts and lastSeen', async () => {

--- a/packages/backend/src/tests/modules/custom-dashboards/panel-registry.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/panel-registry.test.ts
@@ -445,3 +445,81 @@ describe('live_log_stream schema', () => {
     expect(panelConfigSchema.safeParse({ ...valid, maxRows: 9 }).success).toBe(false);
   });
 });
+
+describe('panel time range presets (#305)', () => {
+  const configs: Record<string, Record<string, unknown>> = {
+    time_series: {
+      type: 'time_series', title: 'T', source: 'logs', projectId: null,
+      interval: '24h', levels: ['info'], service: null,
+    },
+    top_n_table: {
+      type: 'top_n_table', title: 'T', source: 'logs', dimension: 'service',
+      limit: 5, projectId: null, interval: '24h',
+    },
+    geo_map: {
+      type: 'geo_map', title: 'T', source: 'logs', projectId: null,
+      interval: '24h', mode: 'country', limit: 100, fieldPrefix: 'geo',
+      levels: [], service: null, hostname: null,
+    },
+    log_table: {
+      type: 'log_table', title: 'T', source: 'logs', projectId: null,
+      mode: 'snapshot', timeRange: '1h', levels: [], service: null,
+      maxRows: 25, columns: [], builtinColumns: ['time', 'message'], wrapCells: false,
+    },
+    metric_chart: {
+      type: 'metric_chart', title: 'T', source: 'metrics', projectId: null,
+      metricName: 'cpu', aggregation: 'avg', interval: '5m', timeRange: '24h',
+      serviceName: null,
+    },
+    metric_stat: {
+      type: 'metric_stat', title: 'T', source: 'metrics', projectId: null,
+      metricName: 'cpu', aggregation: 'last', timeRange: '1h',
+      serviceName: null, unit: null,
+    },
+    trace_latency: {
+      type: 'trace_latency', title: 'T', source: 'traces', projectId: null,
+      serviceName: null, timeRange: '24h', showPercentiles: ['p95'],
+    },
+    trace_volume: {
+      type: 'trace_volume', title: 'T', source: 'traces', projectId: null,
+      serviceName: null, timeRange: '24h', showErrors: true,
+    },
+    detection_events: {
+      type: 'detection_events', title: 'T', source: 'detections', projectId: null,
+      timeRange: '24h', severities: ['high'],
+    },
+    activity_overview: {
+      type: 'activity_overview', title: 'T', source: 'mixed', projectId: null,
+      timeRange: '24h', series: ['logs'],
+    },
+  };
+
+  const timeField: Record<string, string> = {
+    time_series: 'interval',
+    top_n_table: 'interval',
+    geo_map: 'interval',
+    log_table: 'timeRange',
+    metric_chart: 'timeRange',
+    metric_stat: 'timeRange',
+    trace_latency: 'timeRange',
+    trace_volume: 'timeRange',
+    detection_events: 'timeRange',
+    activity_overview: 'timeRange',
+  };
+
+  const presets = ['15m', '1h', '6h', '12h', '24h', '48h', '3d', '7d', '14d', '30d'];
+
+  for (const [type, base] of Object.entries(configs)) {
+    it(`accepts every shared preset on ${type}`, () => {
+      for (const preset of presets) {
+        const result = panelConfigSchema.safeParse({ ...base, [timeField[type]]: preset });
+        expect(result.success, `${type} should accept ${preset}`).toBe(true);
+      }
+    });
+
+    it(`rejects an unknown preset on ${type}`, () => {
+      const result = panelConfigSchema.safeParse({ ...base, [timeField[type]]: '2h' });
+      expect(result.success).toBe(false);
+    });
+  }
+});

--- a/packages/backend/src/tests/modules/custom-dashboards/panel-time-window.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/panel-time-window.test.ts
@@ -1,0 +1,347 @@
+// ============================================================================
+// Panel time window tests (#305)
+// ============================================================================
+//
+// Deterministic (mocked reservoir + dashboardService) coverage for:
+//   - time_series bucket rule and window propagation
+//   - top_n_table service dimension path split (cagg fast path vs topValues)
+//   - applyTimeRangeOverride (the dashboard-level override)
+//
+// The Timescale cagg path of time_series is covered by the integration tests
+// in panel-data-service.test.ts against the real test database.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { db } from '../../../database/index.js';
+import { createTestContext } from '../../helpers/factories.js';
+
+vi.mock('../../../database/reservoir.js', () => ({
+  reservoir: {
+    getEngineType: vi.fn(() => 'clickhouse'),
+    aggregate: vi.fn(async () => ({ timeseries: [], total: 0 })),
+    topValues: vi.fn(async () => ({ values: [] })),
+    count: vi.fn(async () => ({ count: 0 })),
+  },
+}));
+
+vi.mock('../../../modules/dashboard/service.js', () => ({
+  dashboardService: {
+    getTimeseries: vi.fn(async () => []),
+    getTopServices: vi.fn(async () => []),
+    getStats: vi.fn(),
+  },
+}));
+
+// Import AFTER the mocks so the module under test picks them up.
+import {
+  fetchPanelData,
+  applyTimeRangeOverride,
+} from '../../../modules/custom-dashboards/panel-data-service.js';
+import { reservoir } from '../../../database/reservoir.js';
+import { dashboardService } from '../../../modules/dashboard/service.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+let projectId: string;
+let organizationId: string;
+
+function ctx() {
+  return { organizationId, userId: 'test-user' };
+}
+
+beforeEach(async () => {
+  await db.deleteFrom('api_keys').execute();
+  await db.deleteFrom('organization_members').execute();
+  await db.deleteFrom('projects').execute();
+  await db.deleteFrom('organizations').execute();
+  await db.deleteFrom('sessions').execute();
+  await db.deleteFrom('users').execute();
+
+  const testCtx = await createTestContext();
+  projectId = testCtx.project.id;
+  organizationId = testCtx.organization.id;
+
+  vi.clearAllMocks();
+  vi.mocked(reservoir.getEngineType).mockReturnValue('clickhouse');
+  vi.mocked(reservoir.aggregate).mockResolvedValue({ timeseries: [], total: 0 });
+  vi.mocked(reservoir.topValues).mockResolvedValue({ values: [] } as never);
+  vi.mocked(reservoir.count).mockResolvedValue({ count: 0 } as never);
+});
+
+function timeSeriesConfig(interval: string, extra: Record<string, unknown> = {}) {
+  return {
+    type: 'time_series',
+    title: 'T',
+    source: 'logs',
+    projectId,
+    interval,
+    levels: ['debug', 'info', 'warn', 'error', 'critical'],
+    service: null,
+    ...extra,
+  } as never;
+}
+
+describe('time_series window and bucket rule (#305)', () => {
+  const bucketCases: Array<[string, string, number]> = [
+    // [interval, expected aggregate bucket, expected window ms]
+    ['15m', '1m', 15 * 60 * 1000],
+    ['1h', '1m', HOUR_MS],
+    ['6h', '5m', 6 * HOUR_MS],
+    ['12h', '15m', 12 * HOUR_MS],
+    ['24h', '1h', 24 * HOUR_MS],
+    ['48h', '1h', 48 * HOUR_MS],
+    ['7d', '1h', 7 * 24 * HOUR_MS],
+    ['14d', '1h', 14 * 24 * HOUR_MS],
+    ['30d', '1d', 30 * 24 * HOUR_MS],
+  ];
+
+  for (const [interval, expectedBucket, windowMs] of bucketCases) {
+    it(`interval ${interval} aggregates at ${expectedBucket} over the right window`, async () => {
+      const before = Date.now();
+      const result = (await fetchPanelData(timeSeriesConfig(interval), ctx())) as {
+        bucket: string;
+        interval: string;
+      };
+      const after = Date.now();
+
+      expect(result.interval).toBe(interval);
+      expect(result.bucket).toBe(expectedBucket);
+
+      expect(reservoir.aggregate).toHaveBeenCalledTimes(1);
+      const params = vi.mocked(reservoir.aggregate).mock.calls[0][0] as {
+        from: Date;
+        to: Date;
+        interval: string;
+        projectId: string[];
+      };
+      expect(params.interval).toBe(expectedBucket);
+      expect(params.projectId).toEqual([projectId]);
+      // from = to - window, with a little slack for test execution time
+      expect(params.to.getTime() - params.from.getTime()).toBe(windowMs);
+      expect(params.to.getTime()).toBeGreaterThanOrEqual(before);
+      expect(params.to.getTime()).toBeLessThanOrEqual(after);
+    });
+  }
+
+  it('no longer goes through dashboardService.getTimeseries', async () => {
+    await fetchPanelData(timeSeriesConfig('24h'), ctx());
+    expect(dashboardService.getTimeseries).not.toHaveBeenCalled();
+  });
+
+  it('passes the service filter through to the aggregate query', async () => {
+    await fetchPanelData(timeSeriesConfig('24h', { service: 'api' }), ctx());
+    expect(reservoir.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({ service: 'api' }),
+    );
+  });
+
+  it('maps byLevel buckets into the series and zero-fills the window', async () => {
+    const bucket = new Date(Math.floor(Date.now() / HOUR_MS) * HOUR_MS - 2 * HOUR_MS);
+    vi.mocked(reservoir.aggregate).mockResolvedValue({
+      timeseries: [
+        {
+          bucket,
+          total: 15,
+          byLevel: { debug: 0, info: 10, warn: 2, error: 2, critical: 1 },
+        },
+      ],
+      total: 15,
+    });
+
+    const result = (await fetchPanelData(timeSeriesConfig('24h'), ctx())) as {
+      series: Array<{ time: string; total: number; info: number; error: number }>;
+    };
+
+    // 24h window at 1h buckets: 24 or 25 buckets depending on alignment.
+    expect(result.series.length).toBeGreaterThanOrEqual(24);
+    expect(result.series.length).toBeLessThanOrEqual(25);
+
+    const hit = result.series.find((s) => new Date(s.time).getTime() === bucket.getTime());
+    expect(hit).toBeDefined();
+    expect(hit!.info).toBe(10);
+    expect(hit!.error).toBe(2);
+    expect(hit!.total).toBe(15);
+
+    // Every other bucket exists and is zero-filled.
+    for (const point of result.series) {
+      if (point.time !== hit!.time) expect(point.total).toBe(0);
+    }
+  });
+
+  it('zeroes out levels excluded by the config and recomputes total', async () => {
+    const bucket = new Date(Math.floor(Date.now() / HOUR_MS) * HOUR_MS - 2 * HOUR_MS);
+    vi.mocked(reservoir.aggregate).mockResolvedValue({
+      timeseries: [
+        {
+          bucket,
+          total: 15,
+          byLevel: { debug: 4, info: 10, warn: 0, error: 1, critical: 0 },
+        },
+      ],
+      total: 15,
+    });
+
+    const result = (await fetchPanelData(
+      timeSeriesConfig('24h', { levels: ['info'] }),
+      ctx(),
+    )) as { series: Array<{ time: string; total: number; info: number; debug: number; error: number }> };
+
+    const hit = result.series.find((s) => new Date(s.time).getTime() === bucket.getTime());
+    expect(hit).toBeDefined();
+    expect(hit!.info).toBe(10);
+    expect(hit!.debug).toBe(0);
+    expect(hit!.error).toBe(0);
+    expect(hit!.total).toBe(10);
+  });
+
+  it('renders an all-zero series when the aggregate query fails', async () => {
+    vi.mocked(reservoir.aggregate).mockRejectedValue(new Error('engine down'));
+    const result = (await fetchPanelData(timeSeriesConfig('24h'), ctx())) as {
+      series: Array<{ total: number }>;
+    };
+    expect(result.series.length).toBeGreaterThan(0);
+    expect(result.series.every((s) => s.total === 0)).toBe(true);
+  });
+});
+
+describe('top_n_table service dimension window (#305)', () => {
+  function topNConfig(interval: string, extra: Record<string, unknown> = {}) {
+    return {
+      type: 'top_n_table',
+      title: 'Top services',
+      source: 'logs',
+      dimension: 'service',
+      limit: 5,
+      projectId,
+      interval,
+      ...extra,
+    } as never;
+  }
+
+  it('keeps the cagg fast path for the 7d default', async () => {
+    vi.mocked(dashboardService.getTopServices).mockResolvedValue([
+      { name: 'api', count: 10, percentage: 100 },
+    ]);
+
+    const result = (await fetchPanelData(topNConfig('7d'), ctx())) as {
+      rows: Array<{ key: string }>;
+    };
+
+    expect(dashboardService.getTopServices).toHaveBeenCalledWith(organizationId, 5, projectId);
+    expect(reservoir.topValues).not.toHaveBeenCalled();
+    expect(result.rows[0].key).toBe('api');
+  });
+
+  it('honors a non-7d window through reservoir.topValues', async () => {
+    vi.mocked(reservoir.topValues).mockResolvedValue({
+      values: [{ value: 'api', count: 8 }],
+    } as never);
+    vi.mocked(reservoir.count).mockResolvedValue({ count: 10 } as never);
+
+    const result = (await fetchPanelData(topNConfig('48h'), ctx())) as {
+      rows: Array<{ key: string; count: number; percentage: number }>;
+      total: number;
+    };
+
+    expect(dashboardService.getTopServices).not.toHaveBeenCalled();
+    expect(reservoir.topValues).toHaveBeenCalledTimes(1);
+    const params = vi.mocked(reservoir.topValues).mock.calls[0][0] as {
+      field: string;
+      from: Date;
+      to: Date;
+      limit: number;
+    };
+    expect(params.field).toBe('service');
+    expect(params.limit).toBe(5);
+    expect(params.to.getTime() - params.from.getTime()).toBe(48 * HOUR_MS);
+
+    expect(result.rows).toEqual([{ key: 'api', count: 8, percentage: 80 }]);
+    expect(result.total).toBe(10);
+  });
+
+  it('uses the windowed path for 7d when showLastSeen is on', async () => {
+    vi.mocked(reservoir.topValues).mockResolvedValue({
+      values: [{ value: 'api', count: 3, lastSeen: '2026-08-20T10:00:00.000Z' }],
+    } as never);
+    vi.mocked(reservoir.count).mockResolvedValue({ count: 3 } as never);
+
+    const result = (await fetchPanelData(topNConfig('7d', { showLastSeen: true }), ctx())) as {
+      rows: Array<{ key: string; lastSeen?: string }>;
+    };
+
+    expect(dashboardService.getTopServices).not.toHaveBeenCalled();
+    expect(reservoir.topValues).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'service', includeLastSeen: true }),
+    );
+    expect(result.rows[0].lastSeen).toBe('2026-08-20T10:00:00.000Z');
+  });
+});
+
+describe('applyTimeRangeOverride (#305)', () => {
+  it('replaces interval on time_series, top_n_table and geo_map', () => {
+    const ts = applyTimeRangeOverride(
+      { type: 'time_series', title: 'T', source: 'logs', projectId: null, interval: '24h', levels: ['info'], service: null },
+      '48h',
+    );
+    expect(ts).toMatchObject({ type: 'time_series', interval: '48h' });
+
+    const topN = applyTimeRangeOverride(
+      { type: 'top_n_table', title: 'T', source: 'logs', dimension: 'service', limit: 5, projectId: null, interval: '7d' },
+      '3d',
+    );
+    expect(topN).toMatchObject({ type: 'top_n_table', interval: '3d' });
+
+    const geo = applyTimeRangeOverride(
+      { type: 'geo_map', title: 'T', source: 'logs', projectId: null, interval: '24h', mode: 'country', limit: 100, fieldPrefix: 'geo', levels: [], service: null, hostname: null },
+      '14d',
+    );
+    expect(geo).toMatchObject({ type: 'geo_map', interval: '14d' });
+  });
+
+  it('replaces timeRange on the timeRange-scoped panels', () => {
+    for (const config of [
+      { type: 'metric_chart', title: 'T', source: 'metrics', projectId: null, metricName: 'cpu', aggregation: 'avg', interval: '5m', timeRange: '24h', serviceName: null },
+      { type: 'metric_stat', title: 'T', source: 'metrics', projectId: null, metricName: 'cpu', aggregation: 'last', timeRange: '1h', serviceName: null, unit: null },
+      { type: 'trace_latency', title: 'T', source: 'traces', projectId: null, serviceName: null, timeRange: '24h', showPercentiles: ['p95'] },
+      { type: 'trace_volume', title: 'T', source: 'traces', projectId: null, serviceName: null, timeRange: '24h', showErrors: true },
+      { type: 'detection_events', title: 'T', source: 'detections', projectId: null, timeRange: '24h', severities: ['high'] },
+      { type: 'activity_overview', title: 'T', source: 'mixed', projectId: null, timeRange: '24h', series: ['logs'] },
+    ] as never[]) {
+      const result = applyTimeRangeOverride(config, '48h') as { timeRange: string };
+      expect(result.timeRange).toBe('48h');
+    }
+  });
+
+  it('overrides snapshot log tables but leaves live mode alone', () => {
+    const base = {
+      type: 'log_table', title: 'T', source: 'logs', projectId: null,
+      timeRange: '1h', levels: [], service: null, maxRows: 25,
+      columns: [], builtinColumns: ['time'], wrapCells: false,
+    };
+    const snapshot = applyTimeRangeOverride({ ...base, mode: 'snapshot' } as never, '48h');
+    expect(snapshot).toMatchObject({ timeRange: '48h' });
+
+    const live = { ...base, mode: 'live', projectId: 'p1' } as never;
+    expect(applyTimeRangeOverride(live, '48h')).toBe(live);
+  });
+
+  it('leaves windowless panels untouched', () => {
+    for (const config of [
+      { type: 'single_stat', title: 'T', source: 'logs', metric: 'total_logs', projectId: null, compareWithPrevious: true },
+      { type: 'live_log_stream', title: 'T', source: 'logs', projectId: null, service: null, levels: ['info'], maxRows: 25 },
+      { type: 'alert_status', title: 'T', source: 'alerts', projectId: null, ruleIds: [], showHistory: true, limit: 5 },
+      { type: 'monitor_status', title: 'T', source: 'monitors', projectId: null, monitorIds: [], limit: 5 },
+      { type: 'system_status', title: 'T', source: 'monitors', projectId: null, showCounts: true },
+    ] as never[]) {
+      expect(applyTimeRangeOverride(config, '48h')).toBe(config);
+    }
+  });
+
+  it('does not mutate the input config', () => {
+    const config = {
+      type: 'time_series', title: 'T', source: 'logs', projectId: null,
+      interval: '24h', levels: ['info'], service: null,
+    } as never;
+    applyTimeRangeOverride(config, '48h');
+    expect((config as { interval: string }).interval).toBe('24h');
+  });
+});

--- a/packages/backend/src/tests/modules/custom-dashboards/routes.test.ts
+++ b/packages/backend/src/tests/modules/custom-dashboards/routes.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import Fastify, { FastifyInstance } from 'fastify';
 import { customDashboardsRoutes } from '../../../modules/custom-dashboards/routes.js';
+import { fetchPanelData } from '../../../modules/custom-dashboards/panel-data-service.js';
 import { createTestContext, createTestSession } from '../../helpers/index.js';
 
 // Mock panel data service so we don't need real DB queries for data endpoint
-vi.mock('../../../modules/custom-dashboards/panel-data-service.js', () => ({
-  fetchPanelData: vi.fn().mockResolvedValue({ rows: [] }),
-}));
+// Partial mock: fetchPanelData is stubbed (its behavior has its own suites),
+// while applyTimeRangeOverride stays real so the batch route's override
+// wiring is exercised end to end.
+vi.mock('../../../modules/custom-dashboards/panel-data-service.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../modules/custom-dashboards/panel-data-service.js')
+  >();
+  return {
+    ...actual,
+    fetchPanelData: vi.fn().mockResolvedValue({ rows: [] }),
+  };
+});
 
 function authHeaders(token: string) {
   return { Authorization: `Bearer ${token}` };
@@ -458,6 +468,59 @@ describe('POST /api/v1/dashboards/:id/panels/data', () => {
       url: `/api/v1/dashboards/00000000-0000-0000-0000-000000000000/panels/data`,
       headers: authHeaders(authToken),
       payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('applies the dashboard-level timeRange override (#305)', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/dashboards',
+      headers: authHeaders(authToken),
+      payload: {
+        organizationId: ctx.organization.id,
+        name: 'Override dash',
+        panels: [makePanel('p-override')],
+      },
+    });
+    const { dashboard } = JSON.parse(createRes.payload);
+
+    // The stored panel is a 24h time_series; with the override the fetcher
+    // must receive a config rewritten to 15m for this request only.
+    vi.mocked(fetchPanelData).mockClear();
+    const overridden = await app.inject({
+      method: 'POST',
+      url: `/api/v1/dashboards/${dashboard.id}/panels/data`,
+      headers: authHeaders(authToken),
+      payload: { organizationId: ctx.organization.id, timeRange: '15m' },
+    });
+    expect(overridden.statusCode).toBe(200);
+    expect(fetchPanelData).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'time_series', interval: '15m' }),
+      expect.anything(),
+    );
+
+    // Without the override the stored config wins again (nothing persisted).
+    vi.mocked(fetchPanelData).mockClear();
+    const plain = await app.inject({
+      method: 'POST',
+      url: `/api/v1/dashboards/${dashboard.id}/panels/data`,
+      headers: authHeaders(authToken),
+      payload: { organizationId: ctx.organization.id },
+    });
+    expect(plain.statusCode).toBe(200);
+    expect(fetchPanelData).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'time_series', interval: '24h' }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects an unknown timeRange override', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/dashboards/00000000-0000-0000-0000-000000000000/panels/data`,
+      headers: authHeaders(authToken),
+      payload: { organizationId: ctx.organization.id, timeRange: '2h' },
     });
     expect(res.statusCode).toBe(400);
   });

--- a/packages/frontend/src/lib/api/custom-dashboards.ts
+++ b/packages/frontend/src/lib/api/custom-dashboards.ts
@@ -7,6 +7,7 @@ import { getAuthToken } from '$lib/utils/auth';
 import type {
   CustomDashboard,
   PanelInstance,
+  PanelTimeRange,
 } from '@logtide/shared';
 
 export type { CustomDashboard, PanelInstance } from '@logtide/shared';
@@ -138,13 +139,14 @@ class CustomDashboardsAPI {
   async fetchPanelData(
     dashboardId: string,
     organizationId: string,
-    panelIds?: string[]
+    panelIds?: string[],
+    timeRange?: PanelTimeRange
   ): Promise<PanelDataBatchResponse> {
     return this.request<PanelDataBatchResponse>(
       `/${dashboardId}/panels/data`,
       {
         method: 'POST',
-        body: JSON.stringify({ organizationId, panelIds }),
+        body: JSON.stringify({ organizationId, panelIds, timeRange }),
       }
     );
   }

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/ActivityOverviewConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/ActivityOverviewConfigForm.svelte
@@ -12,6 +12,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: ActivityOverviewConfig;
@@ -20,7 +21,6 @@
 
   let { config, onChange }: Props = $props();
 
-  const timeRanges = ['24h', '7d', '30d'] as const;
   const seriesOptions: Array<{ key: ActivityOverviewSeries; label: string }> = [
     { key: 'logs', label: 'Logs' },
     { key: 'log_errors', label: 'Log errors' },
@@ -69,11 +69,11 @@
         v && update('timeRange', v as ActivityOverviewConfig['timeRange'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.timeRange}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each timeRanges as r}
-          <SelectItem value={r}>{r}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/DetectionEventsConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/DetectionEventsConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: DetectionEventsConfig;
@@ -17,7 +18,6 @@
 
   let { config, onChange }: Props = $props();
 
-  const ranges: DetectionEventsConfig['timeRange'][] = ['24h', '7d', '30d'];
   const severities: Array<'critical' | 'high' | 'medium' | 'low' | 'informational'> = [
     'critical',
     'high',
@@ -64,11 +64,11 @@
       onValueChange={(v) => v && update('timeRange', v as DetectionEventsConfig['timeRange'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.timeRange}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each ranges as r}
-          <SelectItem value={r}>{r}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/GeoMapConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/GeoMapConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: GeoMapConfig;
@@ -22,7 +23,6 @@
     { value: 'points', label: 'By location (points)' },
   ];
 
-  const intervals: Array<GeoMapConfig['interval']> = ['1h', '24h', '7d'];
   const allLevels: LogLevelKey[] = ['debug', 'info', 'warn', 'error', 'critical'];
 
   function update<K extends keyof GeoMapConfig>(key: K, value: GeoMapConfig[K]) {
@@ -67,18 +67,18 @@
   </div>
 
   <div class="space-y-1.5">
-    <Label>Time window</Label>
+    <Label>Time range</Label>
     <Select
       type="single"
       value={config.interval}
       onValueChange={(v) => v && update('interval', v as GeoMapConfig['interval'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.interval}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.interval)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each intervals as i}
-          <SelectItem value={i}>{i}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/LogTableConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/LogTableConfigForm.svelte
@@ -11,6 +11,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
   import { ProjectsAPI } from '$lib/api/projects';
   import { authStore } from '$lib/stores/auth';
   import { organizationStore } from '$lib/stores/organization';
@@ -25,7 +26,6 @@
 
   const allLevels: LogLevelKey[] = ['debug', 'info', 'warn', 'error', 'critical'];
   const allBuiltins: BuiltinLogColumn[] = ['time', 'level', 'service', 'message'];
-  const timeRanges: Array<LogTableConfig['timeRange']> = ['15m', '1h', '6h', '24h', '7d'];
 
   const BUILTIN_LABELS: Record<BuiltinLogColumn, string> = {
     time: 'Time',
@@ -156,18 +156,18 @@
 
   {#if config.mode === 'snapshot'}
     <div class="space-y-1.5">
-      <Label>Time window</Label>
+      <Label>Time range</Label>
       <Select
         type="single"
         value={config.timeRange}
         onValueChange={(v) => v && update('timeRange', v as LogTableConfig['timeRange'])}
       >
         <SelectTrigger>
-          <SelectValue>{config.timeRange}</SelectValue>
+          <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {#each timeRanges as range (range)}
-            <SelectItem value={range}>{range}</SelectItem>
+          {#each TIME_RANGE_OPTIONS as option (option.value)}
+            <SelectItem value={option.value}>{option.label}</SelectItem>
           {/each}
         </SelectContent>
       </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/MetricChartConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/MetricChartConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: MetricChartConfig;
@@ -19,7 +20,6 @@
 
   const aggregations: MetricAggregation[] = ['avg', 'sum', 'min', 'max', 'count', 'last', 'p50', 'p95', 'p99'];
   const intervals: MetricInterval[] = ['1m', '5m', '15m', '1h', '6h', '1d'];
-  const ranges: MetricChartConfig['timeRange'][] = ['1h', '6h', '24h', '7d', '30d'];
 
   function update<K extends keyof MetricChartConfig>(key: K, value: MetricChartConfig[K]) {
     onChange({ ...config, [key]: value });
@@ -94,11 +94,11 @@
       onValueChange={(v) => v && update('timeRange', v as MetricChartConfig['timeRange'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.timeRange}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each ranges as r}
-          <SelectItem value={r}>{r}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/MetricStatConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/MetricStatConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: MetricStatConfig;
@@ -18,7 +19,6 @@
   let { config, onChange }: Props = $props();
 
   const aggregations: MetricAggregation[] = ['avg', 'sum', 'min', 'max', 'count', 'last', 'p50', 'p95', 'p99'];
-  const ranges: MetricStatConfig['timeRange'][] = ['1h', '6h', '24h'];
 
   function update<K extends keyof MetricStatConfig>(key: K, value: MetricStatConfig[K]) {
     onChange({ ...config, [key]: value });
@@ -74,11 +74,11 @@
         onValueChange={(v) => v && update('timeRange', v as MetricStatConfig['timeRange'])}
       >
         <SelectTrigger>
-          <SelectValue>{config.timeRange}</SelectValue>
+          <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {#each ranges as r}
-            <SelectItem value={r}>{r}</SelectItem>
+          {#each TIME_RANGE_OPTIONS as option (option.value)}
+            <SelectItem value={option.value}>{option.label}</SelectItem>
           {/each}
         </SelectContent>
       </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/TimeSeriesConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/TimeSeriesConfigForm.svelte
@@ -10,6 +10,7 @@
     SelectValue,
   } from '$lib/components/ui/select';
   import { resolveSeriesLabel } from '../panels/series-labels';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: TimeSeriesConfig;
@@ -18,7 +19,6 @@
 
   let { config, onChange }: Props = $props();
 
-  const intervals = ['1h', '6h', '24h', '7d', '30d'] as const;
   const levels: LogLevelKey[] = ['debug', 'info', 'warn', 'error', 'critical'];
 
   function update<K extends keyof TimeSeriesConfig>(key: K, value: TimeSeriesConfig[K]) {
@@ -64,18 +64,18 @@
   </div>
 
   <div class="space-y-1.5">
-    <Label>Time interval</Label>
+    <Label>Time range</Label>
     <Select
       type="single"
       value={config.interval}
       onValueChange={(v) => v && update('interval', v as TimeSeriesConfig['interval'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.interval}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.interval)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each intervals as i}
-          <SelectItem value={i}>{i}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/TopNTableConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/TopNTableConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: TopNTableConfig;
@@ -23,7 +24,6 @@
     { value: 'metadata', label: 'Metadata field' },
   ];
 
-  const intervals: Array<TopNTableConfig['interval']> = ['1h', '24h', '7d'];
   const allLevels: LogLevelKey[] = ['debug', 'info', 'warn', 'error', 'critical'];
 
   function update<K extends keyof TopNTableConfig>(key: K, value: TopNTableConfig[K]) {
@@ -38,8 +38,10 @@
     update('levels', next);
   }
 
-  // The cagg-backed service dimension has no per-value last seen time.
-  const supportsLastSeen = $derived(config.dimension !== 'service');
+  // Since #305 every dimension supports Last seen: turning it on routes the
+  // service dimension through the windowed reservoir path instead of the
+  // continuous-aggregate fast path (which has no per-value max event time).
+  const supportsLastSeen = true;
 </script>
 
 <div class="space-y-4">
@@ -126,18 +128,18 @@
   {/if}
 
   <div class="space-y-1.5">
-    <Label>Time window</Label>
+    <Label>Time range</Label>
     <Select
       type="single"
       value={config.interval}
       onValueChange={(v) => v && update('interval', v as TopNTableConfig['interval'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.interval}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.interval)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each intervals as i}
-          <SelectItem value={i}>{i}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/TraceLatencyConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/TraceLatencyConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: TraceLatencyConfig;
@@ -17,7 +18,6 @@
 
   let { config, onChange }: Props = $props();
 
-  const ranges: TraceLatencyConfig['timeRange'][] = ['1h', '6h', '24h', '7d'];
   const percentiles: Array<'p50' | 'p95' | 'p99'> = ['p50', 'p95', 'p99'];
 
   function update<K extends keyof TraceLatencyConfig>(key: K, value: TraceLatencyConfig[K]) {
@@ -69,11 +69,11 @@
       onValueChange={(v) => v && update('timeRange', v as TraceLatencyConfig['timeRange'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.timeRange}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each ranges as r}
-          <SelectItem value={r}>{r}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/config-forms/TraceVolumeConfigForm.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/config-forms/TraceVolumeConfigForm.svelte
@@ -9,6 +9,7 @@
     SelectTrigger,
     SelectValue,
   } from '$lib/components/ui/select';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '../time-range-options';
 
   interface Props {
     config: TraceVolumeConfig;
@@ -17,7 +18,6 @@
 
   let { config, onChange }: Props = $props();
 
-  const timeRanges = ['1h', '6h', '24h', '7d'] as const;
 
   function update<K extends keyof TraceVolumeConfig>(key: K, value: TraceVolumeConfig[K]) {
     onChange({ ...config, [key]: value });
@@ -43,11 +43,11 @@
       onValueChange={(v) => v && update('timeRange', v as TraceVolumeConfig['timeRange'])}
     >
       <SelectTrigger>
-        <SelectValue>{config.timeRange}</SelectValue>
+        <SelectValue>{timeRangeLabel(config.timeRange)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {#each timeRanges as r}
-          <SelectItem value={r}>{r}</SelectItem>
+        {#each TIME_RANGE_OPTIONS as option (option.value)}
+          <SelectItem value={option.value}>{option.label}</SelectItem>
         {/each}
       </SelectContent>
     </Select>

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { tick, onMount } from 'svelte';
-  import type { Map as LeafletMap } from 'leaflet';
+  import type { Map as LeafletMap, LayerGroup } from 'leaflet';
   import type { GeoMapConfig } from '@logtide/shared';
-  import { bubbleRadius, loadWorldGeoJson } from './geo-map-utils';
+  import { bubbleRadius, loadWorldGeoJson, geoMapRefitKey } from './geo-map-utils';
 
   interface GeoMapPoint {
     lat: number;
@@ -28,11 +28,24 @@
 
   let { config, data }: Props = $props();
   const typed = $derived(data as GeoMapData | null);
+  const refitKey = $derived(geoMapRefitKey(config));
 
   let mapContainer: HTMLDivElement | undefined = $state();
   let map: LeafletMap | null = null;
+  // Container element the live map was created on. The empty state unmounts
+  // the canvas div, so a later non-empty payload binds a NEW div and the old
+  // map instance must be dropped.
+  let mapEl: HTMLDivElement | null = null;
+  let bubbles: LayerGroup | null = null;
+  let leaflet: typeof import('leaflet') | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+  // Refit key at the last automatic fit. The viewport auto-fits ONLY on first
+  // paint or when this key changes (#304); background refreshes must never
+  // move a viewport the user may have panned/zoomed.
+  let lastFitKey: string | null = null;
   let mapError = $state<string | null>(null);
-  let isInitializing = false;
+  let isSyncing = false;
+  let syncQueued = false;
   let isMounted = false;
 
   function escapeHtml(text: string): string {
@@ -45,6 +58,8 @@
   }
 
   function destroyMap() {
+    resizeObserver?.disconnect();
+    resizeObserver = null;
     if (map) {
       try {
         map.remove();
@@ -53,70 +68,153 @@
       }
       map = null;
     }
+    bubbles = null;
+    mapEl = null;
+    lastFitKey = null;
   }
 
-  async function renderMap() {
-    if (isInitializing || !browser || !isMounted) return;
-    await tick();
-    if (!mapContainer || !typed || typed.points.length === 0) return;
-
-    if ((mapContainer as unknown as { _leaflet_id?: number })._leaflet_id) {
-      destroyMap();
-      await tick();
+  function fitToData() {
+    const points = typed?.points ?? [];
+    if (!map || !leaflet || points.length === 0) return;
+    if (points.length > 1) {
+      const bounds = leaflet.latLngBounds(points.map((p) => [p.lat, p.lon] as [number, number]));
+      map.fitBounds(bounds, { padding: [24, 24], maxZoom: 5 });
+    } else {
+      map.setView([points[0].lat, points[0].lon], 4);
     }
-    if (!mapContainer || !document.body.contains(mapContainer)) return;
+  }
 
-    isInitializing = true;
-    try {
-      const [L, world] = await Promise.all([import('leaflet'), loadWorldGeoJson()]);
-      await import('leaflet/dist/leaflet.css');
+  function addFitControl() {
+    if (!map || !leaflet) return;
+    const L = leaflet;
+    const FitControl = L.Control.extend({
+      onAdd: () => {
+        const div = L.DomUtil.create('div', 'leaflet-bar');
+        const link = L.DomUtil.create('a', 'geo-map-fit', div) as HTMLAnchorElement;
+        link.href = '#';
+        link.title = 'Fit map to data';
+        link.setAttribute('role', 'button');
+        link.setAttribute('aria-label', 'Fit map to data');
+        link.textContent = '⛶';
+        L.DomEvent.disableClickPropagation(div);
+        L.DomEvent.on(link, 'click', (e: Event) => {
+          e.preventDefault();
+          fitToData();
+        });
+        return div;
+      },
+    });
+    map.addControl(new FitControl({ position: 'topleft' }));
+  }
 
-      if (!mapContainer || !document.body.contains(mapContainer)) return;
+  function attachResizeObserver(container: HTMLDivElement) {
+    resizeObserver?.disconnect();
+    resizeObserver = new ResizeObserver(() => {
+      // The old rebuild-on-every-refresh accidentally hid stale sizes; a
+      // persistent map must be told when the panel is resized (edit mode
+      // drag handle, window resizes).
+      map?.invalidateSize();
+    });
+    resizeObserver.observe(container);
+  }
 
-      // No tile layer on purpose: the bundled world GeoJSON is the base map,
-      // so the panel works air-gapped and follows the app theme.
-      map = L.map(mapContainer, {
-        attributionControl: false,
-        zoomControl: true,
-        minZoom: 1,
-        maxZoom: 8,
-        worldCopyJump: true,
-      }).setView([20, 0], 1);
-
-      L.geoJSON(world, {
-        style: () => ({ className: 'geo-map-country', weight: 0.5 }),
-        interactive: false,
-      }).addTo(map);
-
-      const maxCount = Math.max(...typed.points.map((p) => p.count));
-      const bounds = L.latLngBounds([]);
-
-      for (const point of typed.points) {
-        const marker = L.circleMarker([point.lat, point.lon], {
+  function renderBubbles(points: GeoMapPoint[]) {
+    if (!map || !bubbles || !leaflet) return;
+    bubbles.clearLayers();
+    const maxCount = Math.max(...points.map((p) => p.count));
+    for (const point of points) {
+      const marker = leaflet
+        .circleMarker([point.lat, point.lon], {
           radius: bubbleRadius(point.count, maxCount),
           className: 'geo-map-bubble',
           weight: 1,
-        }).addTo(map);
+        })
+        .addTo(bubbles);
+      marker.bindTooltip(
+        `<span class="font-medium">${escapeHtml(point.label)}</span> ${point.count.toLocaleString('en-US')}`,
+        { direction: 'top' }
+      );
+    }
+  }
 
-        marker.bindTooltip(
-          `<span class="font-medium">${escapeHtml(point.label)}</span> ${point.count.toLocaleString('en-US')}`,
-          { direction: 'top' }
-        );
-        bounds.extend([point.lat, point.lon]);
+  // Incremental update (#304): the map, base layer and controls are created
+  // once per container; data refreshes only swap the bubble layer group.
+  async function doSync() {
+    if (!browser || !isMounted) return;
+    await tick();
+    const container = mapContainer;
+    const points = typed?.points;
+    if (!container || !points || points.length === 0) return;
+    if (!document.body.contains(container)) return;
+
+    try {
+      if (!leaflet) {
+        leaflet = await import('leaflet');
+        await import('leaflet/dist/leaflet.css');
       }
 
-      if (typed.points.length > 1) {
-        map.fitBounds(bounds, { padding: [24, 24], maxZoom: 5 });
-      } else {
-        map.setView([typed.points[0].lat, typed.points[0].lon], 4);
+      if (map && mapEl !== container) destroyMap();
+
+      let created = false;
+      if (!map) {
+        const world = await loadWorldGeoJson();
+        if (!isMounted || mapContainer !== container || !document.body.contains(container)) {
+          return;
+        }
+        // No tile layer on purpose: the bundled world GeoJSON is the base
+        // map, so the panel works air-gapped and follows the app theme.
+        map = leaflet
+          .map(container, {
+            attributionControl: false,
+            zoomControl: true,
+            minZoom: 1,
+            maxZoom: 8,
+            worldCopyJump: true,
+          })
+          .setView([20, 0], 1);
+        leaflet
+          .geoJSON(world, {
+            style: () => ({ className: 'geo-map-country', weight: 0.5 }),
+            interactive: false,
+          })
+          .addTo(map);
+        bubbles = leaflet.layerGroup().addTo(map);
+        addFitControl();
+        attachResizeObserver(container);
+        mapEl = container;
+        created = true;
+      }
+
+      renderBubbles(points);
+
+      if (created || lastFitKey !== refitKey) {
+        fitToData();
+        lastFitKey = refitKey;
       }
 
       mapError = null;
     } catch (err) {
       console.error('Failed to initialize geo map:', err);
       mapError = 'Failed to load map';
+    }
+  }
+
+  async function syncMap() {
+    // Coalesce overlapping runs: a refresh landing mid-initialization is
+    // replayed once the current pass finishes instead of racing it.
+    if (isSyncing) {
+      syncQueued = true;
+      return;
+    }
+    isSyncing = true;
+    try {
+      await doSync();
     } finally {
-      isInitializing = false;
+      isSyncing = false;
+      if (syncQueued) {
+        syncQueued = false;
+        void syncMap();
+      }
     }
   }
 
@@ -131,9 +229,12 @@
   $effect(() => {
     const points = typed?.points;
     const container = mapContainer;
-    if (browser && isMounted && container && points && points.length > 0) {
+    // Tracked on purpose: a config edit must resync (and re-fit) even when
+    // the data reference has not changed yet.
+    const key = refitKey;
+    if (browser && isMounted && container && points && points.length > 0 && key) {
       const timeout = setTimeout(() => {
-        renderMap();
+        void syncMap();
       }, 100);
       return () => clearTimeout(timeout);
     }
@@ -195,5 +296,9 @@
     background: hsl(var(--card));
     color: hsl(var(--foreground));
     border-color: hsl(var(--border));
+  }
+  .geo-map-canvas :global(a.geo-map-fit) {
+    font-size: 16px;
+    line-height: 26px;
   }
 </style>

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
@@ -170,6 +170,12 @@
             minZoom: 1,
             maxZoom: 8,
             worldCopyJump: true,
+            // Wheel over an embedded panel must scroll the dashboard, not
+            // zoom the map: with it enabled, scrolling past the panel both
+            // scrolls the page AND silently destroys the user's framing,
+            // defeating the viewport preservation this panel guarantees
+            // (#304). Zoom stays available via +/-, double click and pinch.
+            scrollWheelZoom: false,
           })
           .setView([20, 0], 1);
         leaflet

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/GeoMapPanel.svelte
@@ -289,6 +289,11 @@
   .geo-map-canvas {
     background: transparent;
     font: inherit;
+    /* Leaflet stacks its panes at z-index 400-1000, far above the app's
+       dialogs (z-50). Isolating the canvas creates a stacking context so
+       those values stay contained and the map can never paint on top of an
+       open dialog. */
+    isolation: isolate;
   }
   .geo-map-canvas :global(.leaflet-tooltip) {
     background: hsl(var(--popover));

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/TimeSeriesPanel.svelte
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/TimeSeriesPanel.svelte
@@ -3,7 +3,8 @@
   import * as echarts from 'echarts';
   import { themeStore } from '$lib/stores/theme';
   import { displayPreferences } from '$lib/stores/display-preferences';
-  import { formatTimestamp } from '$lib/utils/format-time';
+  import { formatTimestamp, type TimestampStyle } from '$lib/utils/format-time';
+  import { panelTimeRangeToMs } from '@logtide/shared';
   import {
     chartColors,
     getAxisStyle,
@@ -24,6 +25,8 @@
       critical: number;
     }>;
     interval: string;
+    // Absent on payloads cached before #305; hourly was the only bucket then.
+    bucket?: string;
   }
 
   interface Props {
@@ -45,6 +48,16 @@
     const legendStyle = getLegendStyle();
     const prefs = displayPreferences.get();
     const series = typedData?.series ?? [];
+    // Axis label style follows the bucket (#305): day buckets show the date,
+    // hourly buckets on a multi-day window need date + time to disambiguate
+    // repeated clock times, everything else keeps time-of-day.
+    const bucket = typedData?.bucket ?? '1h';
+    const labelStyle: TimestampStyle =
+      bucket === '1d'
+        ? 'monthDay'
+        : bucket === '1h' && panelTimeRangeToMs(config.interval) > 48 * 60 * 60 * 1000
+          ? 'dateTime'
+          : 'time';
     const showDebug = config.levels.includes('debug');
     const showInfo = config.levels.includes('info');
     const showWarn = config.levels.includes('warn');
@@ -115,7 +128,7 @@
       xAxis: {
         type: 'category',
         boundaryGap: false,
-        data: series.map((d) => formatTimestamp(d.time, 'time', prefs)),
+        data: series.map((d) => formatTimestamp(d.time, labelStyle, prefs)),
         ...axisStyle,
       },
       yAxis: {

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/geo-map-utils.test.ts
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/geo-map-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { bubbleRadius, loadWorldGeoJson } from './geo-map-utils';
+import { bubbleRadius, loadWorldGeoJson, geoMapRefitKey } from './geo-map-utils';
+import type { GeoMapConfig } from '@logtide/shared';
 
 describe('bubbleRadius', () => {
   it('scales with the square root of count (area tracks volume)', () => {
@@ -17,6 +18,44 @@ describe('bubbleRadius', () => {
   it('never exceeds bounds on degenerate inputs', () => {
     expect(bubbleRadius(5, 0)).toBe(18); // maxCount 0 guard
     expect(bubbleRadius(200, 100)).toBe(18); // count > maxCount clamps
+  });
+});
+
+describe('geoMapRefitKey (#304)', () => {
+  const base: GeoMapConfig = {
+    type: 'geo_map',
+    title: 'Traffic Map',
+    source: 'logs',
+    projectId: null,
+    interval: '24h',
+    mode: 'country',
+    limit: 100,
+    fieldPrefix: 'geo',
+    levels: [],
+    service: null,
+    hostname: null,
+  };
+
+  it('is stable across title-only changes and object identity', () => {
+    expect(geoMapRefitKey({ ...base, title: 'Renamed' })).toBe(geoMapRefitKey({ ...base }));
+  });
+
+  it('changes when any query-shaping field changes', () => {
+    const key = geoMapRefitKey(base);
+    expect(geoMapRefitKey({ ...base, mode: 'points' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, fieldPrefix: 'geoip' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, projectId: 'p1' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, interval: '48h' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, levels: ['error'] })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, service: 'caddy' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, hostname: 'edge-1' })).not.toBe(key);
+    expect(geoMapRefitKey({ ...base, limit: 200 })).not.toBe(key);
+  });
+
+  it('ignores level ordering', () => {
+    expect(geoMapRefitKey({ ...base, levels: ['error', 'info'] })).toBe(
+      geoMapRefitKey({ ...base, levels: ['info', 'error'] })
+    );
   });
 });
 

--- a/packages/frontend/src/lib/components/custom-dashboards/panels/geo-map-utils.ts
+++ b/packages/frontend/src/lib/components/custom-dashboards/panels/geo-map-utils.ts
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import type { FeatureCollection } from 'geojson';
+import type { GeoMapConfig } from '@logtide/shared';
 
 const MIN_RADIUS = 4;
 const MAX_RADIUS = 18;
@@ -13,6 +14,24 @@ export function bubbleRadius(count: number, maxCount: number): number {
   if (maxCount <= 0) return MAX_RADIUS;
   const ratio = Math.min(1, Math.max(0, count / maxCount));
   return MIN_RADIUS + (MAX_RADIUS - MIN_RADIUS) * Math.sqrt(ratio);
+}
+
+// Signature of every config field that changes WHAT the panel queries (#304).
+// The panel re-fits the viewport only when this key changes (or on first
+// paint / the explicit control); background refreshes keep the user's pan and
+// zoom. `title` is display-only, so it is excluded on purpose; level order is
+// normalized because it does not change the query.
+export function geoMapRefitKey(config: GeoMapConfig): string {
+  return [
+    config.mode,
+    config.fieldPrefix,
+    config.projectId ?? '',
+    config.interval,
+    [...config.levels].sort().join(','),
+    config.service ?? '',
+    config.hostname ?? '',
+    String(config.limit),
+  ].join('|');
 }
 
 // World base layer: bundled Natural Earth 110m TopoJSON (about 106 KB),

--- a/packages/frontend/src/lib/components/custom-dashboards/time-range-options.ts
+++ b/packages/frontend/src/lib/components/custom-dashboards/time-range-options.ts
@@ -1,0 +1,23 @@
+// ============================================================================
+// Shared time range options for panel config forms (#305)
+// ============================================================================
+//
+// The preset catalog lives in @logtide/shared next to the panel types, so the
+// backend Zod validator and these UI options can never drift apart.
+
+import { PANEL_TIME_RANGES, PANEL_TIME_RANGE_LABELS } from '@logtide/shared';
+import type { PanelTimeRange } from '@logtide/shared';
+
+export interface TimeRangeOption {
+  value: PanelTimeRange;
+  label: string;
+}
+
+export const TIME_RANGE_OPTIONS: TimeRangeOption[] = PANEL_TIME_RANGES.map((value) => ({
+  value,
+  label: PANEL_TIME_RANGE_LABELS[value],
+}));
+
+export function timeRangeLabel(value: string): string {
+  return PANEL_TIME_RANGE_LABELS[value as PanelTimeRange] ?? value;
+}

--- a/packages/frontend/src/lib/stores/custom-dashboards-pause.test.ts
+++ b/packages/frontend/src/lib/stores/custom-dashboards-pause.test.ts
@@ -78,7 +78,7 @@ describe('custom dashboards store - panel pause', () => {
 
     await customDashboardsStore.fetchAllPanelData();
 
-    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', ['panel-b']);
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', ['panel-b'], undefined);
   });
 
   it('skips the network call entirely when every panel is paused', async () => {
@@ -97,7 +97,7 @@ describe('custom dashboards store - panel pause', () => {
 
     await customDashboardsStore.fetchAllPanelData();
 
-    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', undefined);
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', undefined, undefined);
   });
 
   it('does not clobber a paused panel data entry on batch refresh', async () => {
@@ -138,7 +138,7 @@ describe('custom dashboards store - panel pause', () => {
 
     await customDashboardsStore.refreshPanel('panel-a');
 
-    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', ['panel-a']);
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', ['panel-a'], undefined);
     expect(get(panelDataMap)['panel-a'].data).toEqual({ v: 'manual' });
   });
 

--- a/packages/frontend/src/lib/stores/custom-dashboards-timerange.test.ts
+++ b/packages/frontend/src/lib/stores/custom-dashboards-timerange.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import type { CustomDashboard, PanelInstance } from '@logtide/shared';
+
+const { fetchPanelData, getDefault, getById } = vi.hoisted(() => ({
+  fetchPanelData: vi.fn(),
+  getDefault: vi.fn(),
+  getById: vi.fn(),
+}));
+
+vi.mock('$lib/api/custom-dashboards', () => ({
+  customDashboardsAPI: {
+    fetchPanelData,
+    getDefault,
+    getById,
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    setAsDefault: vi.fn(),
+    exportYaml: vi.fn(),
+    importYaml: vi.fn(),
+  },
+}));
+
+import { customDashboardsStore, timeRangeOverride } from './custom-dashboards';
+
+function panel(id: string): PanelInstance {
+  return {
+    id,
+    layout: { x: 0, y: 0, w: 6, h: 3 },
+    config: {
+      type: 'time_series',
+      title: id,
+      source: 'logs',
+      projectId: null,
+      interval: '24h',
+      levels: ['info'],
+      service: null,
+    },
+  } as PanelInstance;
+}
+
+function dashboard(id: string, panelIds: string[]): CustomDashboard {
+  return {
+    id,
+    organizationId: 'org-1',
+    projectId: null,
+    name: id,
+    description: null,
+    isDefault: true,
+    isPersonal: false,
+    createdBy: 'user-1',
+    panels: panelIds.map(panel),
+    createdAt: '2026-08-20T00:00:00.000Z',
+    updatedAt: '2026-08-20T00:00:00.000Z',
+  } as unknown as CustomDashboard;
+}
+
+beforeEach(async () => {
+  customDashboardsStore.reset();
+  vi.clearAllMocks();
+  getDefault.mockResolvedValue(dashboard('dash-1', ['panel-a']));
+  fetchPanelData.mockResolvedValue({ panels: {} });
+  await customDashboardsStore.loadDefault('org-1');
+  fetchPanelData.mockClear();
+});
+
+describe('custom dashboards store - time range override (#305)', () => {
+  it('starts without an override', () => {
+    expect(get(timeRangeOverride)).toBeNull();
+  });
+
+  it('setting the override refetches with it', async () => {
+    await customDashboardsStore.setTimeRangeOverride('48h');
+
+    expect(get(timeRangeOverride)).toBe('48h');
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', undefined, '48h');
+  });
+
+  it('clearing the override refetches without it', async () => {
+    await customDashboardsStore.setTimeRangeOverride('48h');
+    fetchPanelData.mockClear();
+
+    await customDashboardsStore.setTimeRangeOverride(null);
+
+    expect(get(timeRangeOverride)).toBeNull();
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', undefined, undefined);
+  });
+
+  it('manual panel refresh carries the active override', async () => {
+    await customDashboardsStore.setTimeRangeOverride('3d');
+    fetchPanelData.mockClear();
+    fetchPanelData.mockResolvedValue({ panels: { 'panel-a': { data: { ok: 1 } } } });
+
+    await customDashboardsStore.refreshPanel('panel-a');
+
+    expect(fetchPanelData).toHaveBeenCalledWith('dash-1', 'org-1', ['panel-a'], '3d');
+  });
+
+  it('switching dashboards clears the override', async () => {
+    await customDashboardsStore.setTimeRangeOverride('48h');
+    getById.mockResolvedValue(dashboard('dash-2', ['panel-b']));
+
+    await customDashboardsStore.switchTo('dash-2');
+
+    expect(get(timeRangeOverride)).toBeNull();
+  });
+});

--- a/packages/frontend/src/lib/stores/custom-dashboards.ts
+++ b/packages/frontend/src/lib/stores/custom-dashboards.ts
@@ -13,6 +13,7 @@ import type {
   PanelInstance,
   PanelConfig,
   PanelLayout,
+  PanelTimeRange,
 } from '@logtide/shared';
 import { customDashboardsAPI } from '$lib/api/custom-dashboards';
 
@@ -41,6 +42,10 @@ interface DashboardStoreState {
   // Panels frozen by the user. Ephemeral: never saved with the dashboard,
   // never persisted, cleared when the active dashboard changes.
   pausedPanels: Set<string>;
+  // Dashboard-level time range override (#305). Ephemeral view state like
+  // pausedPanels: overrides every window-scoped panel while active, never
+  // saved with the dashboard, cleared when the active dashboard changes.
+  timeRangeOverride: PanelTimeRange | null;
   // Inline edit mode
   editMode: boolean;
   // Pending edit snapshot - null when not editing
@@ -60,6 +65,7 @@ const initialState: DashboardStoreState = {
   saveError: null,
   panelData: {},
   pausedPanels: new Set<string>(),
+  timeRangeOverride: null,
   editMode: false,
   pendingPanels: null,
   originalPanels: null,
@@ -123,6 +129,7 @@ function createDashboardStore() {
           dashboards: mergeDashboardIntoList(s.dashboards, dashboard),
           loadingActive: false,
           pausedPanels: new Set<string>(),
+          timeRangeOverride: null,
         }));
         await this.fetchAllPanelData();
       } catch (e) {
@@ -149,6 +156,7 @@ function createDashboardStore() {
           activeDashboard: fromList,
           panelData: {},
           pausedPanels: new Set<string>(),
+          timeRangeOverride: null,
           activeError: null,
         }));
         await this.fetchAllPanelData();
@@ -167,6 +175,7 @@ function createDashboardStore() {
           activeDashboard: dashboard,
           panelData: {},
           pausedPanels: new Set<string>(),
+          timeRangeOverride: null,
           loadingActive: false,
         }));
         await this.fetchAllPanelData();
@@ -219,7 +228,8 @@ function createDashboardStore() {
           dashboard.organizationId,
           // Undefined keeps the "all panels" request the API already sends
           // when nothing is paused.
-          somePaused ? targetIds : undefined
+          somePaused ? targetIds : undefined,
+          state.timeRangeOverride ?? undefined
         );
         const now = Date.now();
         update((s) => {
@@ -270,7 +280,10 @@ function createDashboardStore() {
         const result = await customDashboardsAPI.fetchPanelData(
           dashboard.id,
           dashboard.organizationId,
-          [panelId]
+          [panelId],
+          // A manual refresh must not silently revert one panel to its
+          // configured window while the dashboard override is active.
+          state.timeRangeOverride ?? undefined
         );
         const entry = result.panels[panelId];
         if (entry) {
@@ -304,6 +317,16 @@ function createDashboardStore() {
         }
         return { ...s, pausedPanels: next };
       });
+    },
+
+    /**
+     * Set (or clear with null) the dashboard-level time range override and
+     * refetch every non-paused panel with it. View state only: nothing is
+     * saved to the dashboard.
+     */
+    async setTimeRangeOverride(range: PanelTimeRange | null): Promise<void> {
+      update((s) => ({ ...s, timeRangeOverride: range }));
+      await this.fetchAllPanelData();
     },
 
     // ─── Edit mode ──────────────────────────────────────────────────────
@@ -578,3 +601,4 @@ export const dashboardSaving = derived(customDashboardsStore, (s) => s.saving);
 export const dashboardSaveError = derived(customDashboardsStore, (s) => s.saveError);
 export const panelDataMap = derived(customDashboardsStore, (s) => s.panelData);
 export const pausedPanelIds = derived(customDashboardsStore, (s) => s.pausedPanels);
+export const timeRangeOverride = derived(customDashboardsStore, (s) => s.timeRangeOverride);

--- a/packages/frontend/src/routes/dashboard/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/+page.svelte
@@ -17,11 +17,14 @@
     dashboardSaveError,
     panelDataMap,
     pausedPanelIds,
+    timeRangeOverride,
   } from '$lib/stores/custom-dashboards';
   import DashboardContainer from '$lib/components/custom-dashboards/DashboardContainer.svelte';
   import DashboardSwitcher from '$lib/components/custom-dashboards/DashboardSwitcher.svelte';
+  import { TIME_RANGE_OPTIONS, timeRangeLabel } from '$lib/components/custom-dashboards/time-range-options';
   import * as Select from '$lib/components/ui/select';
   import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+  import Clock from '@lucide/svelte/icons/clock';
   import PanelConfigDialog from '$lib/components/custom-dashboards/PanelConfigDialog.svelte';
   import AddPanelDialog from '$lib/components/custom-dashboards/AddPanelDialog.svelte';
   import CreateDashboardDialog from '$lib/components/custom-dashboards/CreateDashboardDialog.svelte';
@@ -33,7 +36,7 @@
   import Save from '@lucide/svelte/icons/save';
   import XIcon from '@lucide/svelte/icons/x';
   import Building2 from '@lucide/svelte/icons/building-2';
-  import type { CustomDashboard, PanelConfig, PanelInstance } from '@logtide/shared';
+  import type { CustomDashboard, PanelConfig, PanelInstance, PanelTimeRange } from '@logtide/shared';
 
   let lastLoadedOrg = $state<string | null>(null);
   let maxWidthClass = $state('max-w-full');
@@ -186,6 +189,13 @@
   function setAutoRefresh(v: string | undefined) {
     autoRefreshMs = v ? parseInt(v, 10) || 0 : 0;
     if (browser) localStorage.setItem('logtide_dashboard_autorefresh', String(autoRefreshMs));
+  }
+
+  function setDashboardTimeRange(v: string | undefined) {
+    if (!v) return;
+    void customDashboardsStore.setTimeRangeOverride(
+      v === '__default__' ? null : (v as PanelTimeRange)
+    );
   }
 
   $effect(() => {
@@ -347,6 +357,26 @@
           {$dashboardSaving ? 'Saving…' : 'Save'}
         </Button>
       {:else if $activeDashboard}
+        <!-- Dashboard-level time override (#305): view-only, never saved.
+             "Panel defaults" restores each panel's configured window. -->
+        <Select.Root
+          type="single"
+          value={$timeRangeOverride ?? '__default__'}
+          onValueChange={setDashboardTimeRange}
+        >
+          <Select.Trigger class="w-auto gap-2" title="Dashboard time range (overrides every panel while active)">
+            <Clock class="w-4 h-4 shrink-0 {$timeRangeOverride ? 'text-primary' : 'text-muted-foreground'}" />
+            <span class="whitespace-nowrap">
+              {$timeRangeOverride ? timeRangeLabel($timeRangeOverride) : 'Panel defaults'}
+            </span>
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="__default__">Panel defaults</Select.Item>
+            {#each TIME_RANGE_OPTIONS as opt (opt.value)}
+              <Select.Item value={opt.value}>{opt.label}</Select.Item>
+            {/each}
+          </Select.Content>
+        </Select.Root>
         <Select.Root
           type="single"
           value={String(autoRefreshMs)}

--- a/packages/shared/src/types/dashboard.test.ts
+++ b/packages/shared/src/types/dashboard.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PANEL_TIME_RANGES,
+  PANEL_TIME_RANGE_MS,
+  PANEL_TIME_RANGE_LABELS,
+  panelTimeRangeToMs,
+} from './dashboard.js';
+
+describe('panel time range catalog', () => {
+  it('has an ms value and a label for every preset', () => {
+    for (const range of PANEL_TIME_RANGES) {
+      expect(PANEL_TIME_RANGE_MS[range]).toBeGreaterThan(0);
+      expect(PANEL_TIME_RANGE_LABELS[range]).toBeTruthy();
+    }
+    expect(Object.keys(PANEL_TIME_RANGE_MS).sort()).toEqual([...PANEL_TIME_RANGES].sort());
+    expect(Object.keys(PANEL_TIME_RANGE_LABELS).sort()).toEqual([...PANEL_TIME_RANGES].sort());
+  });
+
+  it('is ordered from shortest to longest window', () => {
+    const values = PANEL_TIME_RANGES.map((r) => PANEL_TIME_RANGE_MS[r]);
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThan(values[i - 1]);
+    }
+  });
+
+  it('covers every preset previously accepted by any panel enum', () => {
+    // Union of the pre-#305 per-panel enums; losing one would break stored dashboards.
+    for (const legacy of ['15m', '1h', '6h', '24h', '7d', '30d']) {
+      expect(PANEL_TIME_RANGES).toContain(legacy);
+    }
+  });
+
+  it('resolves known presets and falls back to 24h for unknown strings', () => {
+    expect(panelTimeRangeToMs('48h')).toBe(48 * 60 * 60 * 1000);
+    expect(panelTimeRangeToMs('3d')).toBe(3 * 24 * 60 * 60 * 1000);
+    expect(panelTimeRangeToMs('bogus')).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -31,6 +31,67 @@ export type PanelType =
   | 'geo_map'
   | 'log_table';
 
+// ─── Time range presets ─────────────────────────────────────────────────────
+//
+// One catalog for every panel that scopes its query to a lookback window
+// (issue #305). Widening this list is backwards compatible; narrowing it or
+// renaming a key is a breaking change for stored dashboards and needs a
+// schema_version bump + migration.
+
+export const PANEL_TIME_RANGES = [
+  '15m',
+  '1h',
+  '6h',
+  '12h',
+  '24h',
+  '48h',
+  '3d',
+  '7d',
+  '14d',
+  '30d',
+] as const;
+
+export type PanelTimeRange = (typeof PANEL_TIME_RANGES)[number];
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export const PANEL_TIME_RANGE_MS: Record<PanelTimeRange, number> = {
+  '15m': 15 * MINUTE_MS,
+  '1h': HOUR_MS,
+  '6h': 6 * HOUR_MS,
+  '12h': 12 * HOUR_MS,
+  '24h': DAY_MS,
+  '48h': 2 * DAY_MS,
+  '3d': 3 * DAY_MS,
+  '7d': 7 * DAY_MS,
+  '14d': 14 * DAY_MS,
+  '30d': 30 * DAY_MS,
+};
+
+export const PANEL_TIME_RANGE_LABELS: Record<PanelTimeRange, string> = {
+  '15m': 'Last 15 minutes',
+  '1h': 'Last hour',
+  '6h': 'Last 6 hours',
+  '12h': 'Last 12 hours',
+  '24h': 'Last 24 hours',
+  '48h': 'Last 48 hours',
+  '3d': 'Last 3 days',
+  '7d': 'Last 7 days',
+  '14d': 'Last 14 days',
+  '30d': 'Last 30 days',
+};
+
+/**
+ * Window size in ms for a panel time range. Unknown strings fall back to 24h,
+ * matching the historical behavior of the backend's timeRangeToMs helper so a
+ * config written by a future version never crashes an older backend.
+ */
+export function panelTimeRangeToMs(range: string): number {
+  return PANEL_TIME_RANGE_MS[range as PanelTimeRange] ?? PANEL_TIME_RANGE_MS['24h'];
+}
+
 // ─── Layout (12-column grid) ────────────────────────────────────────────────
 
 export interface PanelLayout {
@@ -49,7 +110,7 @@ export interface TimeSeriesConfig {
   title: string;
   source: 'logs';
   projectId: string | null; // null = org-wide
-  interval: '1h' | '6h' | '24h' | '7d' | '30d';
+  interval: PanelTimeRange;
   levels: LogLevelKey[];
   service: string | null;
   /** Optional per-level display labels for legend and tooltip; falls back to Debug/Info/Warn/Error/Critical */
@@ -74,7 +135,7 @@ export interface TopNTableConfig {
   metadataField?: string | null;
   limit: number; // 3-50
   projectId: string | null;
-  interval: '1h' | '24h' | '7d';
+  interval: PanelTimeRange;
   /** default false; honored for error_message and metadata dimensions */
   showLastSeen?: boolean;
   /** metadata dimension only; empty/absent = all levels */
@@ -126,7 +187,7 @@ export interface MetricChartConfig {
   metricName: string;
   aggregation: MetricAggregation;
   interval: MetricInterval;
-  timeRange: '1h' | '6h' | '24h' | '7d' | '30d';
+  timeRange: PanelTimeRange;
   serviceName: string | null;
 }
 
@@ -137,7 +198,7 @@ export interface MetricStatConfig {
   projectId: string | null;
   metricName: string;
   aggregation: MetricAggregation;
-  timeRange: '1h' | '6h' | '24h';
+  timeRange: PanelTimeRange;
   serviceName: string | null;
   unit: string | null;
 }
@@ -150,7 +211,7 @@ export interface TraceLatencyConfig {
   source: 'traces';
   projectId: string | null;
   serviceName: string | null;
-  timeRange: '1h' | '6h' | '24h' | '7d';
+  timeRange: PanelTimeRange;
   showPercentiles: Array<'p50' | 'p95' | 'p99'>;
 }
 
@@ -162,7 +223,7 @@ export interface TraceVolumeConfig {
   source: 'traces';
   projectId: string | null;
   serviceName: string | null;
-  timeRange: '1h' | '6h' | '24h' | '7d';
+  timeRange: PanelTimeRange;
   showErrors: boolean;
 }
 
@@ -173,7 +234,7 @@ export interface DetectionEventsConfig {
   title: string;
   source: 'detections';
   projectId: string | null;
-  timeRange: '24h' | '7d' | '30d';
+  timeRange: PanelTimeRange;
   severities: Array<'critical' | 'high' | 'medium' | 'low' | 'informational'>;
 }
 
@@ -213,7 +274,7 @@ export interface ActivityOverviewConfig {
   title: string;
   source: 'mixed';
   projectId: string | null;
-  timeRange: '24h' | '7d' | '30d';
+  timeRange: PanelTimeRange;
   series: ActivityOverviewSeries[];
 }
 
@@ -224,7 +285,7 @@ export interface GeoMapConfig {
   title: string;
   source: 'logs';
   projectId: string | null;
-  interval: '1h' | '24h' | '7d';
+  interval: PanelTimeRange;
   mode: 'country' | 'points';
   limit: number; // points mode top-N; 10-500
   fieldPrefix: string; // geoip step target, e.g. 'geo'; strict charset, no dots
@@ -243,7 +304,7 @@ export interface LogTableConfig {
   source: 'logs';
   projectId: string | null; // null = org-wide; REQUIRED when mode === 'live'
   mode: 'snapshot' | 'live'; // live = per-project WebSocket tail
-  timeRange: '15m' | '1h' | '6h' | '24h' | '7d'; // snapshot mode only
+  timeRange: PanelTimeRange; // snapshot mode only
   levels: LogLevelKey[]; // empty = all levels
   service: string | null;
   maxRows: number; // 10-100

--- a/packages/shared/src/types/siem.ts
+++ b/packages/shared/src/types/siem.ts
@@ -1,6 +1,7 @@
 import type { Severity, IncidentStatus } from '../constants/siem-constants.js';
 import type { PackCategory } from '../constants/sigma-constants.js';
 import type { IncidentSource } from '../constants/monitoring-constants.js';
+import type { PanelTimeRange } from './dashboard.js';
 
 export interface DetectionEvent {
   id: string;
@@ -185,7 +186,9 @@ export interface DashboardStats {
 export interface DashboardFilters {
   organizationId: string;
   projectId?: string | null;
-  timeRange: '24h' | '7d' | '30d';
+  // The SIEM dashboard API keeps offering 24h/7d/30d; the wider union exists
+  // for the detection_events custom-dashboard panel (#305).
+  timeRange: PanelTimeRange;
   severity?: Severity[];
 }
 


### PR DESCRIPTION
Implements #305 and fixes #304 (refs only, issues stay open until release per convention).

## Per-panel time ranges + dashboard override (#305)

- One shared preset catalog (`PANEL_TIME_RANGES`, 15m to 30d, 10 presets) in `@logtide/shared`, applied to every window-scoped panel: `time_series`, `top_n_table`, `geo_map` (`interval`), `log_table`, `metric_chart`, `metric_stat`, `trace_latency`, `trace_volume`, `detection_events`, `activity_overview` (`timeRange`). Strict superset of every previous enum: stored dashboards and YAML imports keep validating, no schema_version bump.
- Field names `interval`/`timeRange` are kept as-is (a rename would force a document migration for zero gain); the UI aligns instead: every config form now labels the control "Time range" with human-readable labels ("Last 48 hours").
- Dashboard-level time override: a Clock select in the dashboard toolbar temporarily overrides every window-scoped panel (batch body `timeRange`, applied via `applyTimeRangeOverride`). It is ephemeral view state like panel pause: never persisted, cleared on dashboard switch; live log tables and windowless panels are untouched. Manual per-panel refresh carries the active override.

### Pre-existing window bugs fixed along the way

- `time_series` ignored its configured interval (always last 24h via `getTimeseries`) AND its service filter. The fetcher is now windowed with adaptive bucketing (1m/5m/15m/1h/1d), a Timescale cagg fast path with bucket-aligned raw-tail backfill for 1h/1d buckets, `reservoir.aggregate` elsewhere, zero-filled buckets, and date-aware axis labels on multi-day ranges.
- `top_n_table` service dimension ignored its interval (always last 7d via the daily cagg). The cagg fast path now serves only `7d && !showLastSeen`; everything else goes through windowed `reservoir.topValues`, which also brings the Last seen column to the service dimension.

## Geo map viewport (#304)

- The panel no longer destroys and rebuilds the Leaflet map on every poll: one persistent map, bubbles swapped in a `LayerGroup`. Auto-fit runs only on first paint, when the panel's query-shaping config changes, or via the new "Fit data" control; background refreshes never move the viewport.
- Wheel over the panel now scrolls the dashboard instead of zooming the map (zoom stays on the +/- controls, double click and pinch), so scrolling past the panel cannot silently reset the framing.
- Leaflet pane z-indexes (400-1000) painted over open dialogs (z-50); the map canvas is now an isolated stacking context. Pre-existing since 1.3.0.
- ResizeObserver keeps the map sized on panel resize (the old rebuild-per-poll masked this).

## Verification

- Backend full suite: 278 files / 5000 tests green. Shared: 203. Frontend: 167, svelte-check at the pre-existing baseline.
- Real-browser smoke on a seeded dev stack: viewport fingerprint (pane transform + viewBox + path hash) byte-identical across panel refresh and across a 30d override refresh; override totals 50 -> 65 -> 83 logs for 24h/48h/30d on data seeded across five age bands; zero console errors.
